### PR TITLE
refactor: CORS設定を特定のオリジンに制限

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,12 @@ import { cors } from 'hono/cors'
 const app = new Hono()
 
 // フロントエンド(Vite:5173)からのアクセスを許可
-app.use('/*', cors())
+app.use(
+  '/*',
+  cors({
+    origin: 'http://localhost:5173', // フロントエンドのURLに合わせて調整
+  })
+)
 
 // APIルートの定義
 const api = app.basePath('/api')

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,7 +8,7 @@ const app = new Hono()
 app.use(
   '/*',
   cors({
-    origin: 'http://localhost:5173', // フロントエンドのURLに合わせて調整
+    origin: process.env.BOOKMARK_PAGE_FRONTEND_URL || 'http://localhost:5173',
   })
 )
 


### PR DESCRIPTION
Issue #5 の対応として、CORS設定をlocalhostのみ許可するように修正しました。

Closes #5