### PR TITLE
chore: Prettierの設定を trailingComma: "all" に変更

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,7 @@
   "semi": false,
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "printWidth": 80,
   "endOfLine": "lf"
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,7 +9,7 @@ app.use(
   '/*',
   cors({
     origin: process.env.BOOKMARK_PAGE_FRONTEND_URL || 'http://localhost:5173',
-  })
+  }),
 )
 
 // APIルートの定義

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,5 +6,5 @@ import App from './App.tsx'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>
+  </StrictMode>,
 )


### PR DESCRIPTION
Gitの差分をクリーンに保つため、.prettierrc の trailingComma 設定を "es5" から "all" に変更しました。
これに伴い、関数の引数末尾などにカンマを追加するフォーマット適用を行いました。

Closes #6