### PR TITLE
feat(server): データベースの自動初期化ロジックの実装とスキーマ定義の導入 #15

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -35,7 +35,7 @@ const initializeDatabase = () => {
   db.pragma('journal_mode = WAL')
 
   // 3. テーブル・インデックスの作成
-  db.exec(SCHEMA)
+  db.transaction(() => db.exec(SCHEMA))()
 }
 
 // 初期化実行（PRAGMA設定とスキーマ作成を一括で行う）

--- a/server/db.ts
+++ b/server/db.ts
@@ -26,16 +26,19 @@ const SCHEMA = `
   CREATE INDEX IF NOT EXISTS idx_bookmark_keywords_keyword_id ON bookmark_keywords(keyword_id);
 `
 
-// データベースの初期化
+// データベースの初期化と設定
 const initializeDatabase = () => {
+  // 1. 接続ごとの設定（外部キー有効化）
   db.pragma('foreign_keys = ON')
+
+  // 2. DBファイル全体の設定（WALモード: パフォーマンス向上）
+  db.pragma('journal_mode = WAL')
+
+  // 3. テーブル・インデックスの作成
   db.exec(SCHEMA)
 }
 
-// 開発中のデバッグ用に WAL モードなどを設定
-db.pragma('journal_mode = WAL')
-
-// 初期化実行
+// 初期化実行（PRAGMA設定とスキーマ作成を一括で行う）
 initializeDatabase()
 
 // アプリケーション終了時にデータベース接続を閉じる

--- a/server/db.ts
+++ b/server/db.ts
@@ -41,7 +41,7 @@ const initializeDatabase = () => {
     })()
   } catch (error) {
     console.error('Failed to initialize database:', error)
-    process.exit(1)
+    throw error
   }
 }
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -17,8 +17,8 @@ const SCHEMA = `
   );
   CREATE TABLE IF NOT EXISTS bookmark_keywords (
     bookmark_keyword_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    bookmark_id INTEGER,
-    keyword_id INTEGER,
+    bookmark_id INTEGER NOT NULL,
+    keyword_id INTEGER NOT NULL,
     FOREIGN KEY (bookmark_id) REFERENCES bookmarks(bookmark_id) ON DELETE CASCADE,
     FOREIGN KEY (keyword_id) REFERENCES keywords(keyword_id) ON DELETE CASCADE,
     UNIQUE (bookmark_id, keyword_id)

--- a/server/db.ts
+++ b/server/db.ts
@@ -4,8 +4,39 @@ import path from 'path'
 const dbPath = path.resolve(process.cwd(), 'bookmarks.sqlite')
 export const db = new Database(dbPath)
 
+// スキーマ定義
+const SCHEMA = `
+  CREATE TABLE IF NOT EXISTS bookmarks (
+    bookmark_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    url TEXT NOT NULL UNIQUE,
+    title TEXT NOT NULL
+  );
+  CREATE TABLE IF NOT EXISTS keywords (
+    keyword_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    keyword_name TEXT NOT NULL UNIQUE
+  );
+  CREATE TABLE IF NOT EXISTS bookmark_keywords (
+    bookmark_keyword_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    bookmark_id INTEGER,
+    keyword_id INTEGER,
+    FOREIGN KEY (bookmark_id) REFERENCES bookmarks(bookmark_id) ON DELETE CASCADE,
+    FOREIGN KEY (keyword_id) REFERENCES keywords(keyword_id) ON DELETE CASCADE,
+    UNIQUE (bookmark_id, keyword_id)
+  );
+  CREATE INDEX IF NOT EXISTS idx_bookmark_keywords_keyword_id ON bookmark_keywords(keyword_id);
+`
+
+// データベースの初期化
+const initializeDatabase = () => {
+  db.pragma('foreign_keys = ON')
+  db.exec(SCHEMA)
+}
+
 // 開発中のデバッグ用に WAL モードなどを設定
 db.pragma('journal_mode = WAL')
+
+// 初期化実行
+initializeDatabase()
 
 // アプリケーション終了時にデータベース接続を閉じる
 const shutdown = () => {

--- a/server/db.ts
+++ b/server/db.ts
@@ -28,14 +28,21 @@ const SCHEMA = `
 
 // データベースの初期化と設定
 const initializeDatabase = () => {
-  // 1. 接続ごとの設定（外部キー有効化）
-  db.pragma('foreign_keys = ON')
+  try {
+    // 1. 接続ごとの設定（外部キー有効化）
+    db.pragma('foreign_keys = ON')
 
-  // 2. DBファイル全体の設定（WALモード: パフォーマンス向上）
-  db.pragma('journal_mode = WAL')
+    // 2. DBファイル全体の設定（WALモード: パフォーマンス向上）
+    db.pragma('journal_mode = WAL')
 
-  // 3. テーブル・インデックスの作成
-  db.transaction(() => db.exec(SCHEMA))()
+    // 3. テーブル・インデックスの作成
+    db.transaction(() => {
+      db.exec(SCHEMA)
+    })()
+  } catch (error) {
+    console.error('Failed to initialize database:', error)
+    process.exit(1)
+  }
 }
 
 // 初期化実行（PRAGMA設定とスキーマ作成を一括で行う）


### PR DESCRIPTION
#### 概要
サーバー起動時にSQLiteデータベースのテーブルを自動的に作成・初期化する機能を実装しました。これにより、手動でのデータベースセットアップが不要になり、開発環境の構築が容易になります。

#### 主な変更内容
- **スキーマ定義の追加**: `kubotama/linkpage` の定義に基づき、`bookmarks`, `keywords`, `bookmark_keywords` テーブルおよびインデックスのDDLを `server/db.ts` に導入しました。
- **自動初期化フローの実装**: `Database` インスタンス生成時に `initializeDatabase` 関数を実行し、テーブルが存在しない場合にのみ自動作成する仕組みを構築しました。
- **SQLite設定の最適化**: 
  - `PRAGMA foreign_keys = ON` を追加し、外部キー制約（カスケード削除等）を有効化しました。
  - `PRAGMA journal_mode = WAL` を追加し、書き込みパフォーマンスを向上させました。
- **初期化順序の整理**: 各種設定（PRAGMA）が適用された後にスキーマが作成されるよう、処理順序を整理しました。

#### 関連Issue
- Closes #15

#### 動作確認内容
- `tsx` を使用して初期化ロジックを実行し、物理ファイル `bookmarks.sqlite` が正しく生成されることを確認しました。
- 生成されたDBに対して `sqlite3` コマンドで `.schema` を実行し、意図した通りの制約とテーブル構造が作成されていることを検証済みです。
- 既存のテスト（`npm test`）がパスすることを確認しました。