### PR TITLE
test: データベースのインメモリ化とテスト環境の分離 (#16)

### DIFF
--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -1,8 +1,23 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import app from '../app'
+import { db, resetDatabase } from '../db'
 
 describe('GET /api/bookmarks', () => {
+  beforeEach(() => {
+    resetDatabase()
+  })
+
   it('適切なレスポンス構造でブックマーク一覧を返すこと', async () => {
+    // シードデータの投入
+    db.prepare('INSERT INTO bookmarks (title, url) VALUES (?, ?)').run(
+      'Example Domain',
+      'https://example.com',
+    )
+    db.prepare('INSERT INTO bookmarks (title, url) VALUES (?, ?)').run(
+      'Google',
+      'https://google.com',
+    )
+
     const res = await app.request('/api/bookmarks')
     expect(res.status).toBe(200)
 
@@ -11,15 +26,21 @@ describe('GET /api/bookmarks', () => {
     // レスポンスが bookmarks キーを持つオブジェクトであることを確認
     expect(body).toHaveProperty('bookmarks')
     expect(Array.isArray(body.bookmarks)).toBe(true)
+    expect(body.bookmarks).toHaveLength(2)
 
     // 各ブックマークが期待されるプロパティを持っていることを確認
-    if (body.bookmarks.length > 0) {
-      const bookmark = body.bookmarks[0]
-      expect(bookmark).toHaveProperty('id')
-      expect(bookmark).toHaveProperty('title')
-      expect(bookmark).toHaveProperty('url')
-      // createdAt は除外されたことを確認
-      expect(bookmark).not.toHaveProperty('createdAt')
-    }
+    const bookmark = body.bookmarks[0]
+    expect(bookmark).toHaveProperty('id')
+    expect(bookmark.title).toBe('Example Domain')
+    expect(bookmark.url).toBe('https://example.com')
+    // createdAt は除外されたことを確認
+    expect(bookmark).not.toHaveProperty('createdAt')
+  })
+
+  it('データが空の場合、空の配列を返すこと', async () => {
+    const res = await app.request('/api/bookmarks')
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.bookmarks).toEqual([])
   })
 })


### PR DESCRIPTION
#### 概要
テスト実行時に物理データベースファイル（`bookmarks.sqlite`）を使用せず、`better-sqlite3` のインメモリモード（`:memory:`）を使用するように変更しました。これにより、開発データとテストデータの干渉を防ぎ、テストの実行速度と信頼性を向上させました。

#### 変更内容
- **`server/db.ts` の修正**:
  - `NODE_ENV=test` の場合に `:memory:` を使用してDBを初期化するロジックを追加。
  - テスト環境以外（開発・本番）でのみ `WAL` モードを有効化。
  - テストごとにデータをクリーンアップするための `resetDatabase` 関数を実装・エクスポート。
  - テスト側でスキーマを再利用できるよう `SCHEMA` 定数をエクスポート。
- **`server/routes/bookmarks.test.ts` の修正**:
  - `beforeEach` で `resetDatabase` を呼び出し、各テストケースの独立性を確保。
  - テストごとに必要なシードデータを直接投入するようにテストケースを更新。
  - データが存在しない場合のテストケースを追加。

#### 影響範囲
- テスト実行環境（`npm test`）
- 開発環境および本番環境のDB動作には影響ありません。

#### 確認事項
- [x] `npm test` が正常にパスすること
- [x] テスト実行後に `bookmarks.sqlite` にテストデータが残っていないこと
- [x] 外部キー制約が有効な状態でデータリセットが行われていること

Closes #16