### PR TITLE
refactor(test): it.each を使用した BookmarkList.test.tsx の整理

### DIFF
--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -2,71 +2,67 @@ import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import { BookmarkList } from './BookmarkList'
 import { UI_MESSAGES } from '@shared/constants'
+import type { Bookmark } from '@shared/schemas/bookmark'
 
 describe('BookmarkList', () => {
-  it('ローディング中にスピナーが表示されること', () => {
-    render(
-      <BookmarkList bookmarks={[]} isLoading={true} error={null} />
-    )
-    expect(screen.getByRole('status')).toBeInTheDocument()
-    expect(screen.getByLabelText(UI_MESSAGES.LOADING_LABEL)).toBeInTheDocument()
-  })
+  const mockBookmarks: Bookmark[] = [
+    { id: '1', title: 'Test Bookmark 1', url: 'https://example.com/1' },
+    { id: '2', title: 'Test Bookmark 2', url: 'https://example.com/2' },
+  ]
 
-  it('ブックマーク一覧が正常に表示されること', () => {
-    const mockBookmarks = [
-      { id: '1', title: 'Test Bookmark 1', url: 'https://example.com/1' },
-      { id: '2', title: 'Test Bookmark 2', url: 'https://example.com/2' },
-    ]
+  const testCases = [
+    {
+      name: 'ローディング中にスピナーが表示されること',
+      props: { bookmarks: [], isLoading: true, error: null },
+      assert: () => {
+        expect(screen.getByRole('status')).toBeInTheDocument()
+        expect(
+          screen.getByLabelText(UI_MESSAGES.LOADING_LABEL),
+        ).toBeInTheDocument()
+      },
+    },
+    {
+      name: 'ブックマーク一覧が正常に表示されること',
+      props: { bookmarks: mockBookmarks, isLoading: false, error: null },
+      assert: () => {
+        expect(screen.getByText('Test Bookmark 1')).toBeInTheDocument()
+        expect(screen.getByText('Test Bookmark 2')).toBeInTheDocument()
+        expect(
+          screen.queryByText('https://example.com/1'),
+        ).not.toBeInTheDocument()
+        expect(screen.getByRole('table')).toBeInTheDocument()
+        expect(screen.getAllByRole('row')).toHaveLength(2)
+      },
+    },
+    {
+      name: 'データが空の場合に適切なメッセージが表示されること',
+      props: { bookmarks: [], isLoading: false, error: null },
+      assert: () => {
+        expect(screen.getByText(UI_MESSAGES.NO_BOOKMARKS)).toBeInTheDocument()
+      },
+    },
+    {
+      name: 'Errorインスタンス発生時にエラーメッセージが表示されること',
+      props: { bookmarks: [], isLoading: false, error: new Error('Test Error') },
+      assert: () => {
+        const alert = screen.getByRole('alert')
+        expect(alert).toHaveTextContent(UI_MESSAGES.ERROR_PREFIX)
+        expect(alert).toHaveTextContent('Test Error')
+      },
+    },
+    {
+      name: 'Errorインスタンス以外のエラー発生時に、予期せぬエラーメッセージが表示されること',
+      props: { bookmarks: [], isLoading: false, error: 'Unexpected string error' },
+      assert: () => {
+        const alert = screen.getByRole('alert')
+        expect(alert).toHaveTextContent(UI_MESSAGES.ERROR_PREFIX)
+        expect(alert).toHaveTextContent(UI_MESSAGES.UNEXPECTED_ERROR)
+      },
+    },
+  ]
 
-    render(
-      <BookmarkList
-        bookmarks={mockBookmarks}
-        isLoading={false}
-        error={null}
-      />
-    )
-
-    // タイトルが表示されていることを確認
-    expect(screen.getByText('Test Bookmark 1')).toBeInTheDocument()
-    expect(screen.getByText('Test Bookmark 2')).toBeInTheDocument()
-
-    // URL が表示されていないことを確認 (仕様変更)
-    expect(screen.queryByText('https://example.com/1')).not.toBeInTheDocument()
-
-    // テーブル構造であることを確認
-    expect(screen.getByRole('table')).toBeInTheDocument()
-    expect(screen.getAllByRole('row')).toHaveLength(2) // 2 items (header is empty and has no row)
-  })
-
-  it('データが空の場合に適切なメッセージが表示されること', () => {
-    render(
-      <BookmarkList bookmarks={[]} isLoading={false} error={null} />
-    )
-    expect(screen.getByText(UI_MESSAGES.NO_BOOKMARKS)).toBeInTheDocument()
-  })
-
-  it('エラー発生時にエラーメッセージが表示されること', () => {
-    const error = new Error('Test Error')
-    render(
-      <BookmarkList bookmarks={[]} isLoading={false} error={error} />
-    )
-
-    const alert = screen.getByRole('alert')
-    expect(alert).toHaveTextContent(UI_MESSAGES.ERROR_PREFIX)
-    expect(alert).toHaveTextContent('Test Error')
-  })
-
-  it('Errorインスタンス以外のエラー発生時に、予期せぬエラーメッセージが表示されること', () => {
-    render(
-      <BookmarkList
-        bookmarks={[]}
-        isLoading={false}
-        error="Unexpected string error"
-      />
-    )
-
-    const alert = screen.getByRole('alert')
-    expect(alert).toHaveTextContent(UI_MESSAGES.ERROR_PREFIX)
-    expect(alert).toHaveTextContent(UI_MESSAGES.UNEXPECTED_ERROR)
+  it.each(testCases)('$name', ({ props, assert }) => {
+    render(<BookmarkList {...props} />)
+    assert()
   })
 })

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -10,7 +10,17 @@ describe('BookmarkList', () => {
     { id: '2', title: 'Test Bookmark 2', url: 'https://example.com/2' },
   ]
 
-  const testCases = [
+  type TestCase = {
+    name: string
+    props: {
+      bookmarks: Bookmark[]
+      isLoading: boolean
+      error: Error | string | null
+    }
+    assert: () => void
+  }
+
+  const testCases: TestCase[] = [
     {
       name: 'ローディング中にスピナーが表示されること',
       props: { bookmarks: [], isLoading: true, error: null },


### PR DESCRIPTION
#### 概要
`BookmarkList.test.tsx` において、各テストケースが同様の構造を繰り返していたため、Vitest の `it.each` を使用してパラメータ化し、コードの重複を排除しました。これにより、保守性と可読性が向上しています。

#### 変更内容
- **テストケースのパラメータ化**
    - 入力（Props）と期待される結果（Assertion）を配列として定義し、`it.each` で一括実行するようにリファクタリング。
- **不整合なテストの整理**
    - 前回の UI 刷新（テーブル化・リンクの削除）に伴い、現状の UI 構造と不整合を起こしていた「不正な URL の href 検証」テストケースを削除。
- **型安全性の向上**
    - テストデータに `Bookmark` 型を適用し、インポートを整理。

#### メリット
- テストコードが簡潔になり、何が検証されているかがひと目で分かるようになった。
- 将来的な新しい表示パターンの追加や、Props の変更への対応が容易になった。

#### 関連 Issue
- Closes #37