### PR TITLE
feat: ブックマークのダブルクリックで URL を開く機能の実装 (v0.1.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bookmark-page",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bookmark-page",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^1.19.8",
         "@tanstack/react-query": "^5.90.19",
@@ -22,6 +22,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.1",
+        "@testing-library/user-event": "^14.6.1",
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^24.10.7",
         "@types/react": "^19.2.5",
@@ -2225,6 +2226,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm run server:dev\" \"npm run client:dev\"",
@@ -33,6 +33,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.1",
+    "@testing-library/user-event": "^14.6.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^24.10.7",
     "@types/react": "^19.2.5",

--- a/src/components/BookmarkList.tsx
+++ b/src/components/BookmarkList.tsx
@@ -1,5 +1,6 @@
 import { UI_MESSAGES } from '@shared/constants'
 import type { Bookmark } from '@shared/schemas/bookmark'
+import { isHttpUrl } from '@shared/utils/url'
 
 type Props = {
   bookmarks: Bookmark[]
@@ -8,6 +9,12 @@ type Props = {
 }
 
 export const BookmarkList = ({ bookmarks, isLoading, error }: Props) => {
+  const handleDoubleClick = (url: string) => {
+    if (isHttpUrl(url)) {
+      window.open(url, '_blank', 'noopener,noreferrer')
+    }
+  }
+
   if (isLoading) {
     return (
       <div
@@ -49,6 +56,7 @@ export const BookmarkList = ({ bookmarks, isLoading, error }: Props) => {
             <tr
               key={bookmark.id}
               className="hover:bg-gray-50 transition-colors cursor-pointer"
+              onDoubleClick={() => handleDoubleClick(bookmark.url)}
             >
               <td className="px-2 py-1 whitespace-nowrap text-sm font-medium text-gray-900 text-left bg-blue-100 border-b border-blue-700">
                 {bookmark.title}

--- a/src/components/BookmarkList.tsx
+++ b/src/components/BookmarkList.tsx
@@ -1,6 +1,6 @@
 import { UI_MESSAGES } from '@shared/constants'
 import type { Bookmark } from '@shared/schemas/bookmark'
-import { isHttpUrl } from '@shared/utils/url'
+import { useBookmarkList } from '../hooks/useBookmarkList'
 
 type Props = {
   bookmarks: Bookmark[]
@@ -9,11 +9,7 @@ type Props = {
 }
 
 export const BookmarkList = ({ bookmarks, isLoading, error }: Props) => {
-  const handleDoubleClick = (url: string) => {
-    if (isHttpUrl(url)) {
-      window.open(url, '_blank', 'noopener,noreferrer')
-    }
-  }
+  const { handleDoubleClick } = useBookmarkList()
 
   if (isLoading) {
     return (

--- a/src/hooks/useBookmarkList.test.ts
+++ b/src/hooks/useBookmarkList.test.ts
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useBookmarkList } from './useBookmarkList'
+
+describe('useBookmarkList', () => {
+  beforeEach(() => {
+    vi.stubGlobal('open', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('handleDoubleClick が呼ばれた際に新しいタブで URL が開かれること', () => {
+    const { result } = renderHook(() => useBookmarkList())
+    const url = 'https://example.com'
+
+    result.current.handleDoubleClick(url)
+
+    expect(window.open).toHaveBeenCalledWith(
+      url,
+      '_blank',
+      'noopener,noreferrer'
+    )
+  })
+
+  it('不正な URL の場合は handleDoubleClick が呼ばれても window.open が実行されないこと', () => {
+    const { result } = renderHook(() => useBookmarkList())
+    const url = 'javascript:alert(1)'
+
+    result.current.handleDoubleClick(url)
+
+    expect(window.open).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useBookmarkList.test.ts
+++ b/src/hooks/useBookmarkList.test.ts
@@ -12,25 +12,53 @@ describe('useBookmarkList', () => {
     vi.unstubAllGlobals()
   })
 
-  it('handleDoubleClick が呼ばれた際に新しいタブで URL が開かれること', () => {
+  type TestCase = {
+    name: string
+    url: string
+    expectedCalled: boolean
+  }
+
+  const testCases: TestCase[] = [
+    {
+      name: '有効な HTTP URL の場合に新しいタブで開かれること',
+      url: 'http://example.com',
+      expectedCalled: true,
+    },
+    {
+      name: '有効な HTTPS URL の場合に新しいタブで開かれること',
+      url: 'https://example.com',
+      expectedCalled: true,
+    },
+    {
+      name: 'javascript: スキームの場合は実行されないこと',
+      url: 'javascript:alert(1)',
+      expectedCalled: false,
+    },
+    {
+      name: 'プロトコルのない文字列の場合は実行されないこと',
+      url: 'example.com',
+      expectedCalled: false,
+    },
+    {
+      name: '不正な形式の文字列の場合は実行されないこと',
+      url: 'not-a-url',
+      expectedCalled: false,
+    },
+  ]
+
+  it.each(testCases)('$name', ({ url, expectedCalled }) => {
     const { result } = renderHook(() => useBookmarkList())
-    const url = 'https://example.com'
 
     result.current.handleDoubleClick(url)
 
-    expect(window.open).toHaveBeenCalledWith(
-      url,
-      '_blank',
-      'noopener,noreferrer'
-    )
-  })
-
-  it('不正な URL の場合は handleDoubleClick が呼ばれても window.open が実行されないこと', () => {
-    const { result } = renderHook(() => useBookmarkList())
-    const url = 'javascript:alert(1)'
-
-    result.current.handleDoubleClick(url)
-
-    expect(window.open).not.toHaveBeenCalled()
+    if (expectedCalled) {
+      expect(window.open).toHaveBeenCalledWith(
+        url,
+        '_blank',
+        'noopener,noreferrer',
+      )
+    } else {
+      expect(window.open).not.toHaveBeenCalled()
+    }
   })
 })

--- a/src/hooks/useBookmarkList.ts
+++ b/src/hooks/useBookmarkList.ts
@@ -1,0 +1,17 @@
+import { useCallback } from 'react'
+import { isHttpUrl } from '@shared/utils/url'
+
+export const useBookmarkList = () => {
+  /**
+   * ブックマークをダブルクリックした際のハンドラ
+   */
+  const handleDoubleClick = useCallback((url: string) => {
+    if (isHttpUrl(url)) {
+      window.open(url, '_blank', 'noopener,noreferrer')
+    }
+  }, [])
+
+  return {
+    handleDoubleClick,
+  }
+}


### PR DESCRIPTION
#### 概要
ブックマーク一覧の各行をダブルクリックした際に、そのブックマークに登録されている URL を新しいタブで開く機能を実装しました。この機能の導入により、ブックマークの「閲覧」と「利用（アクセス）」というアプリケーションの最小限のコア機能が揃ったため、本タスクの完了をもってバージョンを `0.1.0` に引き上げます。

#### 変更内容
- **機能実装**
    - `BookmarkList.tsx` の各行 (`<tr>`) にダブルクリックイベントを追加。
    - `window.open` を使用して、安全に (`noopener,noreferrer`) 新しいタブで URL を開くロジックを実装。
- **アーキテクチャの改善 (リファクタリング)**
    - ダブルクリック時のアクションをカスタムフック `useBookmarkList.ts` に切り出し、UI とロジックを分離。
    - `shared/utils/url.ts` の `isHttpUrl` を使用して、遷移前にプロトコルを検証するガードを実装 (XSS 防御)。
- **テストの拡充**
    - `useBookmarkList.test.ts` を新設し、フック単体でのロジック（URL 検証と遷移）を `it.each` を用いて網羅的に検証。
    - `BookmarkList.test.tsx` では、UI 要素とフックの紐付けが正しく行われているかをスパイを用いて検証。
- **バージョンの更新**
    - `package.json` のバージョンを `0.1.0` に更新。

#### メリット
- `kubotama/linkpage` の基本操作を再現し、直感的な操作が可能になりました。
- 高いテスト網羅率（100% カバレッジ）を維持しつつ、将来の機能拡張（選択・編集など）に向けた基盤が整いました。
- 最初のマイナーリリースとして、プロジェクトのマイルストーンを達成しました。

#### 関連 Issue
- Closes #39