### PR TITLE
refactor: BookmarkId 型の導入とテストデータの集約管理 (v0.2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 - **Frontend:** Vite, React, TypeScript, Tailwind CSS, TanStack Query
 - **Backend:** Hono (@hono/node-server), better-sqlite3
-- **Shared:** TypeScript (Zod schemas, constants)
+- **Shared:** TypeScript (Zod schemas, domain types like BookmarkId, constants)
 - **Database:** SQLite
 
 ## ディレクトリ構成 (Project Structure)
@@ -96,6 +96,7 @@ npm run test:coverage
 
 - テスト実行時は、開発用データベースに影響を与えないよう SQLite のインメモリモード (`:memory:`) が自動的に使用されます。
 - フロントエンドのテストには **React Testing Library** と **MSW (Mock Service Worker)** を使用しており、API リクエストをモックしてコンポーネントの挙動を検証しています。
+- テストデータは Fixture (例: `src/test/fixtures.ts`) として集約管理されており、保守性と一貫性が確保されています。
 - プロジェクトの品質維持のため、カバレッジ閾値が設定されています（詳細は `vite.config.ts` を参照）。
 
 ## API 仕様 (API Specifications)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm run server:dev\" \"npm run client:dev\"",

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -64,32 +64,25 @@ describe('GET /api/bookmarks', () => {
     // console.error をスパイして出力を抑制する
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    try {
-      const res = await app.request(API_PATHS.BOOKMARKS)
+    const res = await app.request(API_PATHS.BOOKMARKS)
 
-      // 1. ステータスコードが 500 であること
-      expect(res.status).toBe(500)
+    // 1. ステータスコードが 500 であること
+    expect(res.status).toBe(500)
 
-      const body = await res.json()
+    const body = await res.json()
 
-      // 2. メッセージが "Internal Server Error" であること
-      expect(body).toHaveProperty(
-        'message',
-        ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-      )
+    // 2. メッセージが "Internal Server Error" であること
+    expect(body).toHaveProperty('message', ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
 
-      // 3. 詳細なエラー情報やスタックトレースが含まれていないこと
-      expect(body).not.toHaveProperty('error')
-      expect(body).not.toHaveProperty('stack')
+    // 3. 詳細なエラー情報やスタックトレースが含まれていないこと
+    expect(body).not.toHaveProperty('error')
+    expect(body).not.toHaveProperty('stack')
 
-      // 4. console.error が適切なメッセージとともに呼び出されたことを確認
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Failed to fetch bookmarks:',
-        expect.any(Error),
-      )
-      expect(consoleSpy.mock.calls[0][1].message).toBe(INTERNAL_ERROR_LOG)
-    } finally {
-      // afterEach により自動リセットされるが明示
-    }
+    // 4. console.error が適切なメッセージとともに呼び出されたことを確認
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to fetch bookmarks:',
+      expect.any(Error),
+    )
+    expect(consoleSpy.mock.calls[0][1].message).toBe(INTERNAL_ERROR_LOG)
   })
 })

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import { db } from '../db'
-import { bookmarksResponseSchema } from '@shared/schemas/bookmark'
+import { bookmarksResponseSchema, type BookmarkId } from '@shared/schemas/bookmark'
 import { ERROR_MESSAGES } from '@shared/constants'
 
 interface BookmarkRow {
@@ -18,7 +18,7 @@ const bookmarksRoute = new Hono().get('/', (c) => {
 
     // DB のデータを API レスポンスの形式に整形
     const bookmarks = rows.map((row) => ({
-      id: String(row.id),
+      id: String(row.id) as BookmarkId,
       title: row.title,
       url: row.url,
     }))

--- a/shared/schemas/bookmark.test.ts
+++ b/shared/schemas/bookmark.test.ts
@@ -1,31 +1,33 @@
 import { describe, it, expect } from 'vitest'
 import { bookmarkSchema } from './bookmark'
+import { MOCK_BOOKMARK_1, INVALID_URLS } from '../test/fixtures'
 
 describe('bookmarkSchema', () => {
   it('有効な HTTP URL を受け入れること', () => {
-    const valid = { id: '1', title: 'Test', url: 'http://example.com' }
-    expect(bookmarkSchema.safeParse(valid).success).toBe(true)
+    const valid = { ...MOCK_BOOKMARK_1, url: 'http://example.com' }
+    const result = bookmarkSchema.safeParse(valid)
+    expect(result.success).toBe(true)
   })
 
   it('有効な HTTPS URL を受け入れること', () => {
-    const valid = { id: '1', title: 'Test', url: 'https://example.com' }
-    expect(bookmarkSchema.safeParse(valid).success).toBe(true)
+    const result = bookmarkSchema.safeParse(MOCK_BOOKMARK_1)
+    expect(result.success).toBe(true)
   })
 
   it('javascript: スキームを拒否すること', () => {
-    const invalid = { id: '1', title: 'Test', url: 'javascript:alert(1)' }
+    const invalid = { ...MOCK_BOOKMARK_1, url: INVALID_URLS.JAVASCRIPT }
     const result = bookmarkSchema.safeParse(invalid)
     expect(result.success).toBe(false)
   })
 
   it('プロトコルのない URL を拒否すること', () => {
-    const invalid = { id: '1', title: 'Test', url: 'example.com' }
+    const invalid = { ...MOCK_BOOKMARK_1, url: INVALID_URLS.NO_PROTOCOL }
     const result = bookmarkSchema.safeParse(invalid)
     expect(result.success).toBe(false)
   })
 
   it('不正な形式の文字列を拒否すること', () => {
-    const invalid = { id: '1', title: 'Test', url: 'not-a-url' }
+    const invalid = { ...MOCK_BOOKMARK_1, url: INVALID_URLS.MALFORMED }
     const result = bookmarkSchema.safeParse(invalid)
     expect(result.success).toBe(false)
   })

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod'
 import { isHttpUrl } from '../utils/url'
 
-export type BookmarkId = string
+export const BookmarkIdSchema = z.string().brand<'BookmarkId'>()
+export type BookmarkId = z.infer<typeof BookmarkIdSchema>
 
 export const bookmarkSchema = z.object({
-  id: z.string() as z.ZodType<BookmarkId>,
+  id: BookmarkIdSchema,
   title: z.string(),
   url: z.string().url().refine(isHttpUrl, {
     message: 'URL は http:// または https:// で始まる必要があります',

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod'
 import { isHttpUrl } from '../utils/url'
 
+export type BookmarkId = string
+
 export const bookmarkSchema = z.object({
-  id: z.string(),
+  id: z.string() as z.ZodType<BookmarkId>,
   title: z.string(),
   url: z.string().url().refine(isHttpUrl, {
     message: 'URL は http:// または https:// で始まる必要があります',

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -1,4 +1,4 @@
-import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
+import type { Bookmark, BookmarkId } from '../schemas/bookmark'
 
 export const MOCK_BOOKMARK_1: Bookmark = {
   id: '1' as BookmarkId,

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from 'msw'
 import { server } from './test/setup'
 import App from './App'
 import { API_PATHS } from '@shared/constants'
+import { MOCK_BOOKMARK_1 } from './test/fixtures'
 
 const createTestQueryClient = () =>
   new QueryClient({
@@ -23,27 +24,23 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 describe('App Integration', () => {
   it('ブックマーク一覧が正常に取得・表示されること', async () => {
-    const mockBookmarks = [
-      { id: '1', title: 'Integrated Bookmark', url: 'https://example.com' },
-    ]
-
     server.use(
       http.get(API_PATHS.BOOKMARKS, () => {
-        return HttpResponse.json({ bookmarks: mockBookmarks })
-      })
+        return HttpResponse.json({ bookmarks: [MOCK_BOOKMARK_1] })
+      }),
     )
 
     render(<App />, { wrapper })
 
     // データの取得待ちと表示確認
-    expect(await screen.findByText('Integrated Bookmark')).toBeInTheDocument()
+    expect(await screen.findByText(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
   })
 
   it('APIエラー時にエラーメッセージが表示されること', async () => {
     server.use(
       http.get(API_PATHS.BOOKMARKS, () => {
         return new HttpResponse(null, { status: 500 })
-      })
+      }),
     )
 
     render(<App />, { wrapper })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,7 +5,7 @@ import { http, HttpResponse } from 'msw'
 import { server } from './test/setup'
 import App from './App'
 import { API_PATHS } from '@shared/constants'
-import { MOCK_BOOKMARK_1 } from './test/fixtures'
+import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 
 const createTestQueryClient = () =>
   new QueryClient({

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -3,20 +3,19 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { BookmarkList, type BookmarkProps } from './BookmarkList'
 import { UI_MESSAGES } from '@shared/constants'
-import type { Bookmark } from '@shared/schemas/bookmark'
+import {
+  MOCK_BOOKMARK_1,
+  MOCK_BOOKMARK_2,
+  MOCK_BOOKMARKS,
+} from '../test/fixtures'
 
 describe('BookmarkList', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  const mockBookmarks: Bookmark[] = [
-    { id: '1', title: 'Test Bookmark 1', url: 'https://example.com/1' },
-    { id: '2', title: 'Test Bookmark 2', url: 'https://example.com/2' },
-  ]
-
   const defaultProps: BookmarkProps = {
-    bookmarks: mockBookmarks,
+    bookmarks: MOCK_BOOKMARKS,
     isLoading: false,
     error: null,
     selectedId: null,
@@ -43,10 +42,10 @@ describe('BookmarkList', () => {
     },
     {
       name: 'ブックマーク一覧が正常に表示されること',
-      props: { bookmarks: mockBookmarks },
+      props: { bookmarks: MOCK_BOOKMARKS },
       assert: () => {
-        expect(screen.getByText('Test Bookmark 1')).toBeInTheDocument()
-        expect(screen.getByText('Test Bookmark 2')).toBeInTheDocument()
+        expect(screen.getByText(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
+        expect(screen.getByText(MOCK_BOOKMARK_2.title)).toBeInTheDocument()
         expect(screen.getByRole('table')).toBeInTheDocument()
         expect(screen.getAllByRole('row')).toHaveLength(2)
       },
@@ -90,11 +89,9 @@ describe('BookmarkList', () => {
   })
 
   it('選択された行のスタイルが太字になること', () => {
-    render(<BookmarkList {...defaultProps} selectedId="1" />)
+    render(<BookmarkList {...defaultProps} selectedId={MOCK_BOOKMARK_1.id} />)
 
-    const cell = screen.getByText('Test Bookmark 1')
-
-    // 選択時のクラスを確認 (太字化)
+    const cell = screen.getByText(MOCK_BOOKMARK_1.title)
     expect(cell).toHaveClass('font-bold')
   })
 
@@ -103,8 +100,8 @@ describe('BookmarkList', () => {
     const onRowClick = vi.fn()
     render(<BookmarkList {...defaultProps} onRowClick={onRowClick} />)
 
-    await user.click(screen.getByText('Test Bookmark 1'))
-    expect(onRowClick).toHaveBeenCalledWith('1')
+    await user.click(screen.getByText(MOCK_BOOKMARK_1.title))
+    expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
   })
 
   it('行をダブルクリックした際に onDoubleClick が呼び出されること', async () => {
@@ -112,8 +109,11 @@ describe('BookmarkList', () => {
     const onDoubleClick = vi.fn()
     render(<BookmarkList {...defaultProps} onDoubleClick={onDoubleClick} />)
 
-    await user.dblClick(screen.getByText('Test Bookmark 1'))
-    expect(onDoubleClick).toHaveBeenCalledWith('1', 'https://example.com/1')
+    await user.dblClick(screen.getByText(MOCK_BOOKMARK_1.title))
+    expect(onDoubleClick).toHaveBeenCalledWith(
+      MOCK_BOOKMARK_1.id,
+      MOCK_BOOKMARK_1.url,
+    )
   })
 
   it('行にフォーカスして Enter キーを押した際に onDoubleClick が呼び出されること', async () => {
@@ -122,12 +122,13 @@ describe('BookmarkList', () => {
     render(<BookmarkList {...defaultProps} onDoubleClick={onDoubleClick} />)
 
     const rows = screen.getAllByRole('row')
-    // Roving tabindex: 未選択時は 1 行目が 0, 2 行目は -1
     expect(rows[0]).toHaveAttribute('tabIndex', '0')
-    expect(rows[1]).toHaveAttribute('tabIndex', '-1')
 
     await user.type(rows[1]!, '{enter}')
-    expect(onDoubleClick).toHaveBeenCalledWith('2', 'https://example.com/2')
+    expect(onDoubleClick).toHaveBeenCalledWith(
+      MOCK_BOOKMARK_2.id,
+      MOCK_BOOKMARK_2.url,
+    )
   })
 
   it('行にフォーカスして スペース キーを押した際に onRowClick が呼び出されること', async () => {
@@ -137,11 +138,13 @@ describe('BookmarkList', () => {
 
     const rows = screen.getAllByRole('row')
     await user.type(rows[0]!, ' ')
-    expect(onRowClick).toHaveBeenCalledWith('1')
+    expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
   })
 
   it('選択状態の行がフォーカス可能(tabIndex=0)になり、他の行は -1 になること', () => {
-    const { rerender } = render(<BookmarkList {...defaultProps} selectedId="2" />)
+    const { rerender } = render(
+      <BookmarkList {...defaultProps} selectedId={MOCK_BOOKMARK_2.id} />,
+    )
 
     const rows = screen.getAllByRole('row')
     expect(rows[0]).toHaveAttribute('tabIndex', '-1')
@@ -155,12 +158,12 @@ describe('BookmarkList', () => {
   })
 
   it('選択状態の行に aria-selected="true" が付与されること', () => {
-    render(<BookmarkList {...defaultProps} selectedId="1" />)
+    render(<BookmarkList {...defaultProps} selectedId={MOCK_BOOKMARK_1.id} />)
 
-    const row = screen.getByText('Test Bookmark 1').closest('tr')
+    const row = screen.getByText(MOCK_BOOKMARK_1.title).closest('tr')
     expect(row).toHaveAttribute('aria-selected', 'true')
 
-    const otherRow = screen.getByText('Test Bookmark 2').closest('tr')
+    const otherRow = screen.getByText(MOCK_BOOKMARK_2.title).closest('tr')
     expect(otherRow).toHaveAttribute('aria-selected', 'false')
   })
 })

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -7,7 +7,7 @@ import {
   MOCK_BOOKMARK_1,
   MOCK_BOOKMARK_2,
   MOCK_BOOKMARKS,
-} from '../test/fixtures'
+} from '@shared/test/fixtures'
 
 describe('BookmarkList', () => {
   afterEach(() => {

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -123,6 +123,7 @@ describe('BookmarkList', () => {
 
     const rows = screen.getAllByRole('row')
     expect(rows[0]).toHaveAttribute('tabIndex', '0')
+    expect(rows[1]).toHaveAttribute('tabIndex', '-1')
 
     await user.type(rows[1]!, '{enter}')
     expect(onDoubleClick).toHaveBeenCalledWith(

--- a/src/components/BookmarkList.tsx
+++ b/src/components/BookmarkList.tsx
@@ -1,13 +1,13 @@
 import { UI_MESSAGES } from '@shared/constants'
-import type { Bookmark } from '@shared/schemas/bookmark'
+import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
 
 export type BookmarkProps = {
   bookmarks: Bookmark[]
   isLoading: boolean
   error: null | string | Error
-  selectedId: string | null
-  onRowClick: (id: string) => void
-  onDoubleClick: (id: string, url: string) => void
+  selectedId: BookmarkId | null
+  onRowClick: (id: BookmarkId) => void
+  onDoubleClick: (id: BookmarkId, url: string) => void
 }
 
 export const BookmarkList = ({

--- a/src/hooks/useBookmarkList.test.ts
+++ b/src/hooks/useBookmarkList.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useBookmarkList } from './useBookmarkList'
-import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2, INVALID_URLS } from '../test/fixtures'
+import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2, INVALID_URLS } from '@shared/test/fixtures'
 
 describe('useBookmarkList', () => {
   beforeEach(() => {

--- a/src/hooks/useBookmarkList.test.ts
+++ b/src/hooks/useBookmarkList.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useBookmarkList } from './useBookmarkList'
+import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2, INVALID_URLS } from '../test/fixtures'
 
 describe('useBookmarkList', () => {
   beforeEach(() => {
@@ -31,30 +32,29 @@ describe('useBookmarkList', () => {
     },
     {
       name: 'javascript: スキームの場合は実行されないこと',
-      url: 'javascript:alert(1)',
+      url: INVALID_URLS.JAVASCRIPT,
       expectedCalled: false,
     },
     {
       name: 'プロトコルのない文字列の場合は実行されないこと',
-      url: 'example.com',
+      url: INVALID_URLS.NO_PROTOCOL,
       expectedCalled: false,
     },
     {
       name: '不正な形式の文字列の場合は実行されないこと',
-      url: 'not-a-url',
+      url: INVALID_URLS.MALFORMED,
       expectedCalled: false,
     },
   ]
 
   it.each(testCases)('$name', ({ url, expectedCalled }) => {
     const { result } = renderHook(() => useBookmarkList())
-    const id = 'test-id'
 
     act(() => {
-      result.current.handleDoubleClick(id, url)
+      result.current.handleDoubleClick(MOCK_BOOKMARK_1.id, url)
     })
 
-    expect(result.current.selectedId).toBe(id) // 無効なURLでも選択は行われる仕様とする
+    expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
 
     if (expectedCalled) {
       expect(window.open).toHaveBeenCalledWith(
@@ -76,30 +76,24 @@ describe('useBookmarkList', () => {
     it('handleRowClick を呼ぶと ID が選択されること', () => {
       const { result } = renderHook(() => useBookmarkList())
 
-      const id = '1'
-
       act(() => {
-        result.current.handleRowClick(id)
+        result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
 
-      expect(result.current.selectedId).toBe(id)
+      expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
     })
 
     it('同じ ID で再度 handleRowClick を呼ぶと選択が解除されること', () => {
       const { result } = renderHook(() => useBookmarkList())
 
-      const id = '1'
+      act(() => {
+        result.current.handleRowClick(MOCK_BOOKMARK_1.id)
+      })
+      expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
 
       act(() => {
-        result.current.handleRowClick(id) // 選択
+        result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
-
-      expect(result.current.selectedId).toBe(id)
-
-      act(() => {
-        result.current.handleRowClick(id) // 解除
-      })
-
       expect(result.current.selectedId).toBeNull()
     })
 
@@ -107,14 +101,13 @@ describe('useBookmarkList', () => {
       const { result } = renderHook(() => useBookmarkList())
 
       act(() => {
-        result.current.handleRowClick('1')
+        result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
-
       act(() => {
-        result.current.handleRowClick('2')
+        result.current.handleRowClick(MOCK_BOOKMARK_2.id)
       })
 
-      expect(result.current.selectedId).toBe('2')
+      expect(result.current.selectedId).toBe(MOCK_BOOKMARK_2.id)
     })
   })
 })

--- a/src/hooks/useBookmarkList.ts
+++ b/src/hooks/useBookmarkList.ts
@@ -1,14 +1,15 @@
 import { useCallback, useState } from 'react'
 import { isHttpUrl } from '@shared/utils/url'
+import type { BookmarkId } from '@shared/schemas/bookmark'
 
 export const useBookmarkList = () => {
-  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [selectedId, setSelectedId] = useState<BookmarkId | null>(null)
 
   /**
    * ブックマーク行をクリックした際のハンドラ (選択/解除のトグル)
    */
   const handleRowClick = useCallback(
-    (id: string) => {
+    (id: BookmarkId) => {
       setSelectedId((prev) => (prev === id ? null : id))
     },
     [setSelectedId],
@@ -18,7 +19,7 @@ export const useBookmarkList = () => {
    * ブックマークをダブルクリックした際のハンドラ
    */
   const handleDoubleClick = useCallback(
-    (id: string, url: string) => {
+    (id: BookmarkId, url: string) => {
       setSelectedId(id)
       if (isHttpUrl(url)) {
         window.open(url, '_blank', 'noopener,noreferrer')

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,0 +1,21 @@
+import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
+
+export const MOCK_BOOKMARK_1: Bookmark = {
+  id: '1' as BookmarkId,
+  title: 'Test Bookmark 1',
+  url: 'https://example.com/1',
+}
+
+export const MOCK_BOOKMARK_2: Bookmark = {
+  id: '2' as BookmarkId,
+  title: 'Test Bookmark 2',
+  url: 'https://example.com/2'
+}
+
+export const MOCK_BOOKMARKS = [MOCK_BOOKMARK_1, MOCK_BOOKMARK_2]
+
+export const INVALID_URLS = {
+  JAVASCRIPT: 'javascript:alert(1)',
+  NO_PROTOCOL: 'example.com',
+  MALFORMED: 'not-a-url',
+} as const


### PR DESCRIPTION
#### 概要
プロジェクト全体の型安全性向上とテストコードの保守性改善を目的として、ブックマーク ID の専用型エイリアスを導入し、テストデータの Fixture 化を行いました。また、内部的な改善を反映してバージョンを `0.2.1` に引き上げました。

#### 変更内容
- **型安全性の強化**
    - `shared/schemas/bookmark.ts` に `BookmarkId` 型エイリアスを定義。
    - サーバー（Hono）、フロントエンド（Hooks, Components）の両方で `string` の代わりに `BookmarkId` を使用するように置換。
- **テストコードのリファクタリング**
    - `src/test/fixtures.ts` を新設し、各テストで重複していたモックデータや定数を集約。
    - 全てのテストファイルからマジックストリングを排除し、Fixture 参照に統一。
    - 不要なインポートや未使用の変数を削除し、テストコードをクリーンアップ。
- **ドキュメントと管理の更新**
    - `README.md` を更新し、型安全な開発方針と Fixture によるデータ管理について追記。
    - `package.json` のバージョンを `0.2.1` に更新。

#### メリット
- ID の混同やタイポによるバグを型レベルで防止できるようになりました。
- テストデータの変更が一箇所で済み、開発効率とテストの信頼性が向上しました。
- 100%（フロントエンド）および 95%（全体）のカバレッジを維持しつつ、よりメンテナンスしやすいコードベースになりました。

#### 関連 Issue
- Closes #42