### PR TITLE
feat: ブックマーク削除 API の実装とプロジェクト全体の定数化リファクタリング

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,13 @@ npm run test:coverage
 
 指定された ID のブックマークを削除します。
 
+**パスパラメータ:**
+
+- `id`: ブックマーク ID (1 以上の整数文字列)
+
 **レスポンス:**
 
 - **204 No Content**: 削除成功
+- **400 Bad Request**: ID の形式が不正な場合
 - **404 Not Found**: 指定された ID が存在しない
 - **500 Internal Server Error**: サーバーエラー

--- a/README.md
+++ b/README.md
@@ -141,3 +141,13 @@ npm run test:coverage
   "url": "https://github.com"
 }
 ```
+
+### DELETE /api/bookmarks/:id
+
+指定された ID のブックマークを削除します。
+
+**レスポンス:**
+
+- **204 No Content**: 削除成功
+- **404 Not Found**: 指定された ID が存在しない
+- **500 Internal Server Error**: サーバーエラー

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm run server:dev\" \"npm run client:dev\"",

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -234,6 +234,22 @@ describe('DELETE /api/bookmarks/:id', () => {
     expect(row).toBeUndefined()
   })
 
+  it.each([
+    { id: 'abc', name: '文字列' },
+    { id: '0', name: 'ゼロ' },
+    { id: '-1', name: '負の数' },
+    { id: '1.5', name: '小数' },
+  ])(
+    '不正な ID 形式 ($name) の場合に 400 エラーを返すこと',
+    async ({ id }) => {
+      const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
+        method: 'DELETE',
+      })
+
+      expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
+    },
+  )
+
   it('存在しない ID を指定した場合に 404 エラーを返すこと', async () => {
     const res = await app.request(`${API_PATHS.BOOKMARKS}/999`, {
       method: 'DELETE',

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import app from '../app'
 import { db, initializeDatabase, resetDatabase } from '../db'
-import { ERROR_MESSAGES, API_PATHS, LOG_MESSAGES, HTTP_STATUS } from '@shared/constants'
+import {
+  ERROR_MESSAGES,
+  API_PATHS,
+  LOG_MESSAGES,
+  HTTP_STATUS,
+} from '@shared/constants'
 import { bookmarkRowSchema } from '@shared/schemas/bookmark'
 
 describe('GET /api/bookmarks', () => {
@@ -120,7 +125,9 @@ describe('POST /api/bookmarks', () => {
     // DBに保存されていることを確認
     const row = bookmarkRowSchema.parse(
       db
-        .prepare('SELECT bookmark_id as id, title, url FROM bookmarks WHERE url = ?')
+        .prepare(
+          'SELECT bookmark_id as id, title, url FROM bookmarks WHERE url = ?',
+        )
         .get(VALID_DATA.url),
     )
     expect(row).toBeDefined()
@@ -128,7 +135,10 @@ describe('POST /api/bookmarks', () => {
   })
 
   it.each([
-    { name: 'タイトルが空', body: { title: '', url: 'https://new-example.com' } },
+    {
+      name: 'タイトルが空',
+      body: { title: '', url: 'https://new-example.com' },
+    },
     { name: 'タイトルが欠落', body: { url: 'https://new-example.com' } },
     { name: 'URL の形式が不正', body: { title: 'New', url: 'not-a-url' } },
     { name: 'URL が欠落', body: { title: 'New' } },
@@ -205,7 +215,9 @@ describe('DELETE /api/bookmarks/:id', () => {
   it('指定した ID のブックマークを削除できること', async () => {
     // 削除対象を登録
     const { bookmark_id: id } = db
-      .prepare('INSERT INTO bookmarks (title, url) VALUES (?, ?) RETURNING bookmark_id')
+      .prepare(
+        'INSERT INTO bookmarks (title, url) VALUES (?, ?) RETURNING bookmark_id',
+      )
       .get(VALID_DATA.title, VALID_DATA.url) as { bookmark_id: number }
 
     const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
@@ -213,7 +225,7 @@ describe('DELETE /api/bookmarks/:id', () => {
     })
 
     expect(res.status).toBe(HTTP_STATUS.NO_CONTENT)
-    expect(res.body).toBeNull()
+    expect(await res.text()).toBe('')
 
     // DB から消えていることを確認
     const row = db

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import app from '../app'
 import { db, initializeDatabase, resetDatabase } from '../db'
-import { ERROR_MESSAGES, API_PATHS, LOG_MESSAGES } from '@shared/constants'
+import { ERROR_MESSAGES, API_PATHS, LOG_MESSAGES, HTTP_STATUS } from '@shared/constants'
 import { bookmarkRowSchema } from '@shared/schemas/bookmark'
 
 describe('GET /api/bookmarks', () => {
@@ -29,7 +29,7 @@ describe('GET /api/bookmarks', () => {
     )
 
     const res = await app.request(API_PATHS.BOOKMARKS)
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(HTTP_STATUS.OK)
 
     const body = await res.json()
 
@@ -49,7 +49,7 @@ describe('GET /api/bookmarks', () => {
 
   it('データが空の場合、空の配列を返すこと', async () => {
     const res = await app.request(API_PATHS.BOOKMARKS)
-    expect(res.status).toBe(200)
+    expect(res.status).toBe(HTTP_STATUS.OK)
     const body = await res.json()
     expect(body.bookmarks).toEqual([])
   })
@@ -68,7 +68,7 @@ describe('GET /api/bookmarks', () => {
     const res = await app.request(API_PATHS.BOOKMARKS)
 
     // 1. ステータスコードが 500 であること
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
 
     const body = await res.json()
 
@@ -110,7 +110,7 @@ describe('POST /api/bookmarks', () => {
       body: JSON.stringify(VALID_DATA),
     })
 
-    expect(res.status).toBe(201)
+    expect(res.status).toBe(HTTP_STATUS.CREATED)
     const body = await res.json()
 
     expect(body).toHaveProperty('id')
@@ -142,7 +142,7 @@ describe('POST /api/bookmarks', () => {
         body: JSON.stringify(body),
       })
 
-      expect(res.status).toBe(400)
+      expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
     },
   )
 
@@ -160,7 +160,7 @@ describe('POST /api/bookmarks', () => {
       body: JSON.stringify(VALID_DATA),
     })
 
-    expect(res.status).toBe(409)
+    expect(res.status).toBe(HTTP_STATUS.CONFLICT)
     const body = await res.json()
     expect(body.message).toBe(ERROR_MESSAGES.DUPLICATE_URL)
   })
@@ -177,11 +177,76 @@ describe('POST /api/bookmarks', () => {
       body: JSON.stringify(VALID_DATA),
     })
 
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     const body = await res.json()
     expect(body.message).toBe(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
     expect(consoleSpy).toHaveBeenCalledWith(
       LOG_MESSAGES.CREATE_BOOKMARK_FAILED,
+      expect.any(Error),
+    )
+  })
+})
+
+describe('DELETE /api/bookmarks/:id', () => {
+  beforeEach(() => {
+    initializeDatabase()
+    resetDatabase()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const VALID_DATA = {
+    title: 'Delete Target',
+    url: 'https://delete-me.com',
+  }
+
+  it('指定した ID のブックマークを削除できること', async () => {
+    // 削除対象を登録
+    const { bookmark_id: id } = db
+      .prepare('INSERT INTO bookmarks (title, url) VALUES (?, ?) RETURNING bookmark_id')
+      .get(VALID_DATA.title, VALID_DATA.url) as { bookmark_id: number }
+
+    const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.NO_CONTENT)
+    expect(res.body).toBeNull()
+
+    // DB から消えていることを確認
+    const row = db
+      .prepare('SELECT * FROM bookmarks WHERE bookmark_id = ?')
+      .get(id)
+    expect(row).toBeUndefined()
+  })
+
+  it('存在しない ID を指定した場合に 404 エラーを返すこと', async () => {
+    const res = await app.request(`${API_PATHS.BOOKMARKS}/999`, {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
+    const body = await res.json()
+    expect(body.message).toBe(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+  })
+
+  it('データベースエラー時に 500 ステータスを返すこと', async () => {
+    vi.spyOn(db, 'prepare').mockImplementation(() => {
+      throw new Error('Database error')
+    })
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const res = await app.request(`${API_PATHS.BOOKMARKS}/1`, {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+    const body = await res.json()
+    expect(body.message).toBe(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+    expect(consoleSpy).toHaveBeenCalledWith(
+      LOG_MESSAGES.DELETE_BOOKMARK_FAILED,
       expect.any(Error),
     )
   })

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -81,31 +81,37 @@ const bookmarksRoute = new Hono()
       )
     }
   })
-  .delete('/:id', zValidator('param', z.object({ id: BookmarkIdSchema })), (c) => {
-    const { id } = c.req.valid('param')
+  .delete(
+    '/:id',
+    zValidator('param', z.object({ id: z.string().regex(/^[1-9]\d*$/) })),
+    (c) => {
+      const { id } = c.req.valid('param')
 
-    try {
-      const info = db.prepare('DELETE FROM bookmarks WHERE bookmark_id = ?').run(id)
+      try {
+        const info = db
+          .prepare('DELETE FROM bookmarks WHERE bookmark_id = ?')
+          .run(id)
 
-      if (info.changes === 0) {
+        if (info.changes === 0) {
+          return c.json(
+            {
+              message: ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+            },
+            HTTP_STATUS.NOT_FOUND,
+          )
+        }
+
+        return c.body(null, HTTP_STATUS.NO_CONTENT)
+      } catch (error) {
+        console.error(LOG_MESSAGES.DELETE_BOOKMARK_FAILED, error)
         return c.json(
           {
-            message: ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+            message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
           },
-          HTTP_STATUS.NOT_FOUND,
+          HTTP_STATUS.INTERNAL_SERVER_ERROR,
         )
       }
-
-      return c.body(null, HTTP_STATUS.NO_CONTENT)
-    } catch (error) {
-      console.error(LOG_MESSAGES.DELETE_BOOKMARK_FAILED, error)
-      return c.json(
-        {
-          message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-        },
-        HTTP_STATUS.INTERNAL_SERVER_ERROR,
-      )
-    }
-  })
+    },
+  )
 
 export default bookmarksRoute

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 
 import { zValidator } from '@hono/zod-validator'
-import { ERROR_MESSAGES, LOG_MESSAGES } from '@shared/constants'
+import { ERROR_MESSAGES, LOG_MESSAGES, HTTP_STATUS } from '@shared/constants'
 import {
   BookmarkIdSchema,
   bookmarkRowSchema,
@@ -41,7 +41,7 @@ const bookmarksRoute = new Hono()
         {
           message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
         },
-        500,
+        HTTP_STATUS.INTERNAL_SERVER_ERROR,
       )
     }
   })
@@ -60,7 +60,7 @@ const bookmarksRoute = new Hono()
           title: row.title,
           url: row.url,
         },
-        201,
+        HTTP_STATUS.CREATED,
       )
     } catch (error) {
       if (isSqliteError(error) && error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
@@ -68,7 +68,7 @@ const bookmarksRoute = new Hono()
           {
             message: ERROR_MESSAGES.DUPLICATE_URL,
           },
-          409,
+          HTTP_STATUS.CONFLICT,
         )
       }
 
@@ -77,7 +77,33 @@ const bookmarksRoute = new Hono()
         {
           message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
         },
-        500,
+        HTTP_STATUS.INTERNAL_SERVER_ERROR,
+      )
+    }
+  })
+  .delete('/:id', zValidator('param', z.object({ id: BookmarkIdSchema })), (c) => {
+    const { id } = c.req.valid('param')
+
+    try {
+      const info = db.prepare('DELETE FROM bookmarks WHERE bookmark_id = ?').run(id)
+
+      if (info.changes === 0) {
+        return c.json(
+          {
+            message: ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+          },
+          HTTP_STATUS.NOT_FOUND,
+        )
+      }
+
+      return c.body(null, HTTP_STATUS.NO_CONTENT)
+    } catch (error) {
+      console.error(LOG_MESSAGES.DELETE_BOOKMARK_FAILED, error)
+      return c.json(
+        {
+          message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+        },
+        HTTP_STATUS.INTERNAL_SERVER_ERROR,
       )
     }
   })

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,6 +1,7 @@
 export const ERROR_MESSAGES = {
   INTERNAL_SERVER_ERROR: 'Internal Server Error',
   DUPLICATE_URL: 'この URL は既に登録されています',
+  BOOKMARK_NOT_FOUND: '指定されたブックマークが見つかりませんでした',
 } as const
 
 export const UI_MESSAGES = {
@@ -15,9 +16,20 @@ export const API_PATHS = {
   BOOKMARKS: '/api/bookmarks',
 } as const
 
+export const HTTP_STATUS = {
+  OK: 200,
+  CREATED: 201,
+  NO_CONTENT: 204,
+  BAD_REQUEST: 400,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  INTERNAL_SERVER_ERROR: 500,
+} as const
+
 export const LOG_MESSAGES = {
   DB_INIT_FAILED: 'Failed to initialize database:',
   SERVER_START_FAILED: 'Failed to start server:',
   FETCH_BOOKMARKS_FAILED: 'Failed to fetch bookmarks:',
   CREATE_BOOKMARK_FAILED: 'Failed to create bookmark:',
+  DELETE_BOOKMARK_FAILED: 'Failed to delete bookmark:',
 } as const

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest'
 import { http, HttpResponse } from 'msw'
 import { server } from './test/setup'
 import App from './App'
-import { API_PATHS } from '@shared/constants'
+import { API_PATHS, HTTP_STATUS } from '@shared/constants'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 
 const createTestQueryClient = () =>
@@ -39,7 +39,7 @@ describe('App Integration', () => {
   it('APIエラー時にエラーメッセージが表示されること', async () => {
     server.use(
       http.get(API_PATHS.BOOKMARKS, () => {
-        return new HttpResponse(null, { status: 500 })
+        return new HttpResponse(null, { status: HTTP_STATUS.INTERNAL_SERVER_ERROR })
       }),
     )
 


### PR DESCRIPTION
#### 概要
ブックマーク削除機能を実装し、あわせてプロジェクト全体でハードコードされていた HTTP ステータスコードやエラーメッセージを定数化するリファクタリングを行いました。

#### 変更内容
- **API 実装**
    - `DELETE /api/bookmarks/:id` エンドポイントを実装。
    - パスパラメータのバリデーションと、リソース不在時の 404 ハンドリングを追加。
- **定数化リファクタリング**
    - `shared/constants.ts` に `HTTP_STATUS` 定数を導入（200, 201, 204, 400, 404, 409, 500）。
    - 既存の GET / POST ルート、および全てのテストコードからマジックナンバー（ステータスコード）を排除。
    - 404 エラーメッセージを `ERROR_MESSAGES.BOOKMARK_NOT_FOUND` として定数化。
    - ログメッセージに `DELETE_BOOKMARK_FAILED` を追加。
- **テスト・ドキュメント**
    - 削除 API の正常系・異常系・DBエラー系のテストを網羅。
    - `README.md` に削除 API の仕様を追記。

#### メリット
- 不要なブックマークを安全に削除できるようになりました。
- マジックナンバーやマジックストリングが排除され、コードの保守性と可読性が飛躍的に向上しました。
- 将来的なステータスコードの変更やメッセージの国際化などに対応しやすい基盤が整いました。

#### 関連 Issue
- Closes #48