### PR TITLE
feat: ブックマーク更新 API (PATCH /api/bookmarks/:id) の実装 (v0.5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,28 @@ npm run test:coverage
 - **400 Bad Request**: ID の形式が不正な場合
 - **404 Not Found**: 指定された ID が存在しない
 - **500 Internal Server Error**: サーバーエラー
+
+### PATCH /api/bookmarks/:id
+
+指定された ID のブックマーク情報を更新します。タイトルまたは URL の少なくとも一方は必須です。
+
+**パスパラメータ:**
+
+- `id`: ブックマーク ID (1 以上の整数文字列)
+
+**リクエストボディ:**
+
+```json
+{
+  "title": "新しいタイトル",
+  "url": "https://updated-example.com"
+}
+```
+
+**レスポンス:**
+
+- **200 OK**: 更新成功。更新後のオブジェクトを返却
+- **400 Bad Request**: リクエスト形式または ID が不正な場合
+- **404 Not Found**: 指定された ID が存在しない
+- **409 Conflict**: 更新後の URL が既に登録されている場合
+- **500 Internal Server Error**: サーバーエラー

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm run server:dev\" \"npm run client:dev\"",

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { z } from 'zod'
 import { db, initializeDatabase, resetDatabase } from './db'
 import { LOG_MESSAGES } from '@shared/constants'
+import { TEST_MESSAGES } from '@shared/test/fixtures'
 
 describe('db.ts', () => {
   beforeEach(() => {
@@ -16,7 +17,6 @@ describe('db.ts', () => {
     vi.unstubAllEnvs()
   })
 
-  const DDL_ERROR_MSG = 'DDL Error'
   const SEED_DATA = { title: 'Initial', url: 'https://initial.com' }
   const AFTER_RESET_DATA = {
     title: 'Test after reset',
@@ -30,13 +30,14 @@ describe('db.ts', () => {
 
     it('DDL実行失敗時にエラーをスローしログを出力すること', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const dbError = new Error(TEST_MESSAGES.DATABASE_ERROR)
       const dbSpy = vi.spyOn(db, 'exec').mockImplementation(() => {
-        throw new Error(DDL_ERROR_MSG)
+        throw dbError
       })
 
-      expect(() => initializeDatabase()).toThrow(DDL_ERROR_MSG)
+      expect(() => initializeDatabase()).toThrow(dbError)
       expect(dbSpy).toHaveBeenCalled()
-      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.DB_INIT_FAILED, expect.any(Error))
+      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.DB_INIT_FAILED, dbError)
     })
 
     it('テスト環境以外では WAL モードが設定されること', () => {

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -123,12 +123,17 @@ const bookmarksRoute = new Hono()
       const updates = c.req.valid('json')
 
       try {
-        // 動的な更新クエリの構築と実行
-        const fields = Object.keys(updates)
-          .map((key) => `${key} = ?`)
-          .join(', ')
-        const values = Object.values(updates)
-
+        const setClauses: string[] = []
+        const values: (string | number)[] = []
+        if (updates.title !== undefined) {
+          setClauses.push('title = ?')
+          values.push(updates.title)
+        }
+        if (updates.url !== undefined) {
+          setClauses.push('url = ?')
+          values.push(updates.url)
+        }
+        const fields = setClauses.join(', ')
         const stmt = db.prepare(
           `UPDATE bookmarks SET ${fields} WHERE bookmark_id = ? RETURNING bookmark_id as id, title, url`,
         )

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -32,4 +32,13 @@ export const LOG_MESSAGES = {
   FETCH_BOOKMARKS_FAILED: 'Failed to fetch bookmarks:',
   CREATE_BOOKMARK_FAILED: 'Failed to create bookmark:',
   DELETE_BOOKMARK_FAILED: 'Failed to delete bookmark:',
+  UPDATE_BOOKMARK_FAILED: 'Failed to update bookmark:',
+} as const
+
+export const VALIDATION_MESSAGES = {
+  TITLE_REQUIRED: 'タイトルは必須です',
+  TITLE_MIN_LENGTH: 'タイトルは1文字以上である必要があります',
+  URL_INVALID_PROTOCOL: 'URL は http:// または https:// で始まる必要があります',
+  URL_INVALID_FORMAT: '有効な URL 形式である必要があります',
+  UPDATE_MIN_FIELDS: 'タイトルまたは URL の少なくとも一方は指定する必要があります',
 } as const

--- a/shared/schemas/bookmark.test.ts
+++ b/shared/schemas/bookmark.test.ts
@@ -1,34 +1,95 @@
 import { describe, it, expect } from 'vitest'
-import { bookmarkSchema } from './bookmark'
+import {
+  bookmarkSchema,
+  createBookmarkSchema,
+  updateBookmarkSchema,
+} from './bookmark'
 import { MOCK_BOOKMARK_1, INVALID_URLS } from '../test/fixtures'
+import { VALIDATION_MESSAGES } from '../constants'
 
 describe('bookmarkSchema', () => {
-  it('有効な HTTP URL を受け入れること', () => {
-    const valid = { ...MOCK_BOOKMARK_1, url: 'http://example.com' }
+  it.each([
+    { name: 'HTTP URL', url: 'http://example.com' },
+    { name: 'HTTPS URL', url: 'https://example.com' },
+  ])('有効な $name を受け入れること', ({ url }) => {
+    const valid = { ...MOCK_BOOKMARK_1, url }
     const result = bookmarkSchema.safeParse(valid)
     expect(result.success).toBe(true)
   })
 
-  it('有効な HTTPS URL を受け入れること', () => {
-    const result = bookmarkSchema.safeParse(MOCK_BOOKMARK_1)
-    expect(result.success).toBe(true)
-  })
-
-  it('javascript: スキームを拒否すること', () => {
+  it('javascript: スキームを拒否し、正しいメッセージを返すこと', () => {
     const invalid = { ...MOCK_BOOKMARK_1, url: INVALID_URLS.JAVASCRIPT }
     const result = bookmarkSchema.safeParse(invalid)
     expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
+      )
+    }
+  })
+})
+
+describe('createBookmarkSchema', () => {
+  it('正常なデータを受け入れること', () => {
+    const valid = { title: 'Test', url: 'https://example.com' }
+    expect(createBookmarkSchema.safeParse(valid).success).toBe(true)
   })
 
-  it('プロトコルのない URL を拒否すること', () => {
-    const invalid = { ...MOCK_BOOKMARK_1, url: INVALID_URLS.NO_PROTOCOL }
-    const result = bookmarkSchema.safeParse(invalid)
+  it.each([
+    {
+      name: 'タイトルが空',
+      data: { title: '', url: 'https://example.com' },
+      expected: VALIDATION_MESSAGES.TITLE_REQUIRED,
+    },
+    {
+      name: 'URL 形式が不正',
+      data: { title: 'Test', url: 'not-a-url' },
+      expected: VALIDATION_MESSAGES.URL_INVALID_FORMAT,
+    },
+    {
+      name: 'プロトコルが不正 (ftp)',
+      data: { title: 'Test', url: 'ftp://example.com' },
+      expected: VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
+    },
+  ])('異常系: $name の場合に正しいエラーを返すこと', ({ data, expected }) => {
+    const result = createBookmarkSchema.safeParse(data)
     expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(expected)
+    }
+  })
+})
+
+describe('updateBookmarkSchema', () => {
+  it.each([
+    { name: 'タイトルのみ', data: { title: 'Updated' } },
+    { name: 'URLのみ', data: { url: 'https://example.com' } },
+    { name: '両方', data: { title: 'Updated', url: 'https://example.com' } },
+  ])('正常系: $name の場合に成功すること', ({ data }) => {
+    expect(updateBookmarkSchema.safeParse(data).success).toBe(true)
   })
 
-  it('不正な形式の文字列を拒否すること', () => {
-    const invalid = { ...MOCK_BOOKMARK_1, url: INVALID_URLS.MALFORMED }
-    const result = bookmarkSchema.safeParse(invalid)
+  it.each([
+    {
+      name: 'タイトルまたは URL の両方が欠落',
+      data: {},
+      expected: VALIDATION_MESSAGES.UPDATE_MIN_FIELDS,
+    },
+    {
+      name: 'タイトルが空文字',
+      data: { title: '' },
+      expected: VALIDATION_MESSAGES.TITLE_MIN_LENGTH,
+    },
+    {
+      name: 'URL 形式が不正',
+      data: { url: 'not-a-url' },
+      expected: VALIDATION_MESSAGES.URL_INVALID_FORMAT,
+    },
+  ])('異常系: $name の場合に正しいエラーを返すこと', ({ data, expected }) => {
+    const result = updateBookmarkSchema.safeParse(data)
     expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(expected)
+    }
   })
 })

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { isHttpUrl } from '../utils/url'
+import { VALIDATION_MESSAGES } from '../constants'
 
 export const BookmarkIdSchema = z.string().brand<'BookmarkId'>()
 export type BookmarkId = z.infer<typeof BookmarkIdSchema>
@@ -7,9 +8,12 @@ export type BookmarkId = z.infer<typeof BookmarkIdSchema>
 export const bookmarkSchema = z.object({
   id: BookmarkIdSchema,
   title: z.string(),
-  url: z.string().url().refine(isHttpUrl, {
-    message: 'URL は http:// または https:// で始まる必要があります',
-  }),
+  url: z
+    .string()
+    .url(VALIDATION_MESSAGES.URL_INVALID_FORMAT)
+    .refine(isHttpUrl, {
+      message: VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
+    }),
 })
 
 export type Bookmark = z.infer<typeof bookmarkSchema>
@@ -23,13 +27,33 @@ export const bookmarkRowSchema = z.object({
 export type BookmarkRow = z.infer<typeof bookmarkRowSchema>
 
 export const createBookmarkSchema = z.object({
-  title: z.string().min(1, 'タイトルは必須です'),
-  url: z.string().url().refine(isHttpUrl, {
-    message: 'URL は http:// または https:// で始まる必要があります',
-  }),
+  title: z.string().min(1, VALIDATION_MESSAGES.TITLE_REQUIRED),
+  url: z
+    .string()
+    .url(VALIDATION_MESSAGES.URL_INVALID_FORMAT)
+    .refine(isHttpUrl, {
+      message: VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
+    }),
 })
 
 export type CreateBookmarkRequest = z.infer<typeof createBookmarkSchema>
+
+export const updateBookmarkSchema = z
+  .object({
+    title: z.string().min(1, VALIDATION_MESSAGES.TITLE_MIN_LENGTH).optional(),
+    url: z
+      .string()
+      .url(VALIDATION_MESSAGES.URL_INVALID_FORMAT)
+      .refine(isHttpUrl, {
+        message: VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
+      })
+      .optional(),
+  })
+  .refine((data) => data.title !== undefined || data.url !== undefined, {
+    message: VALIDATION_MESSAGES.UPDATE_MIN_FIELDS,
+  })
+
+export type UpdateBookmarkRequest = z.infer<typeof updateBookmarkSchema>
 
 export const bookmarksResponseSchema = z.object({
   bookmarks: z.array(bookmarkSchema),

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -19,3 +19,7 @@ export const INVALID_URLS = {
   NO_PROTOCOL: 'example.com',
   MALFORMED: 'not-a-url',
 } as const
+
+export const TEST_MESSAGES = {
+  DATABASE_ERROR: 'Database error',
+} as const


### PR DESCRIPTION
#### 概要
ブックマークのタイトルおよび URL を更新するための PATCH API を実装しました。また、プロジェクト全体のバリデーションメッセージを定数化し、テストコードの網羅性と保守性を向上させました。

#### 変更内容
- **API 実装**
    - `PATCH /api/bookmarks/:id` エンドポイントを追加。
    - タイトルまたは URL の少なくとも一方が送信されていることを検証し、指定されたフィールドのみを動的に更新。
    - 404 (Not Found) および 409 (Conflict/URL 重複) のハンドリング。
- **スキーマ定義と定数化**
    - `shared/schemas/bookmark.ts` に `updateBookmarkSchema` を定義。
    - 全てのバリデーションエラーメッセージを `shared/constants.ts` の `VALIDATION_MESSAGES` に集約。
- **テストの拡充と整理**
    - `it.each` を活用し、スキーマ検証および API 正常系テストを構造化・網羅化。
    - バリデーション失敗時のエラーメッセージが定数と一致することを厳密に検証。
- **ドキュメント・管理**
    - `README.md` に PATCH API の仕様を追記。
    - バージョンを `0.5.0` に更新。

#### メリット
- ブックマーク情報を削除・再登録することなく柔軟に修正可能になりました。
- バリデーションメッセージが一元管理され、UI との整合性や将来的な多言語化に対応しやすい基盤が整いました。
- 重複を排除した堅牢なテストスイートにより、継続的な開発の信頼性が向上しました。

#### 関連 Issue
- Closes #49