### PR TITLE
refactor: BookmarkList から BookmarkItem コンポーネントを抽出

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm run server:dev\" \"npm run client:dev\"",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
+import { useCallback } from 'react'
 import './App.css'
 import { BookmarkList } from './components/BookmarkList'
 import { BookmarkDetail } from './components/BookmarkDetail'
 import { useBookmarks } from './hooks/useBookmarks'
 import { useBookmarkList } from './hooks/useBookmarkList'
 import { useBookmarkActions } from './hooks/useBookmarkActions'
+import type { BookmarkId } from '@shared/schemas/bookmark'
 
 function App() {
   const { data, isLoading, error } = useBookmarks()
@@ -13,6 +15,39 @@ function App() {
 
   const bookmarks = data?.bookmarks ?? []
   const selectedBookmark = bookmarks.find((b) => b.id === selectedId)
+
+  const handleDoubleClick = useCallback(
+    (id: BookmarkId, url: string) => {
+      setSelectedId(id)
+      openBookmark(url)
+    },
+    [setSelectedId, openBookmark],
+  )
+
+  const handleUpdate = useCallback(
+    (title: string, url: string) => {
+      if (selectedBookmark) {
+        updateBookmark(selectedBookmark.id, { title, url })
+      }
+    },
+    [selectedBookmark, updateBookmark],
+  )
+
+  const handleDelete = useCallback(() => {
+    if (selectedBookmark) {
+      deleteBookmark(selectedBookmark.id)
+    }
+  }, [selectedBookmark, deleteBookmark])
+
+  const handleOpen = useCallback(() => {
+    if (selectedBookmark) {
+      openBookmark(selectedBookmark.url)
+    }
+  }, [selectedBookmark, openBookmark])
+
+  const handleClose = useCallback(() => {
+    setSelectedId(null)
+  }, [setSelectedId])
 
   return (
     <div className="flex flex-col h-full w-full bg-gray-50 overflow-hidden">
@@ -25,10 +60,7 @@ function App() {
               error={error}
               selectedId={selectedId}
               onRowClick={handleRowClick}
-              onDoubleClick={(id, url) => {
-                setSelectedId(id)
-                openBookmark(url)
-              }}
+              onDoubleClick={handleDoubleClick}
             />
           </div>
         </div>
@@ -39,12 +71,10 @@ function App() {
           <div className="w-full max-w-2xl">
             <BookmarkDetail
               bookmark={selectedBookmark}
-              onUpdate={(title, url) =>
-                updateBookmark(selectedBookmark.id, { title, url })
-              }
-              onDelete={() => deleteBookmark(selectedBookmark.id)}
-              onOpen={() => openBookmark(selectedBookmark.url)}
-              onClose={() => setSelectedId(null)}
+              onUpdate={handleUpdate}
+              onDelete={handleDelete}
+              onOpen={handleOpen}
+              onClose={handleClose}
             />
           </div>
         </footer>

--- a/src/components/BookmarkItem.test.tsx
+++ b/src/components/BookmarkItem.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { BookmarkItem } from './BookmarkItem'
+import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
+
+describe('BookmarkItem', () => {
+  const defaultProps = {
+    bookmark: MOCK_BOOKMARK_1,
+    isSelected: false,
+    isFocusable: false,
+    onRowClick: vi.fn(),
+    onDoubleClick: vi.fn(),
+  }
+
+  it('ブックマークのタイトルが表示されること', () => {
+    render(
+      <table>
+        <tbody>
+          <BookmarkItem {...defaultProps} />
+        </tbody>
+      </table>,
+    )
+    expect(screen.getByText(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
+  })
+
+  it('選択状態の時に font-bold クラスが付与されること', () => {
+    render(
+      <table>
+        <tbody>
+          <BookmarkItem {...defaultProps} isSelected={true} />
+        </tbody>
+      </table>,
+    )
+    expect(screen.getByText(MOCK_BOOKMARK_1.title)).toHaveClass('font-bold')
+  })
+
+  it('クリック時に onRowClick が呼ばれること', async () => {
+    const user = userEvent.setup()
+    const onRowClick = vi.fn()
+    render(
+      <table>
+        <tbody>
+          <BookmarkItem {...defaultProps} onRowClick={onRowClick} />
+        </tbody>
+      </table>,
+    )
+
+    await user.click(screen.getByRole('row'))
+    expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
+  })
+
+  it('ダブルクリック時に onDoubleClick が呼ばれること', async () => {
+    const user = userEvent.setup()
+    const onDoubleClick = vi.fn()
+    render(
+      <table>
+        <tbody>
+          <BookmarkItem {...defaultProps} onDoubleClick={onDoubleClick} />
+        </tbody>
+      </table>,
+    )
+
+    await user.dblClick(screen.getByRole('row'))
+    expect(onDoubleClick).toHaveBeenCalledWith(
+      MOCK_BOOKMARK_1.id,
+      MOCK_BOOKMARK_1.url,
+    )
+  })
+
+  describe('キーボード操作', () => {
+    it('Enter キーで onDoubleClick が呼ばれること', async () => {
+      const user = userEvent.setup()
+      const onDoubleClick = vi.fn()
+      render(
+        <table>
+          <tbody>
+            <BookmarkItem {...defaultProps} onDoubleClick={onDoubleClick} />
+          </tbody>
+        </table>,
+      )
+
+      await user.type(screen.getByRole('row'), '{enter}')
+      expect(onDoubleClick).toHaveBeenCalledWith(
+        MOCK_BOOKMARK_1.id,
+        MOCK_BOOKMARK_1.url,
+      )
+    })
+
+    it('スペース キーで onRowClick が呼ばれること', async () => {
+      const user = userEvent.setup()
+      const onRowClick = vi.fn()
+      render(
+        <table>
+          <tbody>
+            <BookmarkItem {...defaultProps} onRowClick={onRowClick} />
+          </tbody>
+        </table>,
+      )
+
+      await user.type(screen.getByRole('row'), ' ')
+      expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
+    })
+  })
+
+  describe('tabIndex', () => {
+    it('isFocusable が true の場合は 0 になること', () => {
+      render(
+        <table>
+          <tbody>
+            <BookmarkItem {...defaultProps} isFocusable={true} />
+          </tbody>
+        </table>,
+      )
+      expect(screen.getByRole('row')).toHaveAttribute('tabIndex', '0')
+    })
+
+    it('isFocusable が false の場合は -1 になること', () => {
+      render(
+        <table>
+          <tbody>
+            <BookmarkItem {...defaultProps} isFocusable={false} />
+          </tbody>
+        </table>,
+      )
+      expect(screen.getByRole('row')).toHaveAttribute('tabIndex', '-1')
+    })
+  })
+})

--- a/src/components/BookmarkItem.tsx
+++ b/src/components/BookmarkItem.tsx
@@ -1,0 +1,41 @@
+import React, { memo } from 'react'
+import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
+
+interface BookmarkItemProps {
+  bookmark: Bookmark
+  isSelected: boolean
+  isFocusable: boolean
+  onRowClick: (id: BookmarkId) => void
+  onDoubleClick: (id: BookmarkId, url: string) => void
+}
+
+export const BookmarkItem: React.FC<BookmarkItemProps> = memo(
+  ({ bookmark, isSelected, isFocusable, onRowClick, onDoubleClick }) => {
+    const trClassName = `transition-colors cursor-pointer hover:bg-blue-200 bg-blue-100 text-sm text-left text-gray-900 select-none`
+    const tdClassName = `px-2 py-1 whitespace-nowrap border-b border-blue-700 ${
+      isSelected ? 'font-bold' : ''
+    }`
+
+    return (
+      <tr
+        className={trClassName}
+        tabIndex={isFocusable ? 0 : -1}
+        aria-selected={isSelected}
+        onClick={() => onRowClick(bookmark.id)}
+        onDoubleClick={() => onDoubleClick(bookmark.id, bookmark.url)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            onDoubleClick(bookmark.id, bookmark.url)
+          } else if (e.key === ' ') {
+            e.preventDefault()
+            onRowClick(bookmark.id)
+          }
+        }}
+      >
+        <td className={tdClassName}>{bookmark.title}</td>
+      </tr>
+    )
+  },
+)
+
+BookmarkItem.displayName = 'BookmarkItem'

--- a/src/components/BookmarkList.tsx
+++ b/src/components/BookmarkList.tsx
@@ -1,5 +1,6 @@
 import { UI_MESSAGES } from '@shared/constants'
 import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
+import { BookmarkItem } from './BookmarkItem'
 
 export type BookmarkProps = {
   bookmarks: Bookmark[]
@@ -50,46 +51,24 @@ export const BookmarkList = ({
     )
   }
 
-  const trClassName = `transition-colors cursor-pointer hover:bg-blue-200 bg-blue-100 text-sm text-left text-gray-900 select-none`
-
   return (
     <div className="w-full max-w-2xl mx-auto overflow-hidden bg-white shadow border-t border-l border-r border-blue-700">
       <table className="min-w-full border-collapse">
         <thead className="bg-gray-50"></thead>
         <tbody className="bg-white">
-          {bookmarks.map((bookmark, index) => {
-            const tdClassName = `px-2 py-1 whitespace-nowrap border-b border-blue-700 ${
-              selectedId === bookmark.id ? 'font-bold' : ''
-            }`
-
-            return (
-              <tr
-                key={bookmark.id}
-                className={trClassName}
-                tabIndex={
-                  (selectedId === null && index === 0) ||
-                  selectedId === bookmark.id
-                    ? 0
-                    : -1
-                }
-                aria-selected={selectedId === bookmark.id}
-                onClick={() => onRowClick(bookmark.id)}
-                onDoubleClick={() => onDoubleClick(bookmark.id, bookmark.url)}
-                onKeyDown={(e) => {
-                  // EnterキーでURLを開く (ダブルクリック相当)
-                  if (e.key === 'Enter') {
-                    onDoubleClick(bookmark.id, bookmark.url)
-                  } else if (e.key === ' ') {
-                    // スペースキーで選択/解除 (クリック相当)
-                    e.preventDefault() // ページのスクロールを防止
-                    onRowClick(bookmark.id)
-                  }
-                }}
-              >
-                <td className={tdClassName}>{bookmark.title}</td>
-              </tr>
-            )
-          })}
+          {bookmarks.map((bookmark, index) => (
+            <BookmarkItem
+              key={bookmark.id}
+              bookmark={bookmark}
+              isSelected={selectedId === bookmark.id}
+              isFocusable={
+                selectedId === bookmark.id ||
+                (selectedId === null && index === 0)
+              }
+              onRowClick={onRowClick}
+              onDoubleClick={onDoubleClick}
+            />
+          ))}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
#### 概要
Issue #50 (DnD UI) の実装に先立ち、保守性とテスト容易性を向上させるため、ブックマーク一覧の各行を表示するロジックを独立したコンポーネントとして切り出しました。

#### 変更内容
- **BookmarkItem コンポーネントの抽出**:
    - `BookmarkList.tsx` 内にあった `tr` 要素のレンダリングロジックを `src/components/BookmarkItem.tsx` に移行。
    - 属性 (`tabIndex`, `aria-selected`, `onClick`, `onDoubleClick`, `onKeyDown`) を整理。
- **Roving Tabindex の最適化**:
    - `isFocusable` Prop を追加し、リスト全体で何も選択されていない場合にのみ最初の項目がフォーカス可能になるよう制御。
- **テストの追加・修正**:
    - `BookmarkItem.test.tsx` を新設し、単体での挙動を網羅的に検証。
    - `BookmarkList.test.tsx` も整合性を維持するように修正。

#### 目的・背景
- 並び替え機能 (DnD) 実装時に増大する行レベルのプロパティを整理しやすくするため。
- コンポーネントの責務を分離し、テストの精度を高めるため。