### PR TITLE
style(ui): レイアウトの微調整（#root のパディング削除と背景色の統一）

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,7 +1,7 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 0;
   text-align: center;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,9 +50,9 @@ function App() {
   }, [setSelectedId])
 
   return (
-    <div className="flex flex-col h-full w-full bg-gray-50 overflow-hidden">
+    <div className="flex flex-col h-full w-full bg-white overflow-hidden">
       <main className="flex-1 flex justify-center overflow-hidden">
-        <div className="w-full max-w-2xl flex flex-col h-full bg-white shadow-xl">
+        <div className="w-full max-w-2xl flex flex-col h-full shadow-xl">
           <div className="flex-1 overflow-y-auto pt-4 pb-4 px-4">
             <BookmarkList
               bookmarks={bookmarks}
@@ -67,7 +67,7 @@ function App() {
       </main>
 
       {selectedBookmark && (
-        <footer className="w-full flex justify-center bg-white border-t border-gray-200 shadow-[0_-4px_20px_-2px_rgba(0,0,0,0.1)] z-10">
+        <footer className="w-full flex justify-center border-t border-gray-200 shadow-[0_-4px_20px_-2px_rgba(0,0,0,0.1)] z-10">
           <div className="w-full max-w-2xl">
             <BookmarkDetail
               bookmark={selectedBookmark}


### PR DESCRIPTION
#### 概要
アプリケーション全体を画面高さいっぱいに使い、視覚的な一貫性を高めるためのレイアウト調整を行いました。

#### 変更内容
- **#root のパディング削除**: `src/App.css` にあった Vite デフォルトの `padding: 2rem` を削除し、Flexbox レイアウトが正しく画面全体にフィットするように修正。
- **背景色の統一**: `src/App.tsx` の最外層コンテナの背景色を `bg-gray-50` から `bg-white` に変更し、ブックマーク一覧との境目を目立たなくしました。

#### 影響範囲
- アプリケーション全体のレイアウト。