### PR TITLE
feat: Escape キーによるブックマーク選択の解除 (v0.6.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.6.2",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm run server:dev\" \"npm run client:dev\"",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -144,4 +144,28 @@ describe('App Integration', () => {
       screen.queryByDisplayValue(MOCK_BOOKMARK_1.title),
     ).not.toBeInTheDocument()
   })
+
+  it('Escape キーを押した際に詳細パネルが閉じること', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get(API_PATHS.BOOKMARKS, () => {
+        return HttpResponse.json({ bookmarks: [MOCK_BOOKMARK_1] })
+      }),
+    )
+
+    render(<App />, { wrapper })
+
+    // 選択してパネルを表示
+    const row = await screen.findByText(MOCK_BOOKMARK_1.title)
+    await user.click(row)
+    expect(screen.getByDisplayValue(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
+
+    // Escape キーで閉じる
+    await user.keyboard('{Escape}')
+
+    // パネルが消えたことを確認
+    expect(
+      screen.queryByDisplayValue(MOCK_BOOKMARK_1.title),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import type { BookmarkId } from '@shared/schemas/bookmark'
 function App() {
   const { data, isLoading, error } = useBookmarks()
   const { selectedId, handleRowClick, setSelectedId } = useBookmarkList()
-  const { updateBookmark, deleteBookmark, openBookmark } =
+  const { updateBookmark, deleteBookmark, openBookmark, closeDetail } =
     useBookmarkActions(setSelectedId)
 
   const bookmarks = data?.bookmarks ?? []
@@ -46,8 +46,8 @@ function App() {
   }, [selectedBookmark, openBookmark])
 
   const handleClose = useCallback(() => {
-    setSelectedId(null)
-  }, [setSelectedId])
+    closeDetail()
+  }, [closeDetail])
 
   return (
     <div className="flex flex-col h-full w-full bg-white overflow-hidden">
@@ -61,6 +61,7 @@ function App() {
               selectedId={selectedId}
               onRowClick={handleRowClick}
               onDoubleClick={handleDoubleClick}
+              onClose={handleClose}
             />
           </div>
         </div>

--- a/src/components/BookmarkDetail.test.tsx
+++ b/src/components/BookmarkDetail.test.tsx
@@ -75,6 +75,19 @@ describe('BookmarkDetail', () => {
     })
   })
 
+  it('Escape キーで onClose が呼ばれること', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<BookmarkDetail {...defaultProps} onClose={onClose} />)
+
+    // 入力欄にフォーカスを当ててから Escape キーを押す
+    const titleInput = screen.getByPlaceholderText('Bookmark Title')
+    await user.click(titleInput)
+    await user.keyboard('{Escape}')
+    
+    expect(onClose).toHaveBeenCalled()
+  })
+
   it('別のブックマークが選択された時に入力内容が更新されること', () => {
     const { rerender } = render(<BookmarkDetail {...defaultProps} />)
 

--- a/src/components/BookmarkDetail.tsx
+++ b/src/components/BookmarkDetail.tsx
@@ -36,7 +36,11 @@ export const BookmarkDetail: React.FC<BookmarkDetailProps> = ({
   }
 
   return (
-    <div className="bg-white p-2 w-full">
+    <div className="bg-white p-2 w-full" onKeyDown={(e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    }}>
       <div className="grid grid-cols-[1fr_auto] gap-4 items-stretch">
         {/* 左側: テキストボックスを2段で配置 */}
         <div className="grid grid-rows-2 gap-4">

--- a/src/components/BookmarkItem.test.tsx
+++ b/src/components/BookmarkItem.test.tsx
@@ -11,6 +11,7 @@ describe('BookmarkItem', () => {
     isFocusable: false,
     onRowClick: vi.fn(),
     onDoubleClick: vi.fn(),
+    onClose: vi.fn(),
   }
 
   it('ブックマークのタイトルが表示されること', () => {
@@ -100,6 +101,21 @@ describe('BookmarkItem', () => {
 
       await user.type(screen.getByRole('row'), ' ')
       expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
+    })
+
+    it('Escape キーで onClose が呼ばれること', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(
+        <table>
+          <tbody>
+            <BookmarkItem {...defaultProps} onClose={onClose} />
+          </tbody>
+        </table>,
+      )
+
+      await user.type(screen.getByRole('row'), '{escape}')
+      expect(onClose).toHaveBeenCalled()
     })
   })
 

--- a/src/components/BookmarkItem.tsx
+++ b/src/components/BookmarkItem.tsx
@@ -7,10 +7,18 @@ interface BookmarkItemProps {
   isFocusable: boolean
   onRowClick: (id: BookmarkId) => void
   onDoubleClick: (id: BookmarkId, url: string) => void
+  onClose: () => void
 }
 
 export const BookmarkItem: React.FC<BookmarkItemProps> = memo(
-  ({ bookmark, isSelected, isFocusable, onRowClick, onDoubleClick }) => {
+  ({
+    bookmark,
+    isSelected,
+    isFocusable,
+    onRowClick,
+    onDoubleClick,
+    onClose,
+  }) => {
     const trClassName = `transition-colors cursor-pointer hover:bg-blue-200 bg-blue-100 text-sm text-left text-gray-900 select-none`
     const tdClassName = `px-2 py-1 whitespace-nowrap border-b border-blue-700 ${
       isSelected ? 'font-bold' : ''
@@ -29,6 +37,8 @@ export const BookmarkItem: React.FC<BookmarkItemProps> = memo(
           } else if (e.key === ' ') {
             e.preventDefault()
             onRowClick(bookmark.id)
+          } else if (e.key === 'Escape') {
+            onClose()
           }
         }}
       >

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -21,6 +21,7 @@ describe('BookmarkList', () => {
     selectedId: null,
     onRowClick: vi.fn(),
     onDoubleClick: vi.fn(),
+    onClose: vi.fn(),
   }
 
   type TestCase = {

--- a/src/components/BookmarkList.tsx
+++ b/src/components/BookmarkList.tsx
@@ -9,6 +9,7 @@ export type BookmarkProps = {
   selectedId: BookmarkId | null
   onRowClick: (id: BookmarkId) => void
   onDoubleClick: (id: BookmarkId, url: string) => void
+  onClose: () => void
 }
 
 export const BookmarkList = ({
@@ -18,6 +19,7 @@ export const BookmarkList = ({
   selectedId,
   onRowClick,
   onDoubleClick,
+  onClose,
 }: BookmarkProps) => {
   if (isLoading) {
     return (
@@ -67,6 +69,7 @@ export const BookmarkList = ({
               }
               onRowClick={onRowClick}
               onDoubleClick={onDoubleClick}
+              onClose={onClose}
             />
           ))}
         </tbody>

--- a/src/hooks/useBookmarkActions.ts
+++ b/src/hooks/useBookmarkActions.ts
@@ -45,9 +45,17 @@ export const useBookmarkActions = (
     }
   }, [])
 
+  /**
+   * 詳細パネルを閉じる（選択を解除する）
+   */
+  const closeDetail = useCallback(() => {
+    setSelectedId(null)
+  }, [setSelectedId])
+
   return {
     updateBookmark,
     deleteBookmark,
     openBookmark,
+    closeDetail,
   }
 }


### PR DESCRIPTION
#### 概要
ブックマークが選択されている状態で Escape キーを押すと、選択が解除され詳細パネルが閉じるように改善しました。

#### 変更内容
- **操作性の向上**:
    - 一覧の項目にフォーカスがあるとき、および詳細パネルの入力欄にフォーカスがあるときに Escape キーを検知してパネルを閉じるように実装。
- **ロジックの整理**:
    - `useBookmarkActions` フックに `closeDetail` アクションを追加し、コンポーネントからの呼び出しを容易化。
- **テストの追加**:
    - `BookmarkItem`, `BookmarkDetail` の単体テスト、および `App` の統合テストを追加し、キーボード操作の正当性を検証。
- **管理**:
    - バージョンを `0.6.2` に更新。