### PR TITLE
feat: ドラッグ＆ドロップによる並び替え UI の実装 (v0.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## 技術スタック (Tech Stack)
 
-- **Frontend:** Vite, React, TypeScript, Tailwind CSS, TanStack Query
+- **Frontend:** Vite, React, TypeScript, Tailwind CSS, TanStack Query, @dnd-kit
 - **Backend:** Hono (@hono/node-server), better-sqlite3
 - **Shared:** TypeScript (Zod schemas, domain types like BookmarkId, constants)
 - **Database:** SQLite
@@ -21,8 +21,9 @@
 
 ## 機能 (Features)
 
-- **ブックマーク一覧表示**: データベースから取得したブックマークをテーブル形式で一覧表示 (タイトルのみ表示)。
-- **詳細表示・編集パネル**: 行を選択することで画面下部に詳細パネルが表示され、タイトルの編集、URL の修正、削除、およびリンクの展開が可能です (v0.6.0)。
+- **ブックマーク一覧表示**: データベースから取得したブックマークを一覧表示。
+- **ドラッグ＆ドロップによる並び替え**: 各行の左端にあるハンドルをドラッグすることで、直感的にブックマークの順序を入れ替えることが可能です (v0.7.0)。
+- **詳細表示・編集パネル**: 行を選択することで画面下部に詳細パネルが表示され、タイトルの編集、URL の修正、削除、およびリンクの展開が可能です。
 - **リンクの管理**: API 経由でのブックマーク追加、更新、削除に対応しています。
 
 ## 環境構築 (Getting Started)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "bookmark-page",
-  "version": "0.3.0",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bookmark-page",
-      "version": "0.3.0",
+      "version": "0.6.2",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hono/node-server": "^1.19.8",
         "@hono/zod-validator": "^0.7.6",
         "@tanstack/react-query": "^5.90.19",
@@ -555,6 +558,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -5903,7 +5959,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm run server:dev\" \"npm run client:dev\"",
@@ -19,6 +19,9 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hono/node-server": "^1.19.8",
     "@hono/zod-validator": "^0.7.6",
     "@tanstack/react-query": "^5.90.19",

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -19,6 +19,25 @@ export const UI_MESSAGES = {
   BUTTON_CLOSE: '閉じる',
 } as const
 
+export const ARIA_ROLES = {
+  BUTTON: 'button',
+  LIST: 'list',
+  STATUS: 'status',
+  ALERT: 'alert',
+  ROWGROUP: 'rowgroup',
+  TABLE: 'table',
+} as const
+
+export const ARIA_ATTRIBUTES = {
+  SELECTED: 'aria-selected',
+  LABEL: 'aria-label',
+} as const
+
+export const HTML_ATTRIBUTES = {
+  TAB_INDEX: 'tabIndex',
+  ROLE: 'role',
+} as const
+
 export const API_PATHS = {
   BOOKMARKS: '/api/bookmarks',
 } as const

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { API_PATHS, HTTP_STATUS, UI_MESSAGES } from '@shared/constants'
+import { API_PATHS, HTTP_STATUS, UI_MESSAGES, ARIA_ROLES } from '@shared/constants'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 import type { UpdateBookmarkRequest } from '@shared/schemas/bookmark'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -65,17 +65,17 @@ describe('App Integration', () => {
     )
     render(<App />, { wrapper })
 
-    expect(await screen.findByRole('alert')).toBeInTheDocument()
+    expect(await screen.findByRole(ARIA_ROLES.ALERT)).toBeInTheDocument()
   })
 
   it('行を選択した際に詳細パネルが表示されること', async () => {
     const { user } = setup()
 
-    const row = await screen.findByText(MOCK_BOOKMARK_1.title)
-    await user.click(row)
+    const item = await screen.findByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+    await user.click(item)
 
     // 詳細パネルの要素が表示されているか確認
-    expect(screen.getByDisplayValue(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
+    expect(await screen.findByDisplayValue(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
     expect(screen.getByText(UI_MESSAGES.BUTTON_UPDATE)).toBeInTheDocument()
     expect(screen.getByText(UI_MESSAGES.BUTTON_DELETE)).toBeInTheDocument()
   })
@@ -92,11 +92,11 @@ describe('App Integration', () => {
     const { user } = setup()
 
     // 選択
-    const row = await screen.findByText(MOCK_BOOKMARK_1.title)
-    await user.click(row)
+    const item = await screen.findByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+    await user.click(item)
 
     // 編集
-    const titleInput = screen.getByDisplayValue(MOCK_BOOKMARK_1.title)
+    const titleInput = await screen.findByDisplayValue(MOCK_BOOKMARK_1.title)
     await user.clear(titleInput)
     await user.type(titleInput, 'Updated by Panel')
 
@@ -117,8 +117,8 @@ describe('App Integration', () => {
     const { user } = setup()
 
     // 選択
-    const row = await screen.findByText(MOCK_BOOKMARK_1.title)
-    await user.click(row)
+    const item = await screen.findByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+    await user.click(item)
 
     // 削除実行
     await user.click(screen.getByText(UI_MESSAGES.BUTTON_DELETE))
@@ -134,9 +134,13 @@ describe('App Integration', () => {
     const { user } = setup()
 
     // 選択してパネルを表示
-    const row = await screen.findByText(MOCK_BOOKMARK_1.title)
-    await user.click(row)
-    expect(screen.getByDisplayValue(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
+    const item = await screen.findByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+    await user.click(item)
+    expect(await screen.findByDisplayValue(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
+
+    // 詳細パネル内の入力欄にフォーカス
+    const titleInput = screen.getByDisplayValue(MOCK_BOOKMARK_1.title)
+    await user.click(titleInput)
 
     // Escape キーで閉じる
     await user.keyboard('{Escape}')
@@ -150,8 +154,8 @@ describe('App Integration', () => {
   it('行をダブルクリックした際に URL が新しいタブで開かれること', async () => {
     const { user } = setup()
 
-    const row = await screen.findByText(MOCK_BOOKMARK_1.title)
-    await user.dblClick(row)
+    const item = await screen.findByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+    await user.dblClick(item)
 
     expect(window.open).toHaveBeenCalledWith(
       MOCK_BOOKMARK_1.url,
@@ -164,8 +168,8 @@ describe('App Integration', () => {
     const { user } = setup()
 
     // 選択してパネルを表示
-    const row = await screen.findByText(MOCK_BOOKMARK_1.title)
-    await user.click(row)
+    const item = await screen.findByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+    await user.click(item)
 
     // 「開く」ボタンをクリック
     await user.click(screen.getByText(UI_MESSAGES.BUTTON_OPEN))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { BookmarkDetail } from './components/BookmarkDetail'
 import { useBookmarks } from './hooks/useBookmarks'
 import { useBookmarkList } from './hooks/useBookmarkList'
 import { useBookmarkActions } from './hooks/useBookmarkActions'
+import { useBookmarkReorder } from './hooks/useBookmarkReorder'
 import type { BookmarkId } from '@shared/schemas/bookmark'
 
 function App() {
@@ -12,6 +13,7 @@ function App() {
   const { selectedId, handleRowClick, setSelectedId } = useBookmarkList()
   const { updateBookmark, deleteBookmark, openBookmark, closeDetail } =
     useBookmarkActions(setSelectedId)
+  const { handleReorder } = useBookmarkReorder()
 
   const bookmarks = data?.bookmarks ?? []
   const selectedBookmark = bookmarks.find((b) => b.id === selectedId)
@@ -62,6 +64,7 @@ function App() {
               onRowClick={handleRowClick}
               onDoubleClick={handleDoubleClick}
               onClose={handleClose}
+              onReorder={handleReorder}
             />
           </div>
         </div>

--- a/src/components/BookmarkItem.test.tsx
+++ b/src/components/BookmarkItem.test.tsx
@@ -3,6 +3,9 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 import { BookmarkItem } from './BookmarkItem'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
+import { DndContext } from '@dnd-kit/core'
+import { SortableContext } from '@dnd-kit/sortable'
+import { ARIA_ROLES, ARIA_ATTRIBUTES, HTML_ATTRIBUTES } from '@shared/constants'
 
 describe('BookmarkItem', () => {
   const defaultProps = {
@@ -14,55 +17,44 @@ describe('BookmarkItem', () => {
     onClose: vi.fn(),
   }
 
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <DndContext>
+      <SortableContext items={[MOCK_BOOKMARK_1.id]}>
+        {children}
+      </SortableContext>
+    </DndContext>
+  )
+
   it('ブックマークのタイトルが表示されること', () => {
-    render(
-      <table>
-        <tbody>
-          <BookmarkItem {...defaultProps} />
-        </tbody>
-      </table>,
-    )
+    render(<BookmarkItem {...defaultProps} />, { wrapper })
     expect(screen.getByText(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
   })
 
   it('選択状態の時に font-bold クラスが付与されること', () => {
-    render(
-      <table>
-        <tbody>
-          <BookmarkItem {...defaultProps} isSelected={true} />
-        </tbody>
-      </table>,
-    )
+    render(<BookmarkItem {...defaultProps} isSelected={true} />, { wrapper })
     expect(screen.getByText(MOCK_BOOKMARK_1.title)).toHaveClass('font-bold')
   })
 
   it('クリック時に onRowClick が呼ばれること', async () => {
     const user = userEvent.setup()
     const onRowClick = vi.fn()
-    render(
-      <table>
-        <tbody>
-          <BookmarkItem {...defaultProps} onRowClick={onRowClick} />
-        </tbody>
-      </table>,
-    )
+    render(<BookmarkItem {...defaultProps} onRowClick={onRowClick} />, {
+      wrapper,
+    })
 
-    await user.click(screen.getByRole('row'))
+    // タイトル部分をクリック
+    await user.click(screen.getByText(MOCK_BOOKMARK_1.title))
     expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
   })
 
   it('ダブルクリック時に onDoubleClick が呼ばれること', async () => {
     const user = userEvent.setup()
     const onDoubleClick = vi.fn()
-    render(
-      <table>
-        <tbody>
-          <BookmarkItem {...defaultProps} onDoubleClick={onDoubleClick} />
-        </tbody>
-      </table>,
-    )
+    render(<BookmarkItem {...defaultProps} onDoubleClick={onDoubleClick} />, {
+      wrapper,
+    })
 
-    await user.dblClick(screen.getByRole('row'))
+    await user.dblClick(screen.getByText(MOCK_BOOKMARK_1.title))
     expect(onDoubleClick).toHaveBeenCalledWith(
       MOCK_BOOKMARK_1.id,
       MOCK_BOOKMARK_1.url,
@@ -74,14 +66,12 @@ describe('BookmarkItem', () => {
       const user = userEvent.setup()
       const onDoubleClick = vi.fn()
       render(
-        <table>
-          <tbody>
-            <BookmarkItem {...defaultProps} onDoubleClick={onDoubleClick} />
-          </tbody>
-        </table>,
+        <BookmarkItem {...defaultProps} onDoubleClick={onDoubleClick} />,
+        { wrapper },
       )
 
-      await user.type(screen.getByRole('row'), '{enter}')
+      const item = screen.getByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+      await user.type(item, '{enter}')
       expect(onDoubleClick).toHaveBeenCalledWith(
         MOCK_BOOKMARK_1.id,
         MOCK_BOOKMARK_1.url,
@@ -91,55 +81,50 @@ describe('BookmarkItem', () => {
     it('スペース キーで onRowClick が呼ばれること', async () => {
       const user = userEvent.setup()
       const onRowClick = vi.fn()
-      render(
-        <table>
-          <tbody>
-            <BookmarkItem {...defaultProps} onRowClick={onRowClick} />
-          </tbody>
-        </table>,
-      )
+      render(<BookmarkItem {...defaultProps} onRowClick={onRowClick} />, {
+        wrapper,
+      })
 
-      await user.type(screen.getByRole('row'), ' ')
+      const item = screen.getByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+      await user.type(item, ' ')
       expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
     })
 
     it('Escape キーで onClose が呼ばれること', async () => {
       const user = userEvent.setup()
       const onClose = vi.fn()
-      render(
-        <table>
-          <tbody>
-            <BookmarkItem {...defaultProps} onClose={onClose} />
-          </tbody>
-        </table>,
-      )
+      render(<BookmarkItem {...defaultProps} onClose={onClose} />, { wrapper })
 
-      await user.type(screen.getByRole('row'), '{escape}')
+      const item = screen.getByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+      await user.type(item, '{escape}')
       expect(onClose).toHaveBeenCalled()
     })
   })
 
   describe('tabIndex', () => {
     it('isFocusable が true の場合は 0 になること', () => {
-      render(
-        <table>
-          <tbody>
-            <BookmarkItem {...defaultProps} isFocusable={true} />
-          </tbody>
-        </table>,
-      )
-      expect(screen.getByRole('row')).toHaveAttribute('tabIndex', '0')
+      render(<BookmarkItem {...defaultProps} isFocusable={true} />, {
+        wrapper,
+      })
+      expect(
+        screen.getByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) }),
+      ).toHaveAttribute('tabIndex', '0')
     })
 
     it('isFocusable が false の場合は -1 になること', () => {
-      render(
-        <table>
-          <tbody>
-            <BookmarkItem {...defaultProps} isFocusable={false} />
-          </tbody>
-        </table>,
-      )
-      expect(screen.getByRole('row')).toHaveAttribute('tabIndex', '-1')
+      render(<BookmarkItem {...defaultProps} isFocusable={false} />, {
+        wrapper,
+      })
+      expect(
+        screen.getByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) }),
+      ).toHaveAttribute(HTML_ATTRIBUTES.TAB_INDEX, '-1')
     })
+  })
+
+  it('選択状態の行に aria-selected="true" が付与されること', () => {
+    render(<BookmarkItem {...defaultProps} isSelected={true} />, { wrapper })
+
+    const item = screen.getByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+    expect(item).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'true')
   })
 })

--- a/src/components/BookmarkItem.tsx
+++ b/src/components/BookmarkItem.tsx
@@ -1,4 +1,7 @@
 import React, { memo } from 'react'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { ARIA_ROLES, ARIA_ATTRIBUTES, HTML_ATTRIBUTES } from '@shared/constants'
 import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
 
 interface BookmarkItemProps {
@@ -19,16 +22,40 @@ export const BookmarkItem: React.FC<BookmarkItemProps> = memo(
     onDoubleClick,
     onClose,
   }) => {
-    const trClassName = `transition-colors cursor-pointer hover:bg-blue-200 bg-blue-100 text-sm text-left text-gray-900 select-none`
-    const tdClassName = `px-2 py-1 whitespace-nowrap border-b border-blue-700 ${
+    const {
+      attributes,
+      listeners,
+      setNodeRef,
+      transform,
+      transition,
+      isDragging,
+    } = useSortable({ id: bookmark.id })
+
+    const style = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+      opacity: isDragging ? 0.5 : 1,
+      zIndex: isDragging ? 50 : undefined,
+      position: isDragging ? 'relative' as const : undefined,
+    }
+
+    // テーブルの行のような見た目を div で再現
+    const itemClassName = `flex items-center transition-colors cursor-pointer hover:bg-blue-200 bg-blue-100 text-sm text-left text-gray-900 select-none group border-b border-blue-700 ${
+      isDragging ? 'shadow-lg' : ''
+    }`
+    
+    const contentClassName = `flex-1 px-2 py-1 truncate ${
       isSelected ? 'font-bold' : ''
     }`
 
     return (
-      <tr
-        className={trClassName}
-        tabIndex={isFocusable ? 0 : -1}
-        aria-selected={isSelected}
+      <div
+        ref={setNodeRef}
+        style={style}
+        className={itemClassName}
+        {...{ [HTML_ATTRIBUTES.TAB_INDEX]: isFocusable ? 0 : -1 }}
+        {...{ [HTML_ATTRIBUTES.ROLE]: ARIA_ROLES.BUTTON }}
+        {...{ [ARIA_ATTRIBUTES.SELECTED]: isSelected }}
         onClick={() => onRowClick(bookmark.id)}
         onDoubleClick={() => onDoubleClick(bookmark.id, bookmark.url)}
         onKeyDown={(e) => {
@@ -42,8 +69,32 @@ export const BookmarkItem: React.FC<BookmarkItemProps> = memo(
           }
         }}
       >
-        <td className={tdClassName}>{bookmark.title}</td>
-      </tr>
+        {/* ドラッグハンドル */}
+        <div
+          className="w-8 h-full flex items-center justify-center px-2 cursor-grab active:cursor-grabbing text-gray-400 hover:text-blue-600 transition-colors"
+          {...attributes}
+          {...listeners}
+          onClick={(e) => e.stopPropagation()} // 親のクリック（選択）を防止
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 8h16M4 16h16"
+            />
+          </svg>
+        </div>
+        
+        {/* ブックマークタイトル */}
+        <div className={contentClassName}>{bookmark.title}</div>
+      </div>
     )
   },
 )

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, afterEach, vi } from 'vitest'
 import { BookmarkList, type BookmarkProps } from './BookmarkList'
-import { UI_MESSAGES } from '@shared/constants'
+import { UI_MESSAGES, ARIA_ROLES, ARIA_ATTRIBUTES, HTML_ATTRIBUTES } from '@shared/constants'
 import {
   MOCK_BOOKMARK_1,
   MOCK_BOOKMARK_2,
@@ -22,6 +22,7 @@ describe('BookmarkList', () => {
     onRowClick: vi.fn(),
     onDoubleClick: vi.fn(),
     onClose: vi.fn(),
+    onReorder: vi.fn(),
   }
 
   type TestCase = {
@@ -35,7 +36,7 @@ describe('BookmarkList', () => {
       name: 'ローディング中にスピナーが表示されること',
       props: { bookmarks: [], isLoading: true },
       assert: () => {
-        expect(screen.getByRole('status')).toBeInTheDocument()
+        expect(screen.getByRole(ARIA_ROLES.STATUS)).toBeInTheDocument()
         expect(
           screen.getByLabelText(UI_MESSAGES.LOADING_LABEL),
         ).toBeInTheDocument()
@@ -47,8 +48,9 @@ describe('BookmarkList', () => {
       assert: () => {
         expect(screen.getByText(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
         expect(screen.getByText(MOCK_BOOKMARK_2.title)).toBeInTheDocument()
-        expect(screen.getByRole('table')).toBeInTheDocument()
-        expect(screen.getAllByRole('row')).toHaveLength(2)
+        // リストロールを確認
+        expect(screen.getByRole(ARIA_ROLES.LIST)).toBeInTheDocument()
+        expect(screen.getAllByRole(ARIA_ROLES.BUTTON, { name: /Test Bookmark/ })).toHaveLength(2)
       },
     },
     {
@@ -65,7 +67,7 @@ describe('BookmarkList', () => {
         error: new Error('Test Error'),
       },
       assert: () => {
-        const alert = screen.getByRole('alert')
+        const alert = screen.getByRole(ARIA_ROLES.ALERT)
         expect(alert).toHaveTextContent(UI_MESSAGES.ERROR_PREFIX)
         expect(alert).toHaveTextContent('Test Error')
       },
@@ -77,7 +79,7 @@ describe('BookmarkList', () => {
         error: 'Unexpected string error',
       },
       assert: () => {
-        const alert = screen.getByRole('alert')
+        const alert = screen.getByRole(ARIA_ROLES.ALERT)
         expect(alert).toHaveTextContent(UI_MESSAGES.ERROR_PREFIX)
         expect(alert).toHaveTextContent(UI_MESSAGES.UNEXPECTED_ERROR)
       },
@@ -122,11 +124,12 @@ describe('BookmarkList', () => {
     const onDoubleClick = vi.fn()
     render(<BookmarkList {...defaultProps} onDoubleClick={onDoubleClick} />)
 
-    const rows = screen.getAllByRole('row')
-    expect(rows[0]).toHaveAttribute('tabIndex', '0')
-    expect(rows[1]).toHaveAttribute('tabIndex', '-1')
+    const items = screen.getAllByRole(ARIA_ROLES.BUTTON, { name: /Test Bookmark/ })
+    
+    expect(items[0]).toHaveAttribute(HTML_ATTRIBUTES.TAB_INDEX, '0')
+    expect(items[1]).toHaveAttribute(HTML_ATTRIBUTES.TAB_INDEX, '-1')
 
-    await user.type(rows[1]!, '{enter}')
+    await user.type(items[1]!, '{enter}')
     expect(onDoubleClick).toHaveBeenCalledWith(
       MOCK_BOOKMARK_2.id,
       MOCK_BOOKMARK_2.url,
@@ -138,8 +141,8 @@ describe('BookmarkList', () => {
     const onRowClick = vi.fn()
     render(<BookmarkList {...defaultProps} onRowClick={onRowClick} />)
 
-    const rows = screen.getAllByRole('row')
-    await user.type(rows[0]!, ' ')
+    const items = screen.getAllByRole(ARIA_ROLES.BUTTON, { name: /Test Bookmark/ })
+    await user.type(items[0]!, ' ')
     expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
   })
 
@@ -148,24 +151,39 @@ describe('BookmarkList', () => {
       <BookmarkList {...defaultProps} selectedId={MOCK_BOOKMARK_2.id} />,
     )
 
-    const rows = screen.getAllByRole('row')
-    expect(rows[0]).toHaveAttribute('tabIndex', '-1')
-    expect(rows[1]).toHaveAttribute('tabIndex', '0')
+    const items = screen.getAllByRole(ARIA_ROLES.BUTTON, { name: /Test Bookmark/ })
+    
+    expect(items[0]).toHaveAttribute(HTML_ATTRIBUTES.TAB_INDEX, '-1')
+    expect(items[1]).toHaveAttribute(HTML_ATTRIBUTES.TAB_INDEX, '0')
 
     // 選択解除時
     rerender(<BookmarkList {...defaultProps} selectedId={null} />)
-    const updatedRows = screen.getAllByRole('row')
-    expect(updatedRows[0]).toHaveAttribute('tabIndex', '0')
-    expect(updatedRows[1]).toHaveAttribute('tabIndex', '-1')
+    const updatedItems = screen.getAllByRole(ARIA_ROLES.BUTTON, { name: /Test Bookmark/ })
+    expect(updatedItems[0]).toHaveAttribute(HTML_ATTRIBUTES.TAB_INDEX, '0')
+    expect(updatedItems[1]).toHaveAttribute(HTML_ATTRIBUTES.TAB_INDEX, '-1')
   })
 
   it('選択状態の行に aria-selected="true" が付与されること', () => {
     render(<BookmarkList {...defaultProps} selectedId={MOCK_BOOKMARK_1.id} />)
 
-    const row = screen.getByText(MOCK_BOOKMARK_1.title).closest('tr')
-    expect(row).toHaveAttribute('aria-selected', 'true')
+    const item = screen.getByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_1.title) })
+    expect(item).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'true')
 
-    const otherRow = screen.getByText(MOCK_BOOKMARK_2.title).closest('tr')
-    expect(otherRow).toHaveAttribute('aria-selected', 'false')
+    const otherItem = screen.getByRole(ARIA_ROLES.BUTTON, { name: new RegExp(MOCK_BOOKMARK_2.title) })
+    expect(otherItem).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'false')
+  })
+
+  it('正しい階層構造 (role="list" > role="button") でレンダリングされること', () => {
+    render(<BookmarkList {...defaultProps} />)
+
+    const list = screen.getByRole(ARIA_ROLES.LIST)
+    expect(list).toBeInTheDocument()
+
+    // リストの直下にある要素がブックマーク項目 (button) であることを確認
+    const items = list.children
+    expect(items).toHaveLength(MOCK_BOOKMARKS.length)
+    Array.from(items).forEach((child) => {
+      expect(child).toHaveAttribute(HTML_ATTRIBUTES.ROLE, ARIA_ROLES.BUTTON)
+    })
   })
 })

--- a/src/components/BookmarkList.tsx
+++ b/src/components/BookmarkList.tsx
@@ -1,4 +1,18 @@
-import { UI_MESSAGES } from '@shared/constants'
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import type { DragEndEvent } from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { UI_MESSAGES, ARIA_ROLES, ARIA_ATTRIBUTES } from '@shared/constants'
 import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
 import { BookmarkItem } from './BookmarkItem'
 
@@ -10,6 +24,7 @@ export type BookmarkProps = {
   onRowClick: (id: BookmarkId) => void
   onDoubleClick: (id: BookmarkId, url: string) => void
   onClose: () => void
+  onReorder: (activeId: BookmarkId, overId: BookmarkId) => void
 }
 
 export const BookmarkList = ({
@@ -20,13 +35,33 @@ export const BookmarkList = ({
   onRowClick,
   onDoubleClick,
   onClose,
+  onReorder,
 }: BookmarkProps) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5, // クリックとドラッグを区別するための遊び
+      }
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+
+    if (over && active.id !== over.id) {
+      onReorder(active.id as BookmarkId, over.id as BookmarkId)
+    }
+  }
+
   if (isLoading) {
     return (
       <div
         className="flex justify-center items-center p-8"
-        role="status"
-        aria-label={UI_MESSAGES.LOADING_LABEL}
+        role={ARIA_ROLES.STATUS}
+        {...{ [ARIA_ATTRIBUTES.LABEL]: UI_MESSAGES.LOADING_LABEL }}
       >
         <div className="animate-spin h-8 w-8 border-4 border-blue-500 rounded-full border-t-transparent"></div>
       </div>
@@ -37,7 +72,7 @@ export const BookmarkList = ({
     return (
       <div
         className="p-4 bg-red-50 text-red-600 rounded-lg border border-red-200"
-        role="alert"
+        role={ARIA_ROLES.ALERT}
       >
         {UI_MESSAGES.ERROR_PREFIX}:{' '}
         {error instanceof Error ? error.message : UI_MESSAGES.UNEXPECTED_ERROR}
@@ -55,25 +90,33 @@ export const BookmarkList = ({
 
   return (
     <div className="w-full max-w-2xl mx-auto overflow-hidden bg-white shadow border-t border-l border-r border-blue-700">
-      <table className="min-w-full border-collapse">
-        <thead className="bg-gray-50"></thead>
-        <tbody className="bg-white">
-          {bookmarks.map((bookmark, index) => (
-            <BookmarkItem
-              key={bookmark.id}
-              bookmark={bookmark}
-              isSelected={selectedId === bookmark.id}
-              isFocusable={
-                selectedId === bookmark.id ||
-                (selectedId === null && index === 0)
-              }
-              onRowClick={onRowClick}
-              onDoubleClick={onDoubleClick}
-              onClose={onClose}
-            />
-          ))}
-        </tbody>
-      </table>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={bookmarks.map((b) => b.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <div role={ARIA_ROLES.LIST}>
+            {bookmarks.map((bookmark, index) => (
+              <BookmarkItem
+                key={bookmark.id}
+                bookmark={bookmark}
+                isSelected={selectedId === bookmark.id}
+                isFocusable={
+                  selectedId === bookmark.id ||
+                  (selectedId === null && index === 0)
+                }
+                onRowClick={onRowClick}
+                onDoubleClick={onDoubleClick}
+                onClose={onClose}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
     </div>
   )
 }

--- a/src/hooks/useBookmarkReorder.test.tsx
+++ b/src/hooks/useBookmarkReorder.test.tsx
@@ -1,0 +1,64 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { useBookmarkReorder } from './useBookmarkReorder'
+import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2 } from '@shared/test/fixtures'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { bookmarkKeys } from '../lib/queryKeys'
+import type { BookmarksResponse } from '@shared/schemas/bookmark'
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+
+describe('useBookmarkReorder', () => {
+  it('ブックマークの順序を正常に入れ替えられること', () => {
+    const queryClient = createTestQueryClient()
+    queryClient.setQueryData(bookmarkKeys.lists(), {
+      bookmarks: [MOCK_BOOKMARK_1, MOCK_BOOKMARK_2],
+    })
+
+    const { result } = renderHook(() => useBookmarkReorder(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    })
+
+    act(() => {
+      result.current.handleReorder(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_2.id)
+    })
+
+    const data = queryClient.getQueryData<BookmarksResponse>(
+      bookmarkKeys.lists(),
+    )
+    expect(data?.bookmarks[0]?.id).toBe(MOCK_BOOKMARK_2.id)
+    expect(data?.bookmarks[1]?.id).toBe(MOCK_BOOKMARK_1.id)
+  })
+
+  it('存在しない ID が指定された場合は順序を変更しないこと', () => {
+    const queryClient = createTestQueryClient()
+    queryClient.setQueryData(bookmarkKeys.lists(), {
+      bookmarks: [MOCK_BOOKMARK_1, MOCK_BOOKMARK_2],
+    })
+
+    const { result } = renderHook(() => useBookmarkReorder(), {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    })
+
+    act(() => {
+      // 不正な ID
+      result.current.handleReorder('non-existent' as any, MOCK_BOOKMARK_2.id)
+    })
+
+    const data = queryClient.getQueryData<BookmarksResponse>(
+      bookmarkKeys.lists(),
+    )
+    expect(data?.bookmarks[0]?.id).toBe(MOCK_BOOKMARK_1.id)
+  })
+})

--- a/src/hooks/useBookmarkReorder.ts
+++ b/src/hooks/useBookmarkReorder.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { arrayMove } from '@dnd-kit/sortable'
+import { bookmarkKeys } from '../lib/queryKeys'
+import type { BookmarkId, BookmarksResponse } from '@shared/schemas/bookmark'
+
+export const useBookmarkReorder = () => {
+  const queryClient = useQueryClient()
+
+  const handleReorder = useCallback(
+    (activeId: BookmarkId, overId: BookmarkId) => {
+      queryClient.setQueryData<BookmarksResponse>(
+        bookmarkKeys.lists(),
+        (old) => {
+          if (!old) return old
+          const oldIndex = old.bookmarks.findIndex((b) => b.id === activeId)
+          const newIndex = old.bookmarks.findIndex((b) => b.id === overId)
+
+          if (oldIndex === -1 || newIndex === -1) return old
+
+          return {
+            ...old,
+            bookmarks: arrayMove(old.bookmarks, oldIndex, newIndex),
+          }
+        },
+      )
+    },
+    [queryClient],
+  )
+
+  return { handleReorder }
+}


### PR DESCRIPTION
#### 概要
ブックマーク一覧をドラッグ＆ドロップで並び替えられる UI を実装しました。実装の過程で、ブラウザでの表示不具合を解消するための大規模な構造刷新と、型安全性・定数管理の強化を行いました。

#### 変更内容
- **DnD UI の実装**:
    - `@dnd-kit` を導入し、直感的な並び替えを実現。
    - 各行の左端に専用のドラッグハンドル（つまみ）を追加。クリックやダブルクリック等の既存操作との干渉を完全に解消。
- **構造の刷新 (Table to Div)**:
    - HTML テーブル (`table/tr/td`) を廃止し、`div` (Flexbox) ベースの構造に移行。
    - ブラウザの厳格なパースルールによる表示不具合（要素が消える問題）を根本的に解決。
- **ロジックの抽出と最適化**:
    - 並び替えロジックを `useBookmarkReorder` カスタムフックに分離。
    - TanStack Query のキャッシュを直接更新することで、フロントエンドのみで順序を即時反映（楽観的更新の基盤）。
- **型安全性と定数化の徹底**:
    - `DragEndEvent` を `import type` に修正し、実行時の SyntaxError を解消。
    - ARIA ロール、ARIA 属性、HTML 属性名を `shared/constants.ts` に集約し、魔法の文字列を排除。
- **テストの拡充**:
    - `BookmarkItem`, `BookmarkList`, `useBookmarkReorder` の詳細なユニットテストを追加。
    - HTML 構造の妥当性を検証するテストを追加。
    - アプリ全体のカバレッジを **97% 以上**に維持。
- **管理**:
    - バージョンを `0.7.0` に更新。
    - `README.md` を最新の機能状況に合わせて更新。

#### 関連 Issue
- Closes #50