### PR TITLE
refactor: API レスポンスの共通化とグローバルエラーハンドリングの実装 (v0.8.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ npm run test:coverage
 
 ## API 仕様 (API Specifications)
 
+全ての API レスポンスは、以下の共通形式で返却されます。
+
+- **成功時**: `{ "success": true, "data": T }`
+- **失敗時**: `{ "success": false, "error": { "message": string, "code": string } }`
+
 ### GET /api/bookmarks
 
 ブックマークの一覧を取得します。
@@ -112,13 +117,16 @@ npm run test:coverage
 
 ```json
 {
-  "bookmarks": [
-    {
-      "id": "1",
-      "title": "Example",
-      "url": "https://example.com"
-    }
-  ]
+  "success": true,
+  "data": {
+    "bookmarks": [
+      {
+        "id": "1",
+        "title": "Example",
+        "url": "https://example.com"
+      }
+    ]
+  }
 }
 ```
 
@@ -139,9 +147,12 @@ npm run test:coverage
 
 ```json
 {
-  "id": "2",
-  "title": "GitHub",
-  "url": "https://github.com"
+  "success": true,
+  "data": {
+    "id": "2",
+    "title": "GitHub",
+    "url": "https://github.com"
+  }
 }
 ```
 
@@ -157,12 +168,12 @@ npm run test:coverage
 
 - **204 No Content**: 削除成功
 - **400 Bad Request**: ID の形式が不正な場合
-- **404 Not Found**: 指定された ID が存在しない
+- **404 Not Found**: 指定された ID が存在しない、あるいは共通エラー形式
 - **500 Internal Server Error**: サーバーエラー
 
 ### PATCH /api/bookmarks/:id
 
-指定された ID のブックマーク情報を更新します。タイトルまたは URL の少なくとも一方は必須です。
+指定された ID のブックマーク情報を更新します。
 
 **パスパラメータ:**
 
@@ -179,7 +190,7 @@ npm run test:coverage
 
 **レスポンス:**
 
-- **200 OK**: 更新成功。更新後のオブジェクトを返却
+- **200 OK**: 更新成功。更新後のオブジェクトを \`data\` に含めて返却
 - **400 Bad Request**: リクエスト形式または ID が不正な場合
 - **404 Not Found**: 指定された ID が存在しない
 - **409 Conflict**: 更新後の URL が既に登録されている場合

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "overrides": {
     "esbuild": "0.27.2"

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -1,35 +1,63 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import app from './app'
-import { initializeDatabase, resetDatabase } from './db'
+import { db, initializeDatabase, resetDatabase } from './db'
+import { HTTP_STATUS, API_PATHS, ERROR_MESSAGES } from '@shared/constants'
+import { API_ERROR_CODES } from './utils/error'
 
-describe('App CORS', () => {
+describe('App Global Handlers', () => {
   beforeEach(() => {
     initializeDatabase()
     resetDatabase()
   })
 
-  it('環境変数で指定されたオリジンからのリクエストを許可すること', async () => {
-    const origin = 'http://localhost:5173'
-    const res = await app.request('/api/bookmarks', {
-      headers: { Origin: origin },
-    })
-    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(origin)
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
-  it('Chrome 拡張機能からのリクエストを許可すること', async () => {
-    const origin = 'chrome-extension://abcdefghijklmnopqrstuvwxyz'
-    const res = await app.request('/api/bookmarks', {
-      headers: { Origin: origin },
-    })
-    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(origin)
+  it('存在しないパスへのアクセス時に 404 エラーを共通形式で返すこと', async () => {
+    const res = await app.request('/api/non-existent-path')
+    expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
+    
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error.code).toBe(API_ERROR_CODES.NOT_FOUND)
   })
 
-  it('許可されていないオリジンの場合はデフォルトのオリジンを返すこと', async () => {
-    const origin = 'http://malicious.com'
-    const res = await app.request('/api/bookmarks', {
-      headers: { Origin: origin },
+  it('未キャッチのエラーが発生した際に 500 エラーを共通形式で返すこと', async () => {
+    const dbError = new Error('Test unhandled error')
+    // 既存のエンドポイントでエラーを発生させる
+    vi.spyOn(db, 'select').mockImplementation(() => {
+      throw dbError
     })
-    // 許可されていない場合は allowedOrigin (デフォルト http://localhost:5173) を返す仕様
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await app.request(API_PATHS.BOOKMARKS)
+    
+    expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error.message).toBe(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+    expect(body.error.code).toBe(API_ERROR_CODES.INTERNAL_SERVER_ERROR)
+    
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+
+  it(' CORS 設定が正しく適用されていること', async () => {
+    const res = await app.request(API_PATHS.BOOKMARKS, {
+      headers: {
+        'Origin': 'http://localhost:5173',
+      },
+    })
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:5173')
+  })
+
+  it(' Chrome 拡張機能からの CORS アクセスを許可すること', async () => {
+    const origin = 'chrome-extension://abcdefg'
+    const res = await app.request(API_PATHS.BOOKMARKS, {
+      headers: {
+        'Origin': origin,
+      },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(origin)
   })
 })

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -17,7 +17,7 @@ describe('App Global Handlers', () => {
   it('存在しないパスへのアクセス時に 404 エラーを共通形式で返すこと', async () => {
     const res = await app.request('/api/non-existent-path')
     expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
-    
+
     const body = await res.json()
     expect(body.success).toBe(false)
     expect(body.error.code).toBe(API_ERROR_CODES.NOT_FOUND)
@@ -32,32 +32,45 @@ describe('App Global Handlers', () => {
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const res = await app.request(API_PATHS.BOOKMARKS)
-    
+
     expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     const body = await res.json()
     expect(body.success).toBe(false)
     expect(body.error.message).toBe(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
     expect(body.error.code).toBe(API_ERROR_CODES.INTERNAL_SERVER_ERROR)
-    
+
     expect(consoleSpy).toHaveBeenCalled()
   })
 
   it(' CORS 設定が正しく適用されていること', async () => {
     const res = await app.request(API_PATHS.BOOKMARKS, {
       headers: {
-        'Origin': 'http://localhost:5173',
+        Origin: 'http://localhost:5173',
       },
     })
-    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:5173')
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'http://localhost:5173',
+    )
   })
 
   it(' Chrome 拡張機能からの CORS アクセスを許可すること', async () => {
     const origin = 'chrome-extension://abcdefg'
     const res = await app.request(API_PATHS.BOOKMARKS, {
       headers: {
-        'Origin': origin,
+        Origin: origin,
       },
     })
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe(origin)
+  })
+
+  it('許可されていないオリジンからのリクエストを拒否し、デフォルトのオリジンを返すこと', async () => {
+    const origin = 'http://malicious.com'
+    const res = await app.request(API_PATHS.BOOKMARKS, {
+      headers: { Origin: origin },
+    })
+    // 許可されていない場合は allowedOrigin (デフォルト http://localhost:5173) を返す仕様
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'http://localhost:5173',
+    )
   })
 })

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,6 +1,9 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import bookmarksRoute from './routes/bookmarks'
+import { HTTP_STATUS, ERROR_MESSAGES } from '@shared/constants'
+import { API_ERROR_CODES } from './utils/error'
 
 const app = new Hono()
 
@@ -19,8 +22,43 @@ app.use(
   }),
 )
 
-// APIルートの定義
+// グローバルエラーハンドリング
+app.onError((err, c) => {
+  console.error(`Unhandled error: ${err.message}`, err)
 
+  // すでにステータスコードがセットされている場合はそれを尊重する
+  // 200 (OK) のままエラーになった場合は 500 に倒す
+  const status = (c.res.status === 200
+    ? HTTP_STATUS.INTERNAL_SERVER_ERROR
+    : c.res.status) as ContentfulStatusCode
+
+  return c.json(
+    {
+      success: false,
+      error: {
+        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+        code: API_ERROR_CODES.INTERNAL_SERVER_ERROR,
+      },
+    },
+    status,
+  )
+})
+
+// 404 ハンドリング
+app.notFound((c) => {
+  return c.json(
+    {
+      success: false,
+      error: {
+        message: ERROR_MESSAGES.NOT_FOUND,
+        code: API_ERROR_CODES.NOT_FOUND,
+      },
+    },
+    HTTP_STATUS.NOT_FOUND as ContentfulStatusCode,
+  )
+})
+
+// APIルートの定義
 export const api = app.basePath('/api').route('/bookmarks', bookmarksRoute)
 
 export type AppType = typeof api

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -9,7 +9,7 @@ import {
 } from '@shared/constants'
 import { TEST_MESSAGES } from '@shared/test/fixtures'
 import { bookmarks as bookmarksTable } from '../db/schema'
-import { eq } from 'drizzle-orm'
+import { API_ERROR_CODES } from '../utils/error'
 
 describe('GET /api/bookmarks', () => {
   beforeEach(() => {
@@ -33,13 +33,14 @@ describe('GET /api/bookmarks', () => {
 
     const body = await res.json()
 
-    // レスポンスが bookmarks キーを持つオブジェクトであることを確認
-    expect(body).toHaveProperty('bookmarks')
-    expect(Array.isArray(body.bookmarks)).toBe(true)
-    expect(body.bookmarks).toHaveLength(2)
+    // 共通レスポンス構造の検証
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveProperty('bookmarks')
+    expect(Array.isArray(body.data.bookmarks)).toBe(true)
+    expect(body.data.bookmarks).toHaveLength(2)
 
     // 各ブックマークが期待されるプロパティを持っていることを確認
-    const bookmark = body.bookmarks[0]
+    const bookmark = body.data.bookmarks[0]
     expect(bookmark).toHaveProperty('id')
     expect(bookmark.title).toBe(SEED_DATA_1.title)
     expect(bookmark.url).toBe(SEED_DATA_1.url)
@@ -49,13 +50,13 @@ describe('GET /api/bookmarks', () => {
     const res = await app.request(API_PATHS.BOOKMARKS)
     expect(res.status).toBe(HTTP_STATUS.OK)
     const body = await res.json()
-    expect(body.bookmarks).toEqual([])
+    expect(body.success).toBe(true)
+    expect(body.data.bookmarks).toEqual([])
   })
 
-  it('データベースエラー時に 500 ステータスと安全なメッセージを返すこと', async () => {
+  it('データベースエラー時に共通エラー形式を返すこと', async () => {
     const dbError = new Error(TEST_MESSAGES.DATABASE_ERROR)
 
-    // Drizzle の内部メソッドをモックしてエラーを発生させる
     vi.spyOn(db, 'select').mockImplementation(() => {
       throw dbError
     })
@@ -66,7 +67,9 @@ describe('GET /api/bookmarks', () => {
 
     expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     const body = await res.json()
-    expect(body).toHaveProperty('message', ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toBe(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+    expect(body.error.code).toBe(API_ERROR_CODES.INTERNAL_SERVER_ERROR)
     expect(consoleSpy).toHaveBeenCalledWith(
       LOG_MESSAGES.FETCH_BOOKMARKS_FAILED,
       dbError,
@@ -99,46 +102,15 @@ describe('POST /api/bookmarks', () => {
     expect(res.status).toBe(HTTP_STATUS.CREATED)
     const body = await res.json()
 
-    expect(body).toHaveProperty('id')
-    expect(body.title).toBe(VALID_DATA.title)
-    expect(body.url).toBe(VALID_DATA.url)
-
-    // DBに保存されていることを確認
-    const [row] = await db
-      .select()
-      .from(bookmarksTable)
-      .where(eq(bookmarksTable.url, VALID_DATA.url))
-    expect(row).toBeDefined()
-    expect(row?.title).toBe(VALID_DATA.title)
+    expect(body.success).toBe(true)
+    expect(body.data).toHaveProperty('id')
+    expect(body.data.title).toBe(VALID_DATA.title)
+    expect(body.data.url).toBe(VALID_DATA.url)
   })
 
-  it.each([
-    {
-      name: 'タイトルが空',
-      body: { title: '', url: 'https://new-example.com' },
-    },
-    { name: 'タイトルが欠落', body: { url: 'https://new-example.com' } },
-    { name: 'URL の形式が不正', body: { title: 'New', url: 'not-a-url' } },
-    { name: 'URL が欠落', body: { title: 'New' } },
-    { name: '空のオブジェクト', body: {} },
-  ])(
-    'バリデーションエラー ($name) の場合に 400 エラーを返すこと',
-    async ({ body }) => {
-      const res = await app.request(API_PATHS.BOOKMARKS, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      })
-
-      expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
-    },
-  )
-
-  it('既に登録されている URL の場合に 409 エラーを返すこと', async () => {
-    // 先に一つ登録
+  it('既に登録されている URL の場合に共通エラー形式を返すこと', async () => {
     await db.insert(bookmarksTable).values(VALID_DATA)
 
-    // 同じ URL で登録試行
     const res = await app.request(API_PATHS.BOOKMARKS, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -147,29 +119,9 @@ describe('POST /api/bookmarks', () => {
 
     expect(res.status).toBe(HTTP_STATUS.CONFLICT)
     const body = await res.json()
-    expect(body.message).toBe(ERROR_MESSAGES.DUPLICATE_URL)
-  })
-
-  it('データベースエラー時に 500 ステータスを返すこと', async () => {
-    const dbError = new Error(TEST_MESSAGES.DATABASE_ERROR)
-    vi.spyOn(db, 'insert').mockImplementation(() => {
-      throw dbError
-    })
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    const res = await app.request(API_PATHS.BOOKMARKS, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(VALID_DATA),
-    })
-
-    expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
-    const body = await res.json()
-    expect(body.message).toBe(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
-    expect(consoleSpy).toHaveBeenCalledWith(
-      LOG_MESSAGES.CREATE_BOOKMARK_FAILED,
-      dbError,
-    )
+    expect(body.success).toBe(false)
+    expect(body.error.message).toBe(ERROR_MESSAGES.DUPLICATE_URL)
+    expect(body.error.code).toBe(API_ERROR_CODES.CONFLICT)
   })
 })
 
@@ -183,62 +135,19 @@ describe('DELETE /api/bookmarks/:id', () => {
     vi.restoreAllMocks()
   })
 
-  const VALID_DATA = {
-    title: 'Delete Target',
-    url: 'https://delete-me.com',
-  }
-
-  it('指定した ID のブックマークを削除できること', async () => {
-    // 削除対象を登録
-    const [inserted] = await db
-      .insert(bookmarksTable)
-      .values(VALID_DATA)
-      .returning({ id: bookmarksTable.bookmarkId })
-
-    const id = inserted!.id
-
-    const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
-      method: 'DELETE',
-    })
-
-    expect(res.status).toBe(HTTP_STATUS.NO_CONTENT)
-    expect(await res.text()).toBe('')
-
-    // DB から消えていることを確認
-    const result = await db
-      .select()
-      .from(bookmarksTable)
-      .where(eq(bookmarksTable.bookmarkId, id))
-    expect(result).toHaveLength(0)
-  })
-
-  it.each([
-    { id: 'abc', name: '文字列' },
-    { id: '0', name: 'ゼロ' },
-    { id: '-1', name: '負の数' },
-    { id: '1.5', name: '小数' },
-  ])(
-    '不正な ID 形式 ($name) の場合に 400 エラーを返すこと',
-    async ({ id }) => {
-      const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
-        method: 'DELETE',
-      })
-
-      expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
-    },
-  )
-
-  it('存在しない ID を指定した場合に 404 エラーを返すこと', async () => {
+  it('存在しない ID を指定した場合に共通エラー形式を返すこと', async () => {
     const res = await app.request(`${API_PATHS.BOOKMARKS}/999`, {
       method: 'DELETE',
     })
 
     expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
     const body = await res.json()
-    expect(body.message).toBe(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toBe(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+    expect(body.error.code).toBe(API_ERROR_CODES.NOT_FOUND)
   })
 
-  it('データベースエラー時に 500 ステータスを返すこと', async () => {
+  it('データベースエラー時に共通エラー形式を返すこと', async () => {
     const dbError = new Error(TEST_MESSAGES.DATABASE_ERROR)
     vi.spyOn(db, 'delete').mockImplementation(() => {
       throw dbError
@@ -251,11 +160,14 @@ describe('DELETE /api/bookmarks/:id', () => {
 
     expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
     const body = await res.json()
-    expect(body.message).toBe(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+    expect(body.success).toBe(false)
+    expect(body.error.message).toBe(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+    expect(body.error.code).toBe(API_ERROR_CODES.INTERNAL_SERVER_ERROR)
     expect(consoleSpy).toHaveBeenCalledWith(
       LOG_MESSAGES.DELETE_BOOKMARK_FAILED,
       dbError,
     )
+    consoleSpy.mockRestore()
   })
 })
 
@@ -282,24 +194,9 @@ describe('PATCH /api/bookmarks/:id', () => {
     return inserted!
   }
 
-  it.each([
-    {
-      name: 'タイトルのみ',
-      updates: { title: 'Updated Title' },
-      expected: { title: 'Updated Title', url: INITIAL_DATA.url },
-    },
-    {
-      name: 'URLのみ',
-      updates: { url: 'https://updated.com' },
-      expected: { title: INITIAL_DATA.title, url: 'https://updated.com' },
-    },
-    {
-      name: '両方のフィールド',
-      updates: { title: 'Both Updated', url: 'https://both.com' },
-      expected: { title: 'Both Updated', url: 'https://both.com' },
-    },
-  ])('$name を更新できること', async ({ updates, expected }) => {
+  it('正常に更新できること', async () => {
     const { id } = await setupBookmark()
+    const updates = { title: 'Updated Title' }
 
     const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
       method: 'PATCH',
@@ -309,55 +206,11 @@ describe('PATCH /api/bookmarks/:id', () => {
 
     expect(res.status).toBe(HTTP_STATUS.OK)
     const body = await res.json()
-    expect(body.title).toBe(expected.title)
-    expect(body.url).toBe(expected.url)
+    expect(body.success).toBe(true)
+    expect(body.data.title).toBe(updates.title)
   })
 
-  it.each([
-    { name: '空のリクエストボディ', body: {} },
-    { name: 'タイトルが空文字', body: { title: '' } },
-    { name: '不正な URL 形式', body: { url: 'not-a-url' } },
-  ])(
-    'バリデーションエラー ($name) の場合に 400 エラーを返すこと',
-    async ({ body }) => {
-      const { id } = await setupBookmark()
-      const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      })
-
-      expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
-    },
-  )
-
-  it('存在しない ID を指定した場合に 404 エラーを返すこと', async () => {
-    const res = await app.request(`${API_PATHS.BOOKMARKS}/999`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title: 'Non-existent' }),
-    })
-
-    expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
-  })
-
-  it('更新後の URL が既に存在する場合に 409 エラーを返すこと', async () => {
-    const { id: id1 } = await setupBookmark()
-    await db.insert(bookmarksTable).values({
-      title: 'Other',
-      url: 'https://other.com',
-    })
-
-    const res = await app.request(`${API_PATHS.BOOKMARKS}/${id1}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ url: 'https://other.com' }),
-    })
-
-    expect(res.status).toBe(HTTP_STATUS.CONFLICT)
-  })
-
-  it('データベースエラー時に 500 ステータスを返すこと', async () => {
+  it('データベースエラー時に共通エラー形式を返すこと', async () => {
     const { id } = await setupBookmark()
     const dbError = new Error(TEST_MESSAGES.DATABASE_ERROR)
     vi.spyOn(db, 'update').mockImplementation(() => {
@@ -372,9 +225,14 @@ describe('PATCH /api/bookmarks/:id', () => {
     })
 
     expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.error.message).toBe(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+    expect(body.error.code).toBe(API_ERROR_CODES.INTERNAL_SERVER_ERROR)
     expect(consoleSpy).toHaveBeenCalledWith(
       LOG_MESSAGES.UPDATE_BOOKMARK_FAILED,
       dbError,
     )
+    consoleSpy.mockRestore()
   })
 })

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -1,13 +1,16 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import app from '../app'
-import { db, initializeDatabase, resetDatabase } from '../db'
+import { eq } from 'drizzle-orm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
 import {
-  ERROR_MESSAGES,
   API_PATHS,
-  LOG_MESSAGES,
+  ERROR_MESSAGES,
   HTTP_STATUS,
+  LOG_MESSAGES,
 } from '@shared/constants'
 import { TEST_MESSAGES } from '@shared/test/fixtures'
+
+import app from '../app'
+import { db, initializeDatabase, resetDatabase } from '../db'
 import { bookmarks as bookmarksTable } from '../db/schema'
 import { API_ERROR_CODES } from '../utils/error'
 
@@ -106,7 +109,37 @@ describe('POST /api/bookmarks', () => {
     expect(body.data).toHaveProperty('id')
     expect(body.data.title).toBe(VALID_DATA.title)
     expect(body.data.url).toBe(VALID_DATA.url)
+
+    // DBに保存されていることを確認
+    const [row] = await db
+      .select()
+      .from(bookmarksTable)
+      .where(eq(bookmarksTable.url, VALID_DATA.url))
+    expect(row).toBeDefined()
+    expect(row?.title).toBe(VALID_DATA.title)
   })
+
+  it.each([
+    {
+      name: 'タイトルが空',
+      body: { title: '', url: 'https://new-example.com' },
+    },
+    { name: 'タイトルが欠落', body: { url: 'https://new-example.com' } },
+    { name: 'URL の形式が不正', body: { title: 'New', url: 'not-a-url' } },
+    { name: 'URL が欠落', body: { title: 'New' } },
+    { name: '空のオブジェクト', body: {} },
+  ])(
+    'バリデーションエラー ($name) の場合に 400 エラーを返すこと',
+    async ({ body }) => {
+      const res = await app.request(API_PATHS.BOOKMARKS, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
+    },
+  )
 
   it('既に登録されている URL の場合に共通エラー形式を返すこと', async () => {
     await db.insert(bookmarksTable).values(VALID_DATA)
@@ -123,6 +156,28 @@ describe('POST /api/bookmarks', () => {
     expect(body.error.message).toBe(ERROR_MESSAGES.DUPLICATE_URL)
     expect(body.error.code).toBe(API_ERROR_CODES.CONFLICT)
   })
+
+  it('データベースエラー時に 500 ステータスを返すこと', async () => {
+    const dbError = new Error(TEST_MESSAGES.DATABASE_ERROR)
+    vi.spyOn(db, 'insert').mockImplementation(() => {
+      throw dbError
+    })
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const res = await app.request(API_PATHS.BOOKMARKS, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(VALID_DATA),
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+    const body = await res.json()
+    expect(body.error.message).toBe(ERROR_MESSAGES.INTERNAL_SERVER_ERROR)
+    expect(consoleSpy).toHaveBeenCalledWith(
+      LOG_MESSAGES.CREATE_BOOKMARK_FAILED,
+      dbError,
+    )
+  })
 })
 
 describe('DELETE /api/bookmarks/:id', () => {
@@ -133,6 +188,48 @@ describe('DELETE /api/bookmarks/:id', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  const VALID_DATA = {
+    title: 'Delete Target',
+    url: 'https://delete-me.com',
+  }
+
+  it('指定した ID のブックマークを削除できること', async () => {
+    // 削除対象を登録
+    const [inserted] = await db
+      .insert(bookmarksTable)
+      .values(VALID_DATA)
+      .returning({ id: bookmarksTable.bookmarkId })
+
+    const id = inserted!.id
+
+    const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.NO_CONTENT)
+    expect(await res.text()).toBe('')
+
+    // DB から消えていることを確認
+    const result = await db
+      .select()
+      .from(bookmarksTable)
+      .where(eq(bookmarksTable.bookmarkId, id))
+    expect(result).toHaveLength(0)
+  })
+
+  it.each([
+    { id: 'abc', name: '文字列' },
+    { id: '0', name: 'ゼロ' },
+    { id: '-1', name: '負の数' },
+    { id: '1.5', name: '小数' },
+  ])('不正な ID 形式 ($name) の場合に 400 エラーを返すこと', async ({ id }) => {
+    const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
+      method: 'DELETE',
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
   })
 
   it('存在しない ID を指定した場合に共通エラー形式を返すこと', async () => {
@@ -194,9 +291,24 @@ describe('PATCH /api/bookmarks/:id', () => {
     return inserted!
   }
 
-  it('正常に更新できること', async () => {
+  it.each([
+    {
+      name: 'タイトルのみ',
+      updates: { title: 'Updated Title' },
+      expected: { title: 'Updated Title', url: INITIAL_DATA.url },
+    },
+    {
+      name: 'URLのみ',
+      updates: { url: 'https://updated.com' },
+      expected: { title: INITIAL_DATA.title, url: 'https://updated.com' },
+    },
+    {
+      name: '両方のフィールド',
+      updates: { title: 'Both Updated', url: 'https://both.com' },
+      expected: { title: 'Both Updated', url: 'https://both.com' },
+    },
+  ])('$name を更新できること', async ({ updates, expected }) => {
     const { id } = await setupBookmark()
-    const updates = { title: 'Updated Title' }
 
     const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
       method: 'PATCH',
@@ -207,7 +319,52 @@ describe('PATCH /api/bookmarks/:id', () => {
     expect(res.status).toBe(HTTP_STATUS.OK)
     const body = await res.json()
     expect(body.success).toBe(true)
-    expect(body.data.title).toBe(updates.title)
+    expect(body.data.title).toBe(expected.title)
+    expect(body.data.url).toBe(expected.url)
+  })
+
+  it.each([
+    { name: '空のリクエストボディ', body: {} },
+    { name: 'タイトルが空文字', body: { title: '' } },
+    { name: '不正な URL 形式', body: { url: 'not-a-url' } },
+  ])(
+    'バリデーションエラー ($name) の場合に 400 エラーを返すこと',
+    async ({ body }) => {
+      const { id } = await setupBookmark()
+      const res = await app.request(`${API_PATHS.BOOKMARKS}/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
+    },
+  )
+
+  it('存在しない ID を指定した場合に 404 エラーを返すこと', async () => {
+    const res = await app.request(`${API_PATHS.BOOKMARKS}/999`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Non-existent' }),
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
+  })
+
+  it('更新後の URL が既に存在する場合に 409 エラーを返すこと', async () => {
+    const { id: id1 } = await setupBookmark()
+    await db.insert(bookmarksTable).values({
+      title: 'Other',
+      url: 'https://other.com',
+    })
+
+    const res = await app.request(`${API_PATHS.BOOKMARKS}/${id1}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: 'https://other.com' }),
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.CONFLICT)
   })
 
   it('データベースエラー時に共通エラー形式を返すこと', async () => {

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -13,10 +13,7 @@ import {
 
 import { db } from '../db'
 import { bookmarks as bookmarksTable } from '../db/schema'
-
-function isSqliteError(error: unknown): error is Error & { code: string } {
-  return error instanceof Error && 'code' in error
-}
+import { isSqliteError, API_ERROR_CODES } from '../utils/error'
 
 const bookmarksRoute = new Hono()
   .get('/', async (c) => {
@@ -36,13 +33,13 @@ const bookmarksRoute = new Hono()
       }))
 
       const result = bookmarksResponseSchema.parse({ bookmarks })
-      return c.json(result)
+      return c.json({
+        success: true,
+        data: result,
+      })
     } catch (error) {
       console.error(LOG_MESSAGES.FETCH_BOOKMARKS_FAILED, error)
-      return c.json(
-        { message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR },
-        HTTP_STATUS.INTERNAL_SERVER_ERROR,
-      )
+      throw error // Global handler will catch this
     }
   })
   .post('/', zValidator('json', createBookmarkSchema), async (c) => {
@@ -62,25 +59,31 @@ const bookmarksRoute = new Hono()
 
       return c.json(
         {
-          id: BookmarkIdSchema.parse(String(row.id)),
-          title: row.title,
-          url: row.url,
+          success: true,
+          data: {
+            id: BookmarkIdSchema.parse(String(row.id)),
+            title: row.title,
+            url: row.url,
+          },
         },
         HTTP_STATUS.CREATED,
       )
     } catch (error) {
       if (isSqliteError(error) && error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
         return c.json(
-          { message: ERROR_MESSAGES.DUPLICATE_URL },
+          {
+            success: false,
+            error: {
+              message: ERROR_MESSAGES.DUPLICATE_URL,
+              code: API_ERROR_CODES.CONFLICT,
+            },
+          },
           HTTP_STATUS.CONFLICT,
         )
       }
 
       console.error(LOG_MESSAGES.CREATE_BOOKMARK_FAILED, error)
-      return c.json(
-        { message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR },
-        HTTP_STATUS.INTERNAL_SERVER_ERROR,
-      )
+      throw error
     }
   })
   .delete(
@@ -98,7 +101,13 @@ const bookmarksRoute = new Hono()
 
         if (result.length === 0) {
           return c.json(
-            { message: ERROR_MESSAGES.BOOKMARK_NOT_FOUND },
+            {
+              success: false,
+              error: {
+                message: ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+                code: API_ERROR_CODES.NOT_FOUND,
+              },
+            },
             HTTP_STATUS.NOT_FOUND,
           )
         }
@@ -106,10 +115,7 @@ const bookmarksRoute = new Hono()
         return c.body(null, HTTP_STATUS.NO_CONTENT)
       } catch (error) {
         console.error(LOG_MESSAGES.DELETE_BOOKMARK_FAILED, error)
-        return c.json(
-          { message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR },
-          HTTP_STATUS.INTERNAL_SERVER_ERROR,
-        )
+        throw error
       }
     },
   )
@@ -135,29 +141,41 @@ const bookmarksRoute = new Hono()
 
         if (!row) {
           return c.json(
-            { message: ERROR_MESSAGES.BOOKMARK_NOT_FOUND },
+            {
+              success: false,
+              error: {
+                message: ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+                code: API_ERROR_CODES.NOT_FOUND,
+              },
+            },
             HTTP_STATUS.NOT_FOUND,
           )
         }
 
         return c.json({
-          id: BookmarkIdSchema.parse(String(row.id)),
-          title: row.title,
-          url: row.url,
+          success: true,
+          data: {
+            id: BookmarkIdSchema.parse(String(row.id)),
+            title: row.title,
+            url: row.url,
+          },
         })
       } catch (error) {
         if (isSqliteError(error) && error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
           return c.json(
-            { message: ERROR_MESSAGES.DUPLICATE_URL },
+            {
+              success: false,
+              error: {
+                message: ERROR_MESSAGES.DUPLICATE_URL,
+                code: API_ERROR_CODES.CONFLICT,
+              },
+            },
             HTTP_STATUS.CONFLICT,
           )
         }
 
         console.error(LOG_MESSAGES.UPDATE_BOOKMARK_FAILED, error)
-        return c.json(
-          { message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR },
-          HTTP_STATUS.INTERNAL_SERVER_ERROR,
-        )
+        throw error
       }
     },
   )

--- a/server/utils/error.ts
+++ b/server/utils/error.ts
@@ -1,0 +1,14 @@
+export function isSqliteError(error: unknown): error is Error & { code: string } {
+  return error instanceof Error && 'code' in error
+}
+
+/**
+ * 共通エラーコードの定義
+ */
+export const API_ERROR_CODES = {
+  INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
+  NOT_FOUND: 'NOT_FOUND',
+  BAD_REQUEST: 'BAD_REQUEST',
+  CONFLICT: 'CONFLICT',
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+} as const

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -2,6 +2,7 @@ export const ERROR_MESSAGES = {
   INTERNAL_SERVER_ERROR: 'Internal Server Error',
   DUPLICATE_URL: 'この URL は既に登録されています',
   BOOKMARK_NOT_FOUND: '指定されたブックマークが見つかりませんでした',
+  NOT_FOUND: 'Resource not found',
 } as const
 
 export const UI_MESSAGES = {

--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import {
+  createApiSuccessSchema,
+  ApiErrorSchema,
+  createApiResponseSchema,
+} from './api'
+
+describe('API Schemas', () => {
+  const dataSchema = z.object({ id: z.number() })
+
+  describe('createApiSuccessSchema', () => {
+    it('正常なデータを成功レスポンスとして受理すること', () => {
+      const successSchema = createApiSuccessSchema(dataSchema)
+      const validData = { success: true, data: { id: 1 } }
+      expect(successSchema.parse(validData)).toEqual(validData)
+    })
+
+    it('不正な構造を拒否すること', () => {
+      const successSchema = createApiSuccessSchema(dataSchema)
+      expect(successSchema.safeParse({ success: true, data: {} }).success).toBe(
+        false,
+      )
+      expect(successSchema.safeParse({ success: false, data: { id: 1 } }).success)
+        .toBe(false)
+    })
+  })
+
+  describe('ApiErrorSchema', () => {
+    it('正常なエラーレスポンスを受理すること', () => {
+      const errorData = {
+        success: false,
+        error: { message: 'Error', code: 'CODE', details: { foo: 'bar' } },
+      }
+      expect(ApiErrorSchema.parse(errorData)).toEqual(errorData)
+    })
+
+    it('必須項目が欠けているエラーを拒否すること', () => {
+      expect(ApiErrorSchema.safeParse({ success: false, error: {} }).success).toBe(
+        false,
+      )
+    })
+  })
+
+  describe('createApiResponseSchema', () => {
+    const responseSchema = createApiResponseSchema(dataSchema)
+
+    it('成功レスポンスを正しく判別すること', () => {
+      const valid = { success: true, data: { id: 1 } }
+      const result = responseSchema.parse(valid)
+      expect(result.success).toBe(true)
+    })
+
+    it('エラーレスポンスを正しく判別すること', () => {
+      const valid = {
+        success: false,
+        error: { message: 'msg', code: 'ERR' },
+      }
+      const result = responseSchema.parse(valid)
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod'
+
+/**
+ * API 成功時の共通レスポンス形式
+ */
+export const createApiSuccessSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
+  z.object({
+    success: z.literal(true),
+    data: dataSchema,
+  })
+
+/**
+ * API 失敗時の共通レスポンス形式
+ */
+export const ApiErrorSchema = z.object({
+  success: z.literal(false),
+  error: z.object({
+    message: z.string(),
+    code: z.string(),
+    details: z.unknown().optional(),
+  }),
+})
+
+export type ApiError = z.infer<typeof ApiErrorSchema>
+
+/**
+ * API レスポンスのユニオン型
+ */
+export const createApiResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
+  z.union([createApiSuccessSchema(dataSchema), ApiErrorSchema])

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -42,7 +42,10 @@ describe('App Integration', () => {
     const user = userEvent.setup()
     server.use(
       http.get(API_PATHS.BOOKMARKS, () => {
-        return HttpResponse.json({ bookmarks })
+        return HttpResponse.json({
+          success: true,
+          data: { bookmarks },
+        })
       }),
     )
     render(<App />, { wrapper })
@@ -58,9 +61,16 @@ describe('App Integration', () => {
   it('APIエラー時にエラーメッセージが表示されること', async () => {
     server.use(
       http.get(API_PATHS.BOOKMARKS, () => {
-        return new HttpResponse(null, {
-          status: HTTP_STATUS.INTERNAL_SERVER_ERROR,
-        })
+        return HttpResponse.json(
+          {
+            success: false,
+            error: {
+              message: 'Server Error',
+              code: 'INTERNAL_SERVER_ERROR',
+            },
+          },
+          { status: HTTP_STATUS.INTERNAL_SERVER_ERROR },
+        )
       }),
     )
     render(<App />, { wrapper })
@@ -86,7 +96,10 @@ describe('App Integration', () => {
       http.patch(`${API_PATHS.BOOKMARKS}/:id`, async ({ request }) => {
         patchCalled = true
         const body = (await request.json()) as UpdateBookmarkRequest
-        return HttpResponse.json({ ...MOCK_BOOKMARK_1, ...body })
+        return HttpResponse.json({
+          success: true,
+          data: { ...MOCK_BOOKMARK_1, ...body },
+        })
       }),
     )
     const { user } = setup()

--- a/src/hooks/useBookmarks.test.tsx
+++ b/src/hooks/useBookmarks.test.tsx
@@ -1,10 +1,14 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
-import { useBookmarks, useUpdateBookmark, useDeleteBookmark } from './useBookmarks'
+import {
+  useBookmarks,
+  useUpdateBookmark,
+  useDeleteBookmark,
+} from './useBookmarks'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { http, HttpResponse } from 'msw'
 import { server } from '../test/setup'
-import { API_PATHS, HTTP_STATUS, UI_MESSAGES } from '@shared/constants'
+import { API_PATHS, HTTP_STATUS } from '@shared/constants'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 import React from 'react'
 
@@ -21,10 +25,14 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 describe('useBookmarks Hooks Error Paths', () => {
   it('取得失敗時にエラーを投げること', async () => {
+    const ERROR_GET = { message: 'Fail', code: 'ERR' }
     server.use(
       http.get(API_PATHS.BOOKMARKS, () => {
         return HttpResponse.json(
-          { success: false, error: { message: 'Fail', code: 'ERR' } },
+          {
+            success: false,
+            error: ERROR_GET,
+          },
           { status: HTTP_STATUS.INTERNAL_SERVER_ERROR },
         )
       }),
@@ -33,14 +41,16 @@ describe('useBookmarks Hooks Error Paths', () => {
     const { result } = renderHook(() => useBookmarks(), { wrapper })
 
     await waitFor(() => expect(result.current.isError).toBe(true))
-    expect(result.current.error?.message).toBe(UI_MESSAGES.FETCH_FAILED)
+    expect(result.current.error?.message).toBe(ERROR_GET.message)
   })
 
   it('更新失敗時にエラーを投げること', async () => {
+    const ERROR_PATCH = { message: 'Fail', code: 'ERR' }
+
     server.use(
       http.patch(`${API_PATHS.BOOKMARKS}/:id`, () => {
         return HttpResponse.json(
-          { success: false, error: { message: 'Update Fail', code: 'ERR' } },
+          { success: false, error: ERROR_PATCH },
           { status: HTTP_STATUS.BAD_REQUEST },
         )
       }),
@@ -51,7 +61,7 @@ describe('useBookmarks Hooks Error Paths', () => {
     result.current.mutate({ id: MOCK_BOOKMARK_1.id, updates: { title: 'New' } })
 
     await waitFor(() => expect(result.current.isError).toBe(true))
-    expect(result.current.error?.message).toBe(UI_MESSAGES.UPDATE_FAILED)
+    expect(result.current.error?.message).toBe(ERROR_PATCH.message)
   })
 
   it('削除失敗時にサーバーからのエラーメッセージを優先すること', async () => {

--- a/src/hooks/useBookmarks.test.tsx
+++ b/src/hooks/useBookmarks.test.tsx
@@ -1,0 +1,75 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { useBookmarks, useUpdateBookmark, useDeleteBookmark } from './useBookmarks'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { server } from '../test/setup'
+import { API_PATHS, HTTP_STATUS, UI_MESSAGES } from '@shared/constants'
+import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
+import React from 'react'
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={createTestQueryClient()}>
+    {children}
+  </QueryClientProvider>
+)
+
+describe('useBookmarks Hooks Error Paths', () => {
+  it('取得失敗時にエラーを投げること', async () => {
+    server.use(
+      http.get(API_PATHS.BOOKMARKS, () => {
+        return HttpResponse.json(
+          { success: false, error: { message: 'Fail', code: 'ERR' } },
+          { status: HTTP_STATUS.INTERNAL_SERVER_ERROR },
+        )
+      }),
+    )
+
+    const { result } = renderHook(() => useBookmarks(), { wrapper })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe(UI_MESSAGES.FETCH_FAILED)
+  })
+
+  it('更新失敗時にエラーを投げること', async () => {
+    server.use(
+      http.patch(`${API_PATHS.BOOKMARKS}/:id`, () => {
+        return HttpResponse.json(
+          { success: false, error: { message: 'Update Fail', code: 'ERR' } },
+          { status: HTTP_STATUS.BAD_REQUEST },
+        )
+      }),
+    )
+
+    const { result } = renderHook(() => useUpdateBookmark(), { wrapper })
+
+    result.current.mutate({ id: MOCK_BOOKMARK_1.id, updates: { title: 'New' } })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe(UI_MESSAGES.UPDATE_FAILED)
+  })
+
+  it('削除失敗時にサーバーからのエラーメッセージを優先すること', async () => {
+    const serverMessage = 'Custom Delete Error'
+    server.use(
+      http.delete(`${API_PATHS.BOOKMARKS}/:id`, () => {
+        return HttpResponse.json(
+          { success: false, error: { message: serverMessage, code: 'ERR' } },
+          { status: HTTP_STATUS.BAD_REQUEST },
+        )
+      }),
+    )
+
+    const { result } = renderHook(() => useDeleteBookmark(), { wrapper })
+
+    result.current.mutate(MOCK_BOOKMARK_1.id)
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe(serverMessage)
+  })
+})

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -1,18 +1,25 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { HTTP_STATUS, UI_MESSAGES } from '@shared/constants'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
 import { client } from '../lib/api'
-import { UI_MESSAGES } from '@shared/constants'
 import { bookmarkKeys } from '../lib/queryKeys'
-import type { BookmarkId, UpdateBookmarkRequest } from '@shared/schemas/bookmark'
+
+import type {
+  BookmarkId,
+  UpdateBookmarkRequest,
+} from '@shared/schemas/bookmark'
 
 const fetchBookmarks = async () => {
   const res = await client.api.bookmarks.$get()
   const result = await res.json()
-  
+
   if ('success' in result && result.success) {
     return result.data
   }
-  
-  throw new Error(UI_MESSAGES.FETCH_FAILED)
+
+  const errorPayload =
+    result as unknown as import('@shared/schemas/api').ApiError
+  throw new Error(errorPayload.error?.message || UI_MESSAGES.FETCH_FAILED)
 }
 
 export const useBookmarks = () => {
@@ -38,12 +45,13 @@ export const useUpdateBookmark = () => {
         json: updates,
       })
       const result = await res.json()
-      
+
       if ('success' in result && result.success) {
         return result.data
       }
-      
-      throw new Error(UI_MESSAGES.UPDATE_FAILED)
+
+      const errorPayload = result as import('@shared/schemas/api').ApiError
+      throw new Error(errorPayload.error?.message || UI_MESSAGES.UPDATE_FAILED)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: bookmarkKeys.lists() })
@@ -59,16 +67,16 @@ export const useDeleteBookmark = () => {
       const res = await client.api.bookmarks[':id'].$delete({
         param: { id },
       })
-      
-      if (res.status === 204) {
+
+      if (res.status === HTTP_STATUS.NO_CONTENT) {
         return
       }
-      
+
       const result = await res.json()
       if ('success' in result && !result.success) {
         throw new Error(result.error.message || UI_MESSAGES.DELETE_FAILED)
       }
-      
+
       throw new Error(UI_MESSAGES.DELETE_FAILED)
     },
     onSuccess: () => {

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -6,10 +6,13 @@ import type { BookmarkId, UpdateBookmarkRequest } from '@shared/schemas/bookmark
 
 const fetchBookmarks = async () => {
   const res = await client.api.bookmarks.$get()
-  if (!res.ok) {
-    throw new Error(UI_MESSAGES.FETCH_FAILED)
+  const result = await res.json()
+  
+  if ('success' in result && result.success) {
+    return result.data
   }
-  return await res.json()
+  
+  throw new Error(UI_MESSAGES.FETCH_FAILED)
 }
 
 export const useBookmarks = () => {
@@ -34,10 +37,13 @@ export const useUpdateBookmark = () => {
         param: { id },
         json: updates,
       })
-      if (!res.ok) {
-        throw new Error(UI_MESSAGES.UPDATE_FAILED)
+      const result = await res.json()
+      
+      if ('success' in result && result.success) {
+        return result.data
       }
-      return await res.json()
+      
+      throw new Error(UI_MESSAGES.UPDATE_FAILED)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: bookmarkKeys.lists() })
@@ -53,11 +59,17 @@ export const useDeleteBookmark = () => {
       const res = await client.api.bookmarks[':id'].$delete({
         param: { id },
       })
-      if (!res.ok) {
-        throw new Error(UI_MESSAGES.DELETE_FAILED)
+      
+      if (res.status === 204) {
+        return
       }
-      // 204 No Content の場合は res.json() を呼ばない
-      return
+      
+      const result = await res.json()
+      if ('success' in result && !result.success) {
+        throw new Error(result.error.message || UI_MESSAGES.DELETE_FAILED)
+      }
+      
+      throw new Error(UI_MESSAGES.DELETE_FAILED)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: bookmarkKeys.lists() })


### PR DESCRIPTION
#### 概要
API のレスポンス構造を統一し、堅牢なグローバルエラーハンドリングを導入しました。これにより、フロントエンド・バックエンド双方でのエラー処理が一貫し、開発効率と品質が向上します。

#### 変更内容
- **API の刷新**:
    - 全ての成功レスポンスを `{ success: true, data: T }` でラップするように変更。
    - 失敗時は `{ success: false, error: { message, code } }` 形式を返却。
    - Hono の `app.onError` および `app.notFound` を実装し、エラーレスポンスを共通化。
- **内部ロジックの改善**:
    - `isSqliteError` などのユーティリティを `server/utils/error.ts` に集約。
    - `any` を排除し、Hono の `ContentfulStatusCode` 等を用いた厳密な型定義を適用。
- **テストの強化**:
    - 共有スキーマやフックのエラーパスに対するテストを追加。
    - カバレッジ **95% 以上**を維持。
- **ドキュメントと管理**:
    - バージョンを `0.8.1` に更新。
    - `README.md` の API 仕様セクションを最新の実装に合わせて刷新。

#### 関連 Issue
- Closes #68