### PR TITLE
feat: MITライセンスの追加 (#92)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 kubotama
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -241,3 +241,7 @@ npm run test:coverage
 - **200 OK**: 更新成功
 - **400 Bad Request**: ID リストの形式が不正な場合
 - **500 Internal Server Error**: サーバーエラー
+
+## ライセンス (License)
+
+このプロジェクトは MIT ライセンスの下で公開されています。詳細は [LICENSE](LICENSE) ファイルを参照してください。

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bookmark-page",
   "private": true,
   "version": "0.10.3",
+  "license": "MIT",
   "type": "module",
   "overrides": {
     "esbuild": "0.27.2"


### PR DESCRIPTION
## 概要
プロジェクトの利用条件を明確にするため、MITライセンスを導入しました。

## 変更内容
- プロジェクトルートに `LICENSE` ファイルを作成し、MITライセンスの全文を記述しました。
- `package.json` に `"license": "MIT"` を追加しました。
- `README.md` にライセンスに関するセクションを追記しました。

## 検証内容
- [x] `LICENSE` ファイルの存在と内容の確認
- [x] `package.json` のバリデーション（`npm run lint`）
- [x] `README.md` の表示確認

## 関連Issue
- Fixes #92