### PR TITLE
test(extension): 拡張機能用の単体テスト環境の導入と実装 (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ npm run type-check
 
 ### テスト (Testing)
 
-単体テストを実行します：
+Web アプリ、API サーバー、ブラウザ拡張機能の単体テストを実行します：
 
 ```bash
 npm run test

--- a/extension/public/manifest.json
+++ b/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "ブックマークを保存する拡張機能",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "開いているページをブックマークします",
   "permissions": [
     "tabs",

--- a/extension/src/Options.test.tsx
+++ b/extension/src/Options.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Options } from './Options'
+import { EXTENSION_MESSAGES } from '@shared/constants'
+import { useOptions } from './hooks/useOptions'
+
+// useOptions フックをモック化
+vi.mock('./hooks/useOptions')
+
+describe('Options Component', () => {
+  const baseMockUseOptions = {
+    apiUrl: 'http://localhost:3000',
+    setApiUrl: vi.fn(),
+    status: { type: 'idle' as const },
+    handleSave: vi.fn(),
+    handleTestConnection: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useOptions).mockReturnValue(baseMockUseOptions)
+  })
+
+  it('正しくタイトルと入力欄が表示されること', () => {
+    render(<Options />)
+
+    expect(
+      screen.getByText(EXTENSION_MESSAGES.OPTIONS_TITLE),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByLabelText(EXTENSION_MESSAGES.API_URL_LABEL),
+    ).toBeInTheDocument()
+    expect(screen.getByDisplayValue('http://localhost:3000')).toBeInTheDocument()
+  })
+
+  it('保存ボタンと接続確認ボタンが表示されること', () => {
+    render(<Options />)
+
+    expect(screen.getByText(EXTENSION_MESSAGES.BUTTON_SAVE)).toBeInTheDocument()
+    expect(screen.getByText(EXTENSION_MESSAGES.BUTTON_TEST)).toBeInTheDocument()
+  })
+
+  it('ステータスメッセージがある場合に正しく表示されること', () => {
+    const message = 'Test Status Message'
+    vi.mocked(useOptions).mockReturnValue({
+      ...baseMockUseOptions,
+      status: { type: 'success', message },
+    })
+
+    render(<Options />)
+
+    expect(screen.getByText(message)).toBeInTheDocument()
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+})

--- a/extension/src/Popup.test.tsx
+++ b/extension/src/Popup.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { UI_MESSAGES } from '@shared/constants'
+import { render, screen } from '@testing-library/react'
+
+import { Popup } from './Popup'
+
+describe('Popup Component', () => {
+  it('正しくタイトルが表示されること', () => {
+    render(<Popup />)
+
+    expect(screen.getByText(UI_MESSAGES.EXTENSION_TITLE)).toBeInTheDocument()
+    expect(screen.getByText(UI_MESSAGES.EXTENSION_CONTENT)).toBeInTheDocument()
+  })
+})

--- a/extension/src/Popup.tsx
+++ b/extension/src/Popup.tsx
@@ -1,8 +1,10 @@
+import { UI_MESSAGES } from '@shared/constants'
+
 export const Popup = () => {
   return (
     <div className="p-4 w-64">
-      <h1 className="text-lg font-bold">Bookmark Page</h1>
-      <p>Popup Content</p>
+      <h1 className="text-lg font-bold">{UI_MESSAGES.EXTENSION_TITLE}</h1>
+      <p>{UI_MESSAGES.EXTENSION_CONTENT}</p>
     </div>
   )
 }

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+describe('background service worker', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    // background.ts を再読み込みしてイベントリスナーを登録させる
+    vi.resetModules()
+  })
+
+  it('拡張機能インストール時にログを出力すること', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    // chrome.runtime.onInstalled.addListener のモックを取得
+    const addListenerMock = vi.mocked(chrome.runtime.onInstalled.addListener)
+
+    // background.ts をインポート
+    await import('./background')
+
+    // リスナーが登録されたか確認
+    expect(addListenerMock).toHaveBeenCalled()
+
+    // 登録されたリスナー（コールバック）を直接呼び出す
+    const callback = addListenerMock.mock.calls[0][0]
+    callback({ reason: 'install' } as chrome.runtime.InstalledDetails)
+
+    expect(consoleSpy).toHaveBeenCalledWith('Extension installed')
+  })
+})

--- a/extension/src/hooks/useOptions.test.ts
+++ b/extension/src/hooks/useOptions.test.ts
@@ -1,0 +1,177 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useOptions } from './useOptions'
+import { STORAGE_KEYS, EXTENSION_MESSAGES } from '@shared/constants'
+import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2 } from '@shared/test/fixtures'
+
+describe('useOptions Hook', () => {
+  const defaultUrl = 'http://localhost:3030'
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+    vi.mocked(chrome.storage.sync.get).mockImplementation(() => Promise.resolve({
+      [STORAGE_KEYS.API_URL]: defaultUrl,
+    }))
+  })
+
+  const setupHook = async () => {
+    const hook = renderHook(() => useOptions())
+    await waitFor(() => expect(hook.result.current.apiUrl).toBe(defaultUrl))
+    return hook
+  }
+
+  it('初期化時にストレージから設定を読み込むこと', async () => {
+    const { result } = renderHook(() => useOptions())
+
+    // 初期状態は空文字列であるべき
+    expect(result.current.apiUrl).toBe('')
+
+    // ストレージからの読み込みを待ち、URLが設定されることを確認
+    await waitFor(() => {
+      expect(result.current.apiUrl).toBe(defaultUrl)
+    })
+  })
+
+  describe('handleSave', () => {
+    it('有効な URL の場合に設定を保存できること', async () => {
+      const { result } = await setupHook()
+      const newUrl = 'http://localhost:4000'
+
+      await act(async () => {
+        result.current.setApiUrl(newUrl)
+      })
+
+      expect(result.current.apiUrl).toBe(newUrl)
+
+      await act(async () => {
+        await result.current.handleSave()
+      })
+
+      expect(chrome.storage.sync.set).toHaveBeenCalledWith({
+        [STORAGE_KEYS.API_URL]: newUrl,
+      })
+      expect(result.current.status.type).toBe('success')
+      expect(result.current.status.message).toBe(
+        EXTENSION_MESSAGES.SETTINGS_SAVED,
+      )
+    })
+
+    it('不正なプロトコルの場合にエラーを返すこと', async () => {
+      const { result } = await setupHook()
+      await act(async () => {
+        result.current.setApiUrl('ftp://localhost')
+      })
+
+      await act(async () => {
+        await result.current.handleSave()
+      })
+
+      expect(result.current.status.type).toBe('error')
+      expect(result.current.status.message).toBe(
+        EXTENSION_MESSAGES.INVALID_PROTOCOL,
+      )
+    })
+
+    it('localhost 以外のホストを拒否すること', async () => {
+      const { result } = await setupHook()
+      await act(async () => {
+        result.current.setApiUrl('http://example.com')
+      })
+
+      await act(async () => {
+        await result.current.handleSave()
+      })
+
+      expect(result.current.status.type).toBe('error')
+      expect(result.current.status.message).toBe(
+        EXTENSION_MESSAGES.INVALID_HOST,
+      )
+    })
+
+    it('特権ポートへの接続を拒否すること', async () => {
+      const { result } = await setupHook()
+      await act(async () => {
+        result.current.setApiUrl('http://localhost:80')
+      })
+
+      await act(async () => {
+        await result.current.handleSave()
+      })
+
+      expect(result.current.status.type).toBe('error')
+      expect(result.current.status.message).toBe(
+        EXTENSION_MESSAGES.INVALID_PORT,
+      )
+    })
+  })
+
+  describe('handleTestConnection', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    it('接続テストが成功した場合に件数を表示すること', async () => {
+      const mockResponse = {
+        success: true,
+        data: { bookmarks: [MOCK_BOOKMARK_1, MOCK_BOOKMARK_2] },
+      }
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response)
+
+      const { result } = await setupHook()
+
+      await act(async () => {
+        await result.current.handleTestConnection()
+      })
+
+      expect(result.current.status.type).toBe('success')
+      expect(result.current.status.message).toContain('2 件')
+    })
+
+    it('API がエラーを返した場合にそのメッセージを表示すること', async () => {
+      const errorMessage = 'API Error'
+      const mockResponse = {
+        success: false,
+        error: { message: errorMessage, code: 'ERR_TEST' },
+      }
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      } as Response)
+
+      const { result } = await setupHook()
+
+      await act(async () => {
+        await result.current.handleTestConnection()
+      })
+
+      expect(result.current.status.type).toBe('error')
+      const expectedDetail = `${errorMessage} - ${EXTENSION_MESSAGES.CONNECTION_FAILED_HINT}`
+      expect(result.current.status.message).toBe(
+        EXTENSION_MESSAGES.CONNECTION_FAILED(expectedDetail),
+      )
+    })
+
+    it('タイムアウト発生時に適切なメッセージを表示すること', async () => {
+      const abortError = new Error('Abort')
+      abortError.name = 'AbortError'
+      vi.mocked(fetch).mockRejectedValue(abortError)
+
+      const { result } = await setupHook()
+
+      await act(async () => {
+        await result.current.handleTestConnection()
+      })
+
+      expect(result.current.status.type).toBe('error')
+      expect(result.current.status.message).toBe(
+        EXTENSION_MESSAGES.CONNECTION_FAILED(
+          EXTENSION_MESSAGES.CONNECTION_TIMEOUT,
+        ),
+      )
+    })
+  })
+})

--- a/extension/src/lib/storage.test.ts
+++ b/extension/src/lib/storage.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { storage } from './storage'
+import { STORAGE_KEYS } from '@shared/constants'
+
+describe('extension storage utility', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('get', () => {
+    it('指定されたキーの値をストレージから取得できること', async () => {
+      const mockResult = { [STORAGE_KEYS.API_URL]: 'https://example.com' }
+      vi.mocked(chrome.storage.sync.get).mockImplementation(() =>
+        Promise.resolve(mockResult),
+      )
+
+      const result = await storage.get({ [STORAGE_KEYS.API_URL]: 'default' })
+
+      expect(chrome.storage.sync.get).toHaveBeenCalledWith({
+        [STORAGE_KEYS.API_URL]: 'default',
+      })
+      expect(result).toEqual(mockResult)
+    })
+
+    it('値が設定されていない場合はデフォルト値を返すこと', async () => {
+      const defaultValue = { [STORAGE_KEYS.API_URL]: 'http://localhost:3030' }
+
+      // 値が保存されていない場合に chrome.storage.get が引数のデフォルト値をそのまま返す動作をシミュレート
+      vi.mocked(chrome.storage.sync.get).mockImplementation(
+        async (keys) => keys,
+      )
+
+      const result = await storage.get(defaultValue)
+
+      expect(chrome.storage.sync.get).toHaveBeenCalledWith(defaultValue)
+      expect(result).toEqual(defaultValue)
+    })
+  })
+
+  describe('set', () => {
+    it('値をストレージに保存できること', async () => {
+      const items = { [STORAGE_KEYS.API_URL]: 'https://new-api.com' }
+      vi.mocked(chrome.storage.sync.set).mockResolvedValue(undefined)
+
+      await storage.set(items)
+
+      expect(chrome.storage.sync.set).toHaveBeenCalledWith(items)
+    })
+  })
+})

--- a/extension/test/setup.ts
+++ b/extension/test/setup.ts
@@ -1,0 +1,30 @@
+import { vi } from 'vitest'
+
+/**
+ * Chrome API のモック
+ * Manifest V3 では Promise ベースの API が標準的であるため、
+ * デフォルトで Promise を返すように設定し、テストコードでの型推論を助けます。
+ */
+const chromeMock = {
+  storage: {
+    sync: {
+      get: vi.fn(() => Promise.resolve({})),
+      set: vi.fn(() => Promise.resolve()),
+    },
+    local: {
+      get: vi.fn(() => Promise.resolve({})),
+      set: vi.fn(() => Promise.resolve()),
+    },
+  },
+  runtime: {
+    lastError: null,
+    onInstalled: {
+      addListener: vi.fn(),
+    },
+  },
+  tabs: {
+    query: vi.fn(() => Promise.resolve([])),
+  },
+}
+
+vi.stubGlobal('chrome', chromeMock)

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client", "chrome"],
+    "types": ["vite/client", "chrome", "@testing-library/jest-dom"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "type": "module",
   "overrides": {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -19,6 +19,8 @@ export const UI_MESSAGES = {
   BUTTON_OPEN: '開く',
   BUTTON_DELETE: '削除',
   BUTTON_CLOSE: '閉じる',
+  EXTENSION_TITLE: 'Bookmark Page',
+  EXTENSION_CONTENT: 'Popup Content',
 } as const
 
 export const ARIA_ROLES = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,19 +18,31 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
-    setupFiles: './src/test/setup.ts',
+    setupFiles: ['./src/test/setup.ts', './extension/test/setup.ts'],
     coverage: {
       provider: 'v8',
       clean: true,
       all: true,
       reporter: ['text', 'json', 'html'],
-      include: ['server/**/*.ts', 'shared/**/*.ts', 'src/**/*.ts', 'src/**/*.tsx'],
+      include: [
+        'server/**/*.ts',
+        'shared/**/*.ts',
+        'src/**/*.ts',
+        'src/**/*.tsx',
+        'extension/**/*.ts',
+        'extension/**/*.tsx',
+      ],
       exclude: [
         '**/*.test.ts',
+        '**/*.test.tsx',
         'src/test/**',
+        'extension/test/**',
         'vite.config.ts',
         'server/index.ts',
         'src/main.tsx',
+        'extension/sync-version.ts',
+        'extension/src/main-options.tsx',
+        'extension/src/main-popup.tsx',
       ],
       thresholds: {
         lines: 70,


### PR DESCRIPTION
## 概要
ブラウザ拡張機能の開発において、品質を担保しデグレードを防止するための単体テスト環境を導入しました。これにより、拡張機能側のビジネスロジックに対しても自動テストとカバレッジ測定が可能になります。

## 変更内容
- **テスト環境の構築**:
  - `extension/test/setup.ts` を作成し、`chrome` API (storage, tabs, runtime 等) のグローバルなモックを構築しました。
- **設定の更新**:
  - `vite.config.ts` の `setupFiles` に拡張機能用のセットアップを追加し、`coverage.include` に `extension/` ディレクトリを追加しました。
- **テストの実装**:
  - `extension/src/lib/storage.test.ts`: ストレージの取得・保存・デフォルト値の挙動をテスト。
  - `extension/src/hooks/useOptions.test.ts`: API URL のバリデーション、タイムアウト、接続確認のステータス管理をテスト。
- **ドキュメントとバージョン**:
  - プロジェクトバージョンを `0.11.2` に更新。
  - `README.md` のテストセクションを更新し、拡張機能もテスト対象であることを明記。

## 検証内容
- [x] `npm run test`: 全 133 件のテストがパス。
- [x] `npm run test:coverage`: 拡張機能ディレクトリのカバレッジが正しく測定されていることを確認。
- [x] `npm run extension:build`: 型チェックを含めビルドが成功することを確認。

## 関連Issue
- Fixes #79