### PR TITLE
Issue #109: App.tsx からのロジック抽出とテストの整理

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "type": "module",
   "overrides": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,65 +1,30 @@
-import { useCallback, useState } from 'react'
 import './App.css'
 import { BookmarkList } from './components/BookmarkList'
 import { BookmarkDetail } from './components/BookmarkDetail'
 import { SettingsPanel } from './components/SettingsPanel'
-import { useBookmarks } from './hooks/useBookmarks'
-import { useBookmarkList } from './hooks/useBookmarkList'
-import { useBookmarkActions } from './hooks/useBookmarkActions'
-import { useBookmarkReorder } from './hooks/useBookmarkReorder'
-import { FIELD_LABELS, STORAGE_KEYS } from '@shared/constants'
-import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
+import { useApp } from './hooks/useApp'
+import { FIELD_LABELS } from '@shared/constants'
 
 function App() {
-  const [showSettings, setShowSettings] = useState(false)
-  const { data, isLoading, error } = useBookmarks()
-  const { selectedId, handleRowClick, setSelectedId } = useBookmarkList()
-  const { updateBookmark, deleteBookmark, openBookmark, closeDetail } =
-    useBookmarkActions(setSelectedId)
-  const { handleReorder } = useBookmarkReorder()
-
-  const bookmarks = data?.bookmarks ?? []
-  const selectedBookmark = bookmarks.find((b: Bookmark) => b.id === selectedId)
-
-  const handleDoubleClick = useCallback(
-    (id: BookmarkId, url: string) => {
-      setSelectedId(id)
-      openBookmark(url)
-    },
-    [setSelectedId, openBookmark],
-  )
-
-  const handleUpdate = useCallback(
-    (title: string, url: string) => {
-      if (selectedBookmark) {
-        updateBookmark(selectedBookmark.id, { title, url })
-      }
-    },
-    [selectedBookmark, updateBookmark],
-  )
-
-  const handleDelete = useCallback(() => {
-    if (selectedBookmark) {
-      deleteBookmark(selectedBookmark.id)
-    }
-  }, [selectedBookmark, deleteBookmark])
-
-  const handleOpen = useCallback(() => {
-    if (selectedBookmark) {
-      openBookmark(selectedBookmark.url)
-    }
-  }, [selectedBookmark, openBookmark])
-
-  const handleClose = useCallback(() => {
-    closeDetail()
-  }, [closeDetail])
-
-  const handleSaveSettings = (apiUrl: string) => {
-    localStorage.setItem(STORAGE_KEYS.API_URL, apiUrl)
-    window.location.reload()
-  }
-
-  const currentApiUrl = localStorage.getItem(STORAGE_KEYS.API_URL) || ''
+  const {
+    bookmarks,
+    selectedBookmark,
+    selectedId,
+    isLoading,
+    error,
+    showSettings,
+    currentApiUrl,
+    handleRowClick,
+    handleDoubleClick,
+    handleUpdate,
+    handleDelete,
+    handleOpen,
+    handleClose,
+    handleReorder,
+    handleSaveSettings,
+    toggleSettings,
+    closeSettings,
+  } = useApp()
 
   return (
     <div className="flex flex-col h-full w-full bg-white overflow-hidden">
@@ -67,7 +32,7 @@ function App() {
       <header className="p-2 border-b border-gray-200 flex justify-between items-center bg-gray-50">
         <div className="font-bold text-gray-700 mx-auto">Bookmark Page</div>
         <button
-          onClick={() => setShowSettings(!showSettings)}
+          onClick={toggleSettings}
           className="p-1 rounded-md hover:bg-gray-200 text-gray-600 transition-colors"
           title={FIELD_LABELS.SETTING_TITLE}
         >
@@ -96,7 +61,7 @@ function App() {
 
       {showSettings && (
         <SettingsPanel
-          onClose={() => setShowSettings(false)}
+          onClose={closeSettings}
           onSave={handleSaveSettings}
           currentApiUrl={currentApiUrl}
         />

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { SettingsPanel } from './SettingsPanel'
-import { FIELD_LABELS, COMMON_MESSAGES, VALIDATION_MESSAGES } from '@shared/constants'
+import { FIELD_LABELS, COMMON_MESSAGES } from '@shared/constants'
 import { useExtensionSync } from '../hooks/useExtensionSync'
 
 // useExtensionSync をモック化
@@ -12,7 +12,7 @@ vi.mock('../hooks/useExtensionSync', () => ({
 describe('SettingsPanel', () => {
   const defaultProps = {
     onClose: vi.fn(),
-    onSave: vi.fn(),
+    onSave: vi.fn(() => null), // デフォルトは成功を返す
     currentApiUrl: 'http://localhost:3030',
   }
 
@@ -44,26 +44,24 @@ describe('SettingsPanel', () => {
     expect(input).toHaveValue(validUrl)
   })
 
-  it('有効な URL の場合、保存して適用ボタンで onSave が呼ばれること', () => {
+  it('保存して適用ボタンで onSave が呼ばれること', () => {
     render(<SettingsPanel {...defaultProps} />)
     const saveButton = screen.getByText(FIELD_LABELS.BUTTON_SAVE_AND_APPLY)
     
     fireEvent.click(saveButton)
     expect(defaultProps.onSave).toHaveBeenCalledWith(defaultProps.currentApiUrl)
-    expect(defaultProps.onClose).toHaveBeenCalled()
   })
 
-  it('無効な URL の場合、エラーメッセージを表示し保存を中断すること', () => {
-    render(<SettingsPanel {...defaultProps} />)
-    const input = screen.getByLabelText(FIELD_LABELS.URL)
+  it('onSave がエラーを返した場合、エラーメッセージを表示すること', () => {
+    const errorMsg = 'Validation Error'
+    const onSave = vi.fn(() => errorMsg)
+    render(<SettingsPanel {...defaultProps} onSave={onSave} />)
+    
     const saveButton = screen.getByText(FIELD_LABELS.BUTTON_SAVE_AND_APPLY)
-
-    // 不正なプロトコル
-    fireEvent.change(input, { target: { value: 'ftp://invalid' } })
     fireEvent.click(saveButton)
 
-    expect(screen.getByText(VALIDATION_MESSAGES.URL_INVALID_PROTOCOL)).toBeInTheDocument()
-    expect(defaultProps.onSave).not.toHaveBeenCalled()
+    expect(screen.getByText(errorMsg)).toBeInTheDocument()
+    expect(defaultProps.onClose).not.toHaveBeenCalled()
   })
 
   it('同期ボタンクリック時に拡張機能からの同期が試行されること', async () => {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -3,11 +3,10 @@ import { useExtensionSync } from '../hooks/useExtensionSync'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
 import { COMMON_MESSAGES, FIELD_LABELS, DEFAULT_API_URL } from '@shared/constants'
-import { validateApiUrl, getOrigin } from '@shared/utils/url'
 
 interface SettingsPanelProps {
   onClose: () => void
-  onSave: (apiUrl: string) => void
+  onSave: (apiUrl: string) => string | null
   currentApiUrl: string
 }
 
@@ -35,19 +34,14 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
     setLocalMessage(null)
     setValidationError(null)
 
-    const error = validateApiUrl(url)
+    // フック側のバリデーション付き保存を実行
+    const error = onSave(url)
     if (error) {
       setValidationError(error)
       return
     }
-
-    try {
-      const sanitizedUrl = getOrigin(url)
-      onSave(sanitizedUrl)
-      onClose()
-    } catch {
-      setValidationError(COMMON_MESSAGES.UNEXPECTED_RESPONSE)
-    }
+    
+    // 成功時は親コンポーネント側で閉じられる
   }
 
   return (

--- a/src/hooks/useApp.test.tsx
+++ b/src/hooks/useApp.test.tsx
@@ -1,0 +1,130 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useApp } from './useApp'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import React from 'react'
+import { STORAGE_KEYS, API_PATHS, VALIDATION_MESSAGES } from '@shared/constants'
+import { http, HttpResponse } from 'msw'
+import { server } from '../test/setup'
+import * as urlUtils from '@shared/utils/url'
+
+// QueryClient のセットアップ
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={createTestQueryClient()}>
+    {children}
+  </QueryClientProvider>
+)
+
+describe('useApp Hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    // window.location.reload のモック
+    vi.stubGlobal('window', {
+      ...window,
+      location: { ...window.location, reload: vi.fn() },
+    })
+
+    // MSW のデフォルトハンドラを設定
+    server.use(
+      http.get(API_PATHS.BOOKMARKS, () => {
+        return HttpResponse.json({ success: true, data: { bookmarks: [] } })
+      })
+    )
+  })
+
+  it('初期状態が正しいこと', () => {
+    const { result } = renderHook(() => useApp(), { wrapper })
+
+    expect(result.current.showSettings).toBe(false)
+    expect(result.current.bookmarks).toEqual([])
+    expect(result.current.selectedId).toBeNull()
+    expect(result.current.currentApiUrl).toBe('')
+  })
+
+  it('toggleSettings で showSettings が切り替わること', () => {
+    const { result } = renderHook(() => useApp(), { wrapper })
+
+    act(() => {
+      result.current.toggleSettings()
+    })
+    expect(result.current.showSettings).toBe(true)
+
+    act(() => {
+      result.current.toggleSettings()
+    })
+    expect(result.current.showSettings).toBe(false)
+  })
+
+  describe('handleSaveSettings', () => {
+    it('有効な URL の場合、localStorage が更新され、設定パネルが閉じられ、リロードが呼ばれること', () => {
+      const { result } = renderHook(() => useApp(), { wrapper })
+      
+      // パネルを開いた状態にする
+      act(() => {
+        result.current.toggleSettings()
+      })
+      expect(result.current.showSettings).toBe(true)
+
+      const inputUrl = 'http://localhost:3030/path' // パス付き
+      const expectedUrl = 'http://localhost:3030' // オリジンのみ
+
+      let error: string | null = 'not-called'
+      act(() => {
+        error = result.current.handleSaveSettings(inputUrl)
+      })
+
+      expect(error).toBeNull()
+      expect(localStorage.getItem(STORAGE_KEYS.API_URL)).toBe(expectedUrl)
+      expect(result.current.showSettings).toBe(false) // パネルが閉じていること
+      expect(window.location.reload).toHaveBeenCalled()
+    })
+
+    it('無効な URL の場合、エラーを返し、保存を中断すること（パネルは閉じない）', () => {
+      const { result } = renderHook(() => useApp(), { wrapper })
+      
+      // パネルを開いた状態にする
+      act(() => {
+        result.current.toggleSettings()
+      })
+
+      const invalidUrl = 'ftp://invalid'
+
+      let error: string | null = null
+      act(() => {
+        error = result.current.handleSaveSettings(invalidUrl)
+      })
+
+      expect(error).toBe(VALIDATION_MESSAGES.URL_INVALID_PROTOCOL)
+      expect(localStorage.getItem(STORAGE_KEYS.API_URL)).toBeNull()
+      expect(result.current.showSettings).toBe(true) // パネルは開いたまま
+      expect(window.location.reload).not.toHaveBeenCalled()
+    })
+
+    it('予期せぬ例外が発生した場合、エラーメッセージを返し、ログを出力すること', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      // getOrigin をスパイして例外を投げさせる
+      vi.spyOn(urlUtils, 'getOrigin').mockImplementation(() => {
+        throw new Error('Unexpected error')
+      })
+
+      const { result } = renderHook(() => useApp(), { wrapper })
+      
+      let error: string | null = null
+      act(() => {
+        error = result.current.handleSaveSettings('http://localhost:3030')
+      })
+
+      expect(error).toBe('Unexpected error')
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to save settings:', expect.any(Error))
+      expect(window.location.reload).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/hooks/useApp.ts
+++ b/src/hooks/useApp.ts
@@ -1,0 +1,108 @@
+import { useCallback, useState } from 'react'
+import { STORAGE_KEYS, COMMON_MESSAGES } from '@shared/constants'
+import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
+import { validateApiUrl, getOrigin } from '@shared/utils/url'
+import { useBookmarks } from './useBookmarks'
+import { useBookmarkList } from './useBookmarkList'
+import { useBookmarkActions } from './useBookmarkActions'
+import { useBookmarkReorder } from './useBookmarkReorder'
+
+export const useApp = () => {
+  const [showSettings, setShowSettings] = useState(false)
+  const [currentApiUrl] = useState(() => {
+    return typeof window !== 'undefined'
+      ? localStorage.getItem(STORAGE_KEYS.API_URL) || ''
+      : ''
+  })
+
+  const { data, isLoading, error } = useBookmarks()
+  const { selectedId, handleRowClick, setSelectedId } = useBookmarkList()
+  const { updateBookmark, deleteBookmark, openBookmark, closeDetail } =
+    useBookmarkActions(setSelectedId)
+  const { handleReorder } = useBookmarkReorder()
+
+  const bookmarks = data?.bookmarks ?? []
+  const selectedBookmark = bookmarks.find((b: Bookmark) => b.id === selectedId)
+
+  const handleDoubleClick = useCallback(
+    (id: BookmarkId, url: string) => {
+      setSelectedId(id)
+      openBookmark(url)
+    },
+    [setSelectedId, openBookmark],
+  )
+
+  const handleUpdate = useCallback(
+    (title: string, url: string) => {
+      if (selectedBookmark) {
+        updateBookmark(selectedBookmark.id, { title, url })
+      }
+    },
+    [selectedBookmark, updateBookmark],
+  )
+
+  const handleDelete = useCallback(() => {
+    if (selectedBookmark) {
+      deleteBookmark(selectedBookmark.id)
+    }
+  }, [selectedBookmark, deleteBookmark])
+
+  const handleOpen = useCallback(() => {
+    if (selectedBookmark) {
+      openBookmark(selectedBookmark.url)
+    }
+  }, [selectedBookmark, openBookmark])
+
+  const handleClose = useCallback(() => {
+    closeDetail()
+  }, [closeDetail])
+
+  const handleSaveSettings = useCallback((apiUrl: string) => {
+    const error = validateApiUrl(apiUrl)
+    if (error) {
+      return error
+    }
+
+    try {
+      const sanitizedUrl = getOrigin(apiUrl)
+      localStorage.setItem(STORAGE_KEYS.API_URL, sanitizedUrl)
+      // リロード前に設定パネルを閉じて UI の応答性を高める
+      setShowSettings(false)
+      window.location.reload()
+      return null
+    } catch (err) {
+      console.error('Failed to save settings:', err)
+      return err instanceof Error ? err.message : COMMON_MESSAGES.UNKNOWN_ERROR
+    }
+  }, [])
+
+  const toggleSettings = useCallback(() => {
+    setShowSettings((prev) => !prev)
+  }, [])
+
+  const closeSettings = useCallback(() => {
+    setShowSettings(false)
+  }, [])
+
+  return {
+    // 状態
+    bookmarks,
+    selectedBookmark,
+    selectedId,
+    isLoading,
+    error,
+    showSettings,
+    currentApiUrl,
+    // ハンドラ
+    handleRowClick,
+    handleDoubleClick,
+    handleUpdate,
+    handleDelete,
+    handleOpen,
+    handleClose,
+    handleReorder,
+    handleSaveSettings,
+    toggleSettings,
+    closeSettings,
+  }
+}


### PR DESCRIPTION
## 概要
Issue #109 に基づき、`App.tsx` に集中していた状態管理とイベントハンドリングのロジックをカスタムフック `useApp.ts` に抽出しました。これにより、UI とロジックの分離が進み、将来的な Context 導入（Issue #108）に向けた準備が整いました。

## 変更内容
### 1. カスタムフックの導入
- **src/hooks/useApp.ts**: `App.tsx` で使用していた全てのステート（`showSettings` 等）と、複数のフックを組み合わせた複雑なハンドラを統合しました。

### 2. App.tsx のリファクタリング
- JSX の構造を維持しつつ、ロジックを `useApp` への呼び出しに置き換え、コンポーネントをレイアウト定義に専念させました。

### 3. テストの再編と強化
- **src/App.test.tsx**: 既存の統合テストが引き続きパスすることを確認。
- **src/hooks/useApp.test.tsx**: 新規フックの単体テストを追加し、UI に依存しないロジック（設定トグルやストレージ更新）を厳密に検証可能にしました。

## 確認事項
- [x] `npm run lint` がパスすること
- [x] `npm run type-check` がパスすること
- [x] 全てのテストがパスすること