### PR TITLE
Issue #117: テスト実行時の act 警告およびノイズの排除

### DIFF
--- a/src/hooks/useApp.test.tsx
+++ b/src/hooks/useApp.test.tsx
@@ -65,12 +65,12 @@ describe('useApp Hook', () => {
   it('toggleSettings で showSettings が切り替わること', async () => {
     const { result } = await renderAppHook()
 
-    await act(async () => {
+    act(() => {
       result.current.toggleSettings()
     })
     expect(result.current.showSettings).toBe(true)
 
-    await act(async () => {
+    act(() => {
       result.current.toggleSettings()
     })
     expect(result.current.showSettings).toBe(false)
@@ -79,12 +79,12 @@ describe('useApp Hook', () => {
   it('closeSettings で showSettings が false になること', async () => {
     const { result } = await renderAppHook()
 
-    await act(async () => {
+    act(() => {
       result.current.toggleSettings()
     })
     expect(result.current.showSettings).toBe(true)
 
-    await act(async () => {
+    act(() => {
       result.current.closeSettings()
     })
     expect(result.current.showSettings).toBe(false)
@@ -97,7 +97,7 @@ describe('useApp Hook', () => {
       const expectedUrl = 'http://localhost:4000'
 
       let error: string | null = 'not-called'
-      await act(async () => {
+      act(() => {
         error = result.current.handleSaveSettings(inputUrl)
       })
 
@@ -111,7 +111,7 @@ describe('useApp Hook', () => {
       const invalidUrl = 'ftp://invalid'
 
       let error: string | null = null
-      await act(async () => {
+      act(() => {
         error = result.current.handleSaveSettings(invalidUrl)
       })
 
@@ -128,7 +128,7 @@ describe('useApp Hook', () => {
       const { result } = await renderAppHook()
 
       let error: string | null = null
-      await act(async () => {
+      act(() => {
         error = result.current.handleSaveSettings('http://localhost:3030')
       })
 
@@ -148,7 +148,7 @@ describe('useApp Hook', () => {
       const { result } = await renderAppHook()
 
       let error: string | null = null
-      await act(async () => {
+      act(() => {
         error = result.current.handleSaveSettings('http://localhost:3030')
       })
 
@@ -160,7 +160,7 @@ describe('useApp Hook', () => {
     it('handleRowClick でブックマークが選択されること', async () => {
       const { result } = await renderAppHook()
 
-      await act(async () => {
+      act(() => {
         result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
 
@@ -196,7 +196,7 @@ describe('useApp Hook', () => {
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
       const { result } = await renderAppHook()
 
-      await act(async () => {
+      act(() => {
         result.current.handleDoubleClick(
           MOCK_BOOKMARK_1.id,
           MOCK_BOOKMARK_1.url,
@@ -225,7 +225,7 @@ describe('useApp Hook', () => {
 
       const { result } = await renderAppHook()
 
-      await act(async () => {
+      act(() => {
         result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
 

--- a/src/hooks/useApp.test.tsx
+++ b/src/hooks/useApp.test.tsx
@@ -1,18 +1,23 @@
-import { act } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useApp } from './useApp'
-import { STORAGE_KEYS, VALIDATION_MESSAGES, COMMON_MESSAGES } from '@shared/constants'
 import { http, HttpResponse } from 'msw'
-import { server } from '../test/setup'
-import { renderHook } from '../test/utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  COMMON_MESSAGES,
+  STORAGE_KEYS,
+  VALIDATION_MESSAGES,
+} from '@shared/constants'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 import * as urlUtils from '@shared/utils/url'
+
+import { server } from '../test/setup'
+import { act, renderHook, waitFor } from '../test/utils'
+import { useApp } from './useApp'
 
 describe('useApp Hook', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
-    
+
     // location.reload をモック
     Object.defineProperty(window, 'location', {
       writable: true,
@@ -23,14 +28,17 @@ describe('useApp Hook', () => {
     // MSW のデフォルトハンドラを設定
     server.use(
       http.get('*/api/bookmarks', () => {
-        return HttpResponse.json({ success: true, data: { bookmarks: [MOCK_BOOKMARK_1] } })
+        return HttpResponse.json({
+          success: true,
+          data: { bookmarks: [MOCK_BOOKMARK_1] },
+        })
       }),
       http.patch('*/api/bookmarks/:id', () => {
         return HttpResponse.json({ success: true, data: MOCK_BOOKMARK_1 })
       }),
       http.delete('*/api/bookmarks/:id', () => {
         return new HttpResponse(null, { status: 204 })
-      })
+      }),
     )
   })
 
@@ -39,7 +47,9 @@ describe('useApp Hook', () => {
    */
   const renderAppHook = async (initialUrl?: string) => {
     const renderResult = renderHook(() => useApp(), { initialUrl })
-    await vi.waitFor(() => {
+
+    // isLoading が false になるまで待機 (act 内で実行)
+    await waitFor(() => {
       expect(renderResult.result.current.isLoading).toBe(false)
     })
     return renderResult
@@ -69,10 +79,14 @@ describe('useApp Hook', () => {
   it('closeSettings で showSettings が false になること', async () => {
     const { result } = await renderAppHook()
 
-    await act(async () => { result.current.toggleSettings() })
+    await act(async () => {
+      result.current.toggleSettings()
+    })
     expect(result.current.showSettings).toBe(true)
 
-    await act(async () => { result.current.closeSettings() })
+    await act(async () => {
+      result.current.closeSettings()
+    })
     expect(result.current.showSettings).toBe(false)
   })
 
@@ -112,14 +126,17 @@ describe('useApp Hook', () => {
       })
 
       const { result } = await renderAppHook()
-      
+
       let error: string | null = null
       await act(async () => {
         error = result.current.handleSaveSettings('http://localhost:3030')
       })
 
       expect(error).toBe('Unexpected error')
-      expect(consoleSpy).toHaveBeenCalledWith('Failed to save settings:', expect.any(Error))
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to save settings:',
+        expect.any(Error),
+      )
     })
 
     it('Error 以外の例外が発生した場合、共通エラーメッセージを返すこと', async () => {
@@ -129,7 +146,7 @@ describe('useApp Hook', () => {
       })
 
       const { result } = await renderAppHook()
-      
+
       let error: string | null = null
       await act(async () => {
         error = result.current.handleSaveSettings('http://localhost:3030')
@@ -142,7 +159,7 @@ describe('useApp Hook', () => {
   describe('ブックマーク操作の検証', () => {
     it('handleRowClick でブックマークが選択されること', async () => {
       const { result } = await renderAppHook()
-      
+
       await act(async () => {
         result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
@@ -157,11 +174,11 @@ describe('useApp Hook', () => {
         http.patch('*/api/bookmarks/:id', () => {
           patchCalled = true
           return HttpResponse.json({ success: true, data: MOCK_BOOKMARK_1 })
-        })
+        }),
       )
 
       const { result } = await renderAppHook()
-      
+
       await act(async () => {
         result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
@@ -180,28 +197,37 @@ describe('useApp Hook', () => {
       const { result } = await renderAppHook()
 
       await act(async () => {
-        result.current.handleDoubleClick(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_1.url)
+        result.current.handleDoubleClick(
+          MOCK_BOOKMARK_1.id,
+          MOCK_BOOKMARK_1.url,
+        )
       })
 
       expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
-      expect(openSpy).toHaveBeenCalledWith(MOCK_BOOKMARK_1.url, '_blank', 'noopener,noreferrer')
+      expect(openSpy).toHaveBeenCalledWith(
+        MOCK_BOOKMARK_1.url,
+        '_blank',
+        'noopener,noreferrer',
+      )
     })
 
     it('handleDelete, handleOpen, handleClose が正しく動作すること', async () => {
       let deleteCalled = false
       vi.spyOn(window, 'confirm').mockReturnValue(true)
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
-      
+
       server.use(
         http.delete('*/api/bookmarks/:id', () => {
           deleteCalled = true
           return new HttpResponse(null, { status: 204 })
-        })
+        }),
       )
 
       const { result } = await renderAppHook()
-      
-      await act(async () => { result.current.handleRowClick(MOCK_BOOKMARK_1.id) })
+
+      await act(async () => {
+        result.current.handleRowClick(MOCK_BOOKMARK_1.id)
+      })
 
       await act(async () => {
         result.current.handleOpen()


### PR DESCRIPTION
## 概要
Issue #117 に基づき、`npm run test` 実行時に大量に発生していた `act(...)` 警告（計36件以上）を解消しました。これにより、テストログがクリーンになり、本来のテスト結果やデバッグ情報の視認性が向上しました。

## 変更内容
### 1. useApp.test.tsx の修正
- **非同期の状態更新の捕捉**: `renderHook` 直後の初期データ取得がテストサイクル外で発生していたため、これらを一つの `act` ブロック内で確実に待機する `renderAppHook` ヘルパーへ刷新しました。
- **イベントハンドラの適切なラップ**: 全ての操作（保存、更新、削除等）を `act` で包み、同期/非同期の種別に応じて適切に待機するように調整しました。

## 確認事項
- [x] `npm run lint` がパスすること
- [x] `npm run type-check` がパスすること
- [x] 全てのテストがパスし、`stderr` に `act` 警告が出力されないことを確認