### PR TITLE
Issue #114: プロジェクト全体のマジックストリングの定数化

### DIFF
--- a/extension/src/Options.test.tsx
+++ b/extension/src/Options.test.tsx
@@ -5,6 +5,7 @@ import { Options } from './Options'
 import {
   DEFAULT_API_URL,
   FIELD_LABELS,
+  UI_STATUS,
 } from '@shared/constants'
 import { useOptions } from './hooks/useOptions'
 
@@ -15,7 +16,7 @@ describe('Options Component', () => {
   const baseMockUseOptions = {
     apiUrl: DEFAULT_API_URL,
     setApiUrl: vi.fn(),
-    status: { type: 'idle' as const },
+    status: { type: UI_STATUS.IDLE, message: '' },
     handleSave: vi.fn(),
     handleTestConnection: vi.fn(),
   }
@@ -66,7 +67,7 @@ describe('Options Component', () => {
     const message = 'Test Status Message'
     vi.mocked(useOptions).mockReturnValue({
       ...baseMockUseOptions,
-      status: { type: 'success', message },
+      status: { type: UI_STATUS.SUCCESS, message },
     })
 
     render(<Options />)
@@ -79,7 +80,7 @@ describe('Options Component', () => {
     const message = 'Error Occurred'
     vi.mocked(useOptions).mockReturnValue({
       ...baseMockUseOptions,
-      status: { type: 'error', message },
+      status: { type: UI_STATUS.ERROR, message },
     })
 
     render(<Options />)

--- a/extension/src/Options.tsx
+++ b/extension/src/Options.tsx
@@ -1,21 +1,15 @@
 import {
-  COMMON_MESSAGES,
-  FIELD_LABELS,
-  DEFAULT_API_URL,
-  UI_STATUS,
   ARIA_ROLES,
+  COMMON_MESSAGES,
+  DEFAULT_API_URL,
+  FIELD_LABELS,
+  STATUS_STYLES,
+  UI_STATUS,
 } from '@shared/constants'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
 
 import { useOptions } from './hooks/useOptions'
-
-const statusStyles: Record<string, string> = {
-  [UI_STATUS.IDLE]: '',
-  [UI_STATUS.LOADING]: 'bg-blue-100 text-blue-800',
-  [UI_STATUS.SUCCESS]: 'bg-green-100 text-green-800',
-  [UI_STATUS.ERROR]: 'bg-red-100 text-red-800',
-}
 
 export const Options = () => {
   const { apiUrl, setApiUrl, status, handleSave, handleTestConnection } =
@@ -61,8 +55,12 @@ export const Options = () => {
 
         {status.type !== UI_STATUS.IDLE && (
           <div
-            role={status.type === UI_STATUS.ERROR ? ARIA_ROLES.ALERT : ARIA_ROLES.STATUS}
-            className={`ml-14 p-3 rounded-md text-sm ${statusStyles[status.type]}`}
+            role={
+              status.type === UI_STATUS.ERROR
+                ? ARIA_ROLES.ALERT
+                : ARIA_ROLES.STATUS
+            }
+            className={`ml-14 p-3 rounded-md text-sm ${STATUS_STYLES[status.type]}`}
           >
             {status.message}
           </div>

--- a/extension/src/Options.tsx
+++ b/extension/src/Options.tsx
@@ -2,17 +2,19 @@ import {
   COMMON_MESSAGES,
   FIELD_LABELS,
   DEFAULT_API_URL,
+  UI_STATUS,
+  ARIA_ROLES,
 } from '@shared/constants'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
 
-import { type StatusType, useOptions } from './hooks/useOptions'
+import { useOptions } from './hooks/useOptions'
 
-const statusStyles: Record<StatusType, string> = {
-  idle: '',
-  loading: 'bg-blue-100 text-blue-800',
-  success: 'bg-green-100 text-green-800',
-  error: 'bg-red-100 text-red-800',
+const statusStyles: Record<string, string> = {
+  [UI_STATUS.IDLE]: '',
+  [UI_STATUS.LOADING]: 'bg-blue-100 text-blue-800',
+  [UI_STATUS.SUCCESS]: 'bg-green-100 text-green-800',
+  [UI_STATUS.ERROR]: 'bg-red-100 text-red-800',
 }
 
 export const Options = () => {
@@ -43,7 +45,7 @@ export const Options = () => {
           <Button
             onClick={handleSave}
             size="medium"
-            disabled={status.type === 'loading'}
+            disabled={status.type === UI_STATUS.LOADING}
           >
             {FIELD_LABELS.BUTTON_SAVE}
           </Button>
@@ -51,15 +53,15 @@ export const Options = () => {
             onClick={handleTestConnection}
             variant="secondary"
             size="medium"
-            disabled={status.type === 'loading'}
+            disabled={status.type === UI_STATUS.LOADING}
           >
             {FIELD_LABELS.BUTTON_TEST}
           </Button>
         </div>
 
-        {status.type !== 'idle' && (
+        {status.type !== UI_STATUS.IDLE && (
           <div
-            role={status.type === 'error' ? 'alert' : 'status'}
+            role={status.type === UI_STATUS.ERROR ? ARIA_ROLES.ALERT : ARIA_ROLES.STATUS}
             className={`ml-14 p-3 rounded-md text-sm ${statusStyles[status.type]}`}
           >
             {status.message}

--- a/extension/src/Popup.test.tsx
+++ b/extension/src/Popup.test.tsx
@@ -6,6 +6,7 @@ import { usePopup } from './hooks/usePopup'
 import {
   COMMON_MESSAGES,
   FIELD_LABELS,
+  UI_STATUS,
 } from '@shared/constants'
 import { VALID_URLS } from '@shared/test/fixtures'
 
@@ -18,7 +19,7 @@ describe('Popup Component', () => {
     setTitle: vi.fn(),
     url: VALID_URLS.HTTPS,
     setUrl: vi.fn(),
-    status: { type: 'idle' as const },
+    status: { type: UI_STATUS.IDLE, message: '' },
     handleSave: vi.fn(),
   }
 
@@ -69,7 +70,7 @@ describe('Popup Component', () => {
     const loadingMessage = COMMON_MESSAGES.SAVING
     vi.mocked(usePopup).mockReturnValue({
       ...baseMockUsePopup,
-      status: { type: 'loading', message: loadingMessage },
+      status: { type: UI_STATUS.LOADING, message: loadingMessage },
     })
 
     render(<Popup />)
@@ -84,7 +85,7 @@ describe('Popup Component', () => {
     const errorMessage = 'Test Error Message'
     vi.mocked(usePopup).mockReturnValue({
       ...baseMockUsePopup,
-      status: { type: 'error', message: errorMessage },
+      status: { type: UI_STATUS.ERROR, message: errorMessage },
     })
 
     render(<Popup />)
@@ -97,7 +98,7 @@ describe('Popup Component', () => {
     const successMessage = 'Test Success Message'
     vi.mocked(usePopup).mockReturnValue({
       ...baseMockUsePopup,
-      status: { type: 'success', message: successMessage },
+      status: { type: UI_STATUS.SUCCESS, message: successMessage },
     })
 
     render(<Popup />)

--- a/extension/src/Popup.tsx
+++ b/extension/src/Popup.tsx
@@ -3,6 +3,7 @@ import {
   COMMON_MESSAGES,
   EXTENSION_CONSTANTS,
   FIELD_LABELS,
+  PLACEHOLDERS,
   STATUS_STYLES,
   UI_STATUS,
 } from '@shared/constants'
@@ -26,7 +27,7 @@ export const Popup = () => {
           label={FIELD_LABELS.TITLE}
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          placeholder="タイトルを入力"
+          placeholder={PLACEHOLDERS.TITLE}
         />
 
         <InputField
@@ -34,7 +35,7 @@ export const Popup = () => {
           label={FIELD_LABELS.URL}
           value={url}
           onChange={(e) => setUrl(e.target.value)}
-          placeholder="https://..."
+          placeholder={PLACEHOLDERS.URL}
           className="font-mono"
         />
 

--- a/extension/src/Popup.tsx
+++ b/extension/src/Popup.tsx
@@ -2,17 +2,19 @@ import {
   COMMON_MESSAGES,
   EXTENSION_CONSTANTS,
   FIELD_LABELS,
+  UI_STATUS,
+  ARIA_ROLES,
 } from '@shared/constants'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
 
-import { type PopupStatusType, usePopup } from './hooks/usePopup'
+import { usePopup } from './hooks/usePopup'
 
-const statusStyles: Record<PopupStatusType, string> = {
-  idle: '',
-  loading: 'bg-blue-50 text-blue-700 border-blue-200',
-  success: 'bg-green-50 text-green-700 border-green-200',
-  error: 'bg-red-50 text-red-700 border-red-200',
+const statusStyles: Record<string, string> = {
+  [UI_STATUS.IDLE]: '',
+  [UI_STATUS.LOADING]: 'bg-blue-50 text-blue-700 border-blue-200',
+  [UI_STATUS.SUCCESS]: 'bg-green-50 text-green-700 border-green-200',
+  [UI_STATUS.ERROR]: 'bg-red-50 text-red-700 border-red-200',
 }
 
 export const Popup = () => {
@@ -46,17 +48,17 @@ export const Popup = () => {
           <Button
             onClick={handleSave}
             size="medium"
-            disabled={status.type === 'loading' || status.type === 'success'}
+            disabled={status.type === UI_STATUS.LOADING || status.type === UI_STATUS.SUCCESS}
           >
-            {status.type === 'loading'
+            {status.type === UI_STATUS.LOADING
               ? COMMON_MESSAGES.SAVING
               : FIELD_LABELS.BUTTON_SAVE}
           </Button>
         </div>
 
-        {status.type !== 'idle' && (
+        {status.type !== UI_STATUS.IDLE && (
           <div
-            role={status.type === 'error' ? 'alert' : 'status'}
+            role={status.type === UI_STATUS.ERROR ? ARIA_ROLES.ALERT : ARIA_ROLES.STATUS}
             className={`p-3 rounded-md text-sm border ${statusStyles[status.type]}`}
           >
             {status.message}

--- a/extension/src/Popup.tsx
+++ b/extension/src/Popup.tsx
@@ -1,21 +1,15 @@
 import {
+  ARIA_ROLES,
   COMMON_MESSAGES,
   EXTENSION_CONSTANTS,
   FIELD_LABELS,
+  STATUS_STYLES,
   UI_STATUS,
-  ARIA_ROLES,
 } from '@shared/constants'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
 
 import { usePopup } from './hooks/usePopup'
-
-const statusStyles: Record<string, string> = {
-  [UI_STATUS.IDLE]: '',
-  [UI_STATUS.LOADING]: 'bg-blue-50 text-blue-700 border-blue-200',
-  [UI_STATUS.SUCCESS]: 'bg-green-50 text-green-700 border-green-200',
-  [UI_STATUS.ERROR]: 'bg-red-50 text-red-700 border-red-200',
-}
 
 export const Popup = () => {
   const { title, setTitle, url, setUrl, status, handleSave } = usePopup()
@@ -48,7 +42,10 @@ export const Popup = () => {
           <Button
             onClick={handleSave}
             size="medium"
-            disabled={status.type === UI_STATUS.LOADING || status.type === UI_STATUS.SUCCESS}
+            disabled={
+              status.type === UI_STATUS.LOADING ||
+              status.type === UI_STATUS.SUCCESS
+            }
           >
             {status.type === UI_STATUS.LOADING
               ? COMMON_MESSAGES.SAVING
@@ -58,8 +55,12 @@ export const Popup = () => {
 
         {status.type !== UI_STATUS.IDLE && (
           <div
-            role={status.type === UI_STATUS.ERROR ? ARIA_ROLES.ALERT : ARIA_ROLES.STATUS}
-            className={`p-3 rounded-md text-sm border ${statusStyles[status.type]}`}
+            role={
+              status.type === UI_STATUS.ERROR
+                ? ARIA_ROLES.ALERT
+                : ARIA_ROLES.STATUS
+            }
+            className={`p-3 rounded-md text-sm border ${STATUS_STYLES[status.type]}`}
           >
             {status.message}
           </div>

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -5,6 +5,7 @@ import {
   EXTENSION_MESSAGE_TYPES,
   STORAGE_KEYS,
   LOG_MESSAGES,
+  ALLOWED_ORIGINS,
 } from '@shared/constants'
 
 describe('background service worker', () => {
@@ -59,23 +60,24 @@ describe('background service worker', () => {
   describe('アイコン状態更新 (updateIconStatus)', () => {
     const mockApiUrl = 'http://localhost:3030'
     const mockBookmarks = {
-      bookmarks: [{ id: '1', title: 'Example', url: 'https://example.com' }],
+      bookmarks: [
+        { id: '1', title: 'Example', url: 'https://example.com' }
+      ]
     }
 
     beforeEach(() => {
-      vi.mocked(chrome.storage.sync.get).mockImplementation(() => {
+      // chrome.storage.sync.get のモック
+      vi.mocked(chrome.storage.sync.get).mockImplementation((_keys, callback) => {
         const data = { [STORAGE_KEYS.API_URL]: mockApiUrl }
+        if (callback) (callback as unknown as (data: unknown) => void)(data)
         return Promise.resolve(data)
       })
 
       // fetch のグローバルモック
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve({ success: true, data: mockBookmarks }),
-        }),
-      )
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true, data: mockBookmarks })
+      }))
     })
 
     it('未登録の URL の場合にデフォルトアイコンをセットすること', async () => {
@@ -83,15 +85,12 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, {
-        url: 'https://new-site.com',
-        title: 'New',
-      } as chrome.tabs.Tab)
+      await handler(1, { status: 'complete' }, { url: 'https://new-site.com', title: 'New' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
           tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.NONE],
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.NONE]
         })
       })
     })
@@ -101,15 +100,27 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, {
-        url: 'https://example.com',
-        title: 'Example',
-      } as chrome.tabs.Tab)
+      await handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
           tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.REGISTERED],
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.REGISTERED]
+        })
+      })
+    })
+
+    it('登録済みだがタイトル不一致の場合に MODIFIED アイコンをセットすること', async () => {
+      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
+      await import('./background')
+
+      const handler = onUpdatedMock.mock.calls[0][0]
+      await handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Modified' } as chrome.tabs.Tab)
+
+      await vi.waitFor(() => {
+        expect(chrome.action.setIcon).toHaveBeenCalledWith({
+          tabId: 1,
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.MODIFIED]
         })
       })
     })
@@ -122,37 +133,43 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, {
-        url: 'https://example.com',
-        title: 'Example',
-      } as chrome.tabs.Tab)
+      await handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
           tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.ERROR],
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.ERROR]
         })
       })
     })
 
     it('API エラー（接続不可）の場合に ERROR アイコンをセットすること', async () => {
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockRejectedValue(new Error('Network Error')),
-      )
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network Error')))
       const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, {
-        url: 'https://example.com',
-        title: 'Example',
-      } as chrome.tabs.Tab)
+      await handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
           tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.ERROR],
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.ERROR]
+        })
+      })
+    })
+
+    it('http 以外のプロトコルの場合に NONE アイコンをセットすること', async () => {
+      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
+      await import('./background')
+
+      const handler = onUpdatedMock.mock.calls[0][0]
+      await handler(1, { status: 'complete' }, { url: 'chrome://settings', title: 'Settings' } as chrome.tabs.Tab)
+
+      await vi.waitFor(() => {
+        expect(chrome.action.setIcon).toHaveBeenCalledWith({
+          tabId: 1,
+          path: EXTENSION_ICONS[BOOKMARK_STATUS.NONE]
         })
       })
     })
@@ -162,17 +179,12 @@ describe('background service worker', () => {
     it('API URL 設定変更時にキャッシュをクリアし全タブのアイコンを更新すること', async () => {
       const onChangedMock = vi.mocked(chrome.storage.onChanged.addListener)
       vi.mocked(chrome.tabs.query).mockImplementation((_query, callback) => {
-        callback([
-          { id: 1, url: 'https://example.com', title: 'Example' },
-        ] as chrome.tabs.Tab[])
+        (callback as unknown as (tabs: unknown[]) => void)([{ id: 1, url: 'https://example.com', title: 'Example' }])
       })
       await import('./background')
 
       const handler = onChangedMock.mock.calls[0][0]
-      handler(
-        { [STORAGE_KEYS.API_URL]: { newValue: 'http://new-api.com' } },
-        'sync',
-      )
+      handler({ [STORAGE_KEYS.API_URL]: { newValue: 'http://new-api.com' } }, 'sync')
 
       await vi.waitFor(() => {
         expect(chrome.tabs.query).toHaveBeenCalled()
@@ -181,19 +193,14 @@ describe('background service worker', () => {
 
     it('内部メッセージ INVALIDATE_CACHE でアイコンを再更新すること', async () => {
       const onMessageMock = vi.mocked(chrome.runtime.onMessage.addListener)
+      // query の戻り値を空にしないことで内部パスをカバー
       vi.mocked(chrome.tabs.query).mockImplementation((_query, callback) => {
-        callback([
-          { id: 1, url: 'https://example.com', title: 'Example' },
-        ] as chrome.tabs.Tab[])
+        (callback as unknown as (tabs: unknown[]) => void)([{ id: 1, url: 'https://example.com', title: 'Example' }])
       })
       await import('./background')
 
       const handler = onMessageMock.mock.calls[0][0]
-      handler(
-        { type: 'INVALIDATE_CACHE' },
-        { origin: 'http://localhost:5173' },
-        vi.fn(),
-      )
+      handler({ type: EXTENSION_MESSAGE_TYPES.INVALIDATE_CACHE }, { origin: ALLOWED_ORIGINS[0] }, vi.fn())
 
       await vi.waitFor(() => {
         expect(chrome.tabs.query).toHaveBeenCalled()
@@ -201,9 +208,8 @@ describe('background service worker', () => {
     })
 
     it('不許可拡張機能 (sender.id あり) をブロックすること', async () => {
-      const addListenerMock = vi.mocked(
-        chrome.runtime.onMessageExternal.addListener,
-      )
+      const addListenerMock = vi.mocked(chrome.runtime.onMessageExternal.addListener)
+      const consoleSpy = vi.mocked(console.warn)
       await import('./background')
 
       const messageHandler = addListenerMock.mock.calls[0][0]
@@ -211,17 +217,17 @@ describe('background service worker', () => {
 
       const result = messageHandler(
         { type: EXTENSION_MESSAGE_TYPES.GET_API_CONFIG },
-        { id: 'other-extension-id', origin: 'http://localhost:5173' },
-        sendResponse,
+        { id: 'other-extension-id', origin: ALLOWED_ORIGINS[0] },
+        sendResponse
       )
 
       expect(result).toBe(false)
+      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.UNAUTHORIZED_EXTENSION_MESSAGE, 'other-extension-id')
     })
 
     it('不許可オリジンをブロックすること', async () => {
-      const addListenerMock = vi.mocked(
-        chrome.runtime.onMessageExternal.addListener,
-      )
+      const addListenerMock = vi.mocked(chrome.runtime.onMessageExternal.addListener)
+      const consoleSpy = vi.mocked(console.warn)
       await import('./background')
 
       const messageHandler = addListenerMock.mock.calls[0][0]
@@ -230,10 +236,11 @@ describe('background service worker', () => {
       const result = messageHandler(
         { type: EXTENSION_MESSAGE_TYPES.GET_API_CONFIG },
         { origin: 'http://malicious.com' },
-        sendResponse,
+        sendResponse
       )
 
       expect(result).toBe(false)
+      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.UNAUTHORIZED_ORIGIN_MESSAGE, 'http://malicious.com')
     })
   })
 })

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -5,6 +5,7 @@ import {
   EXTENSION_MESSAGE_TYPES,
   STORAGE_KEYS,
   LOG_MESSAGES,
+  ALLOWED_ORIGINS,
 } from '@shared/constants'
 import type { Bookmark, BookmarksResponse } from '@shared/schemas/bookmark'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
@@ -55,7 +56,7 @@ const updateIconStatus = async (
     // 2. セキュリティバリデーション (Security fix)
     const urlError = validateApiUrl(apiUrl)
     if (urlError) {
-      console.warn('Invalid API URL in background:', urlError)
+      console.warn(LOG_MESSAGES.INVALID_STORAGE_URL_BACKGROUND, urlError)
       chrome.action.setIcon({
         tabId,
         path: EXTENSION_ICONS[BOOKMARK_STATUS.ERROR],
@@ -94,7 +95,7 @@ const updateIconStatus = async (
       path: EXTENSION_ICONS[BOOKMARK_STATUS[status]],
     })
   } catch (err) {
-    console.error('Failed to update icon status:', err)
+    console.error(LOG_MESSAGES.ICON_STATUS_UPDATE_FAILED, err)
     chrome.action.setIcon({
       tabId,
       path: EXTENSION_ICONS[BOOKMARK_STATUS.ERROR],
@@ -152,17 +153,17 @@ chrome.storage.onChanged.addListener((changes, area) => {
  */
 chrome.runtime.onMessageExternal.addListener(
   (message, sender, sendResponse) => {
-    // 許可されたオリジンリスト
-    const allowedOrigins = ['http://localhost:5173']
+    // 許可されたオリジンリストを定数から取得
+    const allowedOrigins: readonly string[] = ALLOWED_ORIGINS
 
-    // 他の拡張機能からのメッセージを拒否（sender.id がある場合は外部拡張）
+    // 他の拡張機能からのメッセージを拒否
     if (sender.id) {
-      console.warn('Blocked message from unauthorized extension:', sender.id)
+      console.warn(LOG_MESSAGES.UNAUTHORIZED_EXTENSION_MESSAGE, sender.id)
       return false
     }
 
     if (sender.origin && !allowedOrigins.includes(sender.origin)) {
-      console.warn('Blocked unauthorized message from origin:', sender.origin)
+      console.warn(LOG_MESSAGES.UNAUTHORIZED_ORIGIN_MESSAGE, sender.origin)
       return false
     }
 
@@ -183,7 +184,7 @@ chrome.runtime.onMessageExternal.addListener(
  * 内部メッセージ（キャッシュ無効化）を処理
  */
 chrome.runtime.onMessage.addListener((message) => {
-  if (message.type === 'INVALIDATE_CACHE') {
+  if (message.type === EXTENSION_MESSAGE_TYPES.INVALIDATE_CACHE) {
     queryClient.invalidateQueries({ queryKey: ['bookmarks'] })
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const tab = tabs[0]

--- a/extension/src/hooks/useOptions.test.ts
+++ b/extension/src/hooks/useOptions.test.ts
@@ -8,6 +8,7 @@ import {
   LOG_MESSAGES,
   STORAGE_KEYS,
   VALIDATION_MESSAGES,
+  UI_STATUS,
 } from '@shared/constants'
 import {
   MOCK_BOOKMARK_1,
@@ -66,7 +67,7 @@ describe('useOptions Hook', () => {
     const { result } = renderHook(() => useOptions())
 
     await waitFor(() => {
-      expect(result.current.status.type).toBe('error')
+      expect(result.current.status.type).toBe(UI_STATUS.ERROR)
       expect(result.current.status.message).toBe(
         EXTENSION_MESSAGES.SETTINGS_LOAD_FAILED,
       )
@@ -93,7 +94,7 @@ describe('useOptions Hook', () => {
       expect(chrome.storage.sync.set).toHaveBeenCalledWith({
         [STORAGE_KEYS.API_URL]: newUrl,
       })
-      expect(result.current.status.type).toBe('success')
+      expect(result.current.status.type).toBe(UI_STATUS.SUCCESS)
       expect(result.current.status.message).toBe(
         EXTENSION_MESSAGES.SETTINGS_SAVED,
       )
@@ -114,7 +115,7 @@ describe('useOptions Hook', () => {
       })
 
       expect(chrome.storage.sync.set).not.toHaveBeenCalled()
-      expect(result.current.status.type).toBe('error')
+      expect(result.current.status.type).toBe(UI_STATUS.ERROR)
       expect(result.current.status.message).toBe(
         VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
       )
@@ -131,7 +132,7 @@ describe('useOptions Hook', () => {
         await result.current.handleSave()
       })
 
-      expect(result.current.status.type).toBe('error')
+      expect(result.current.status.type).toBe(UI_STATUS.ERROR)
       expect(result.current.status.message).toBe(
         EXTENSION_MESSAGES.SETTINGS_SAVE_FAILED,
       )
@@ -164,7 +165,7 @@ describe('useOptions Hook', () => {
         await result.current.handleTestConnection()
       })
 
-      expect(result.current.status.type).toBe('success')
+      expect(result.current.status.type).toBe(UI_STATUS.SUCCESS)
       expect(result.current.status.message).toContain('2 件')
       expect(consoleSpy).not.toHaveBeenCalled()
     })
@@ -184,7 +185,7 @@ describe('useOptions Hook', () => {
       })
 
       expect(fetch).not.toHaveBeenCalled()
-      expect(result.current.status.type).toBe('error')
+      expect(result.current.status.type).toBe(UI_STATUS.ERROR)
       expect(result.current.status.message).toBe(
         VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
       )
@@ -267,7 +268,7 @@ describe('useOptions Hook', () => {
           await result.current.handleTestConnection()
         })
 
-        expect(result.current.status.type).toBe('error')
+        expect(result.current.status.type).toBe(UI_STATUS.ERROR)
         if (expectedMessage) {
           expect(result.current.status.message).toBe(
             EXTENSION_MESSAGES.CONNECTION_FAILED(expectedMessage as string),

--- a/extension/src/hooks/useOptions.ts
+++ b/extension/src/hooks/useOptions.ts
@@ -8,16 +8,11 @@ import {
   STORAGE_KEYS,
   DEFAULT_API_URL,
   EXTENSION_CONSTANTS,
+  UI_STATUS,
+  type StatusInfo,
 } from '@shared/constants'
 import { bookmarksResponseSchema } from '@shared/schemas/bookmark'
 import { validateApiUrl, getOrigin } from '@shared/utils/url'
-
-export type StatusType = 'idle' | 'loading' | 'success' | 'error'
-
-export interface StatusState {
-  type: StatusType
-  message?: string
-}
 
 const DEFAULT_SETTINGS = {
   [STORAGE_KEYS.API_URL]: DEFAULT_API_URL,
@@ -28,7 +23,7 @@ const apiResponseSchema = bookmarksResponseSchema
 
 export const useOptions = () => {
   const [apiUrl, setApiUrl] = useState('')
-  const [status, setStatus] = useState<StatusState>({ type: 'idle' })
+  const [status, setStatus] = useState<StatusInfo>({ type: UI_STATUS.IDLE, message: '' })
 
   // 初期値の読み込み
   useEffect(() => {
@@ -48,7 +43,7 @@ export const useOptions = () => {
         console.error(LOG_MESSAGES.EXTENSION_SETTING_LOAD_FAILED, err)
         if (isMounted) {
           setStatus({
-            type: 'error',
+            type: UI_STATUS.ERROR,
             message: EXTENSION_MESSAGES.SETTINGS_LOAD_FAILED,
           })
         }
@@ -63,7 +58,7 @@ export const useOptions = () => {
   const runValidation = useCallback((): boolean => {
     const errorMessage = validateApiUrl(apiUrl)
     if (errorMessage) {
-      setStatus({ type: 'error', message: errorMessage })
+      setStatus({ type: UI_STATUS.ERROR, message: errorMessage })
       return false
     }
     return true
@@ -72,16 +67,16 @@ export const useOptions = () => {
   const handleSave = useCallback(async () => {
     if (!runValidation()) return
 
-    setStatus({ type: 'loading', message: COMMON_MESSAGES.SAVING })
+    setStatus({ type: UI_STATUS.LOADING, message: COMMON_MESSAGES.SAVING })
     try {
       const sanitizedUrl = getOrigin(apiUrl)
       await storage.set({ [STORAGE_KEYS.API_URL]: sanitizedUrl })
       setApiUrl(sanitizedUrl)
-      setStatus({ type: 'success', message: EXTENSION_MESSAGES.SETTINGS_SAVED })
+      setStatus({ type: UI_STATUS.SUCCESS, message: EXTENSION_MESSAGES.SETTINGS_SAVED })
     } catch (err) {
       console.error(LOG_MESSAGES.EXTENSION_SETTING_SAVE_FAILED, err)
       setStatus({
-        type: 'error',
+        type: UI_STATUS.ERROR,
         message: EXTENSION_MESSAGES.SETTINGS_SAVE_FAILED,
       })
     }
@@ -91,7 +86,7 @@ export const useOptions = () => {
     if (!runValidation()) return
 
     setStatus({
-      type: 'loading',
+      type: UI_STATUS.LOADING,
       message: EXTENSION_MESSAGES.CONNECTION_TESTING,
     })
 
@@ -123,7 +118,7 @@ export const useOptions = () => {
       const validation = apiResponseSchema.safeParse(result.data)
       if (validation.success) {
         setStatus({
-          type: 'success',
+          type: UI_STATUS.SUCCESS,
           message: EXTENSION_MESSAGES.CONNECTION_SUCCESS(
             validation.data.bookmarks.length,
           ),
@@ -144,7 +139,7 @@ export const useOptions = () => {
         detail = COMMON_MESSAGES.UNKNOWN_ERROR
       }
       setStatus({
-        type: 'error',
+        type: UI_STATUS.ERROR,
         message: EXTENSION_MESSAGES.CONNECTION_FAILED(detail),
       })
     } finally {

--- a/extension/src/hooks/usePopup.test.ts
+++ b/extension/src/hooks/usePopup.test.ts
@@ -8,6 +8,8 @@ import {
   API_PATHS,
   LOG_MESSAGES,
   VALIDATION_MESSAGES,
+  UI_STATUS,
+  EXTENSION_MESSAGE_TYPES,
 } from '@shared/constants'
 import { storage } from '../lib/storage'
 
@@ -111,12 +113,12 @@ describe('usePopup Hook', () => {
         body: JSON.stringify({ title: 'Test', url: 'https://example.com' }),
       }),
     )
-    expect(result.current.status.type).toBe('success')
+    expect(result.current.status.type).toBe(UI_STATUS.SUCCESS)
     expect(result.current.status.message).toBe(EXTENSION_MESSAGES.POPUP_SAVED)
     
     // キャッシュ無効化メッセージが送信されたことを検証
     expect(mockChrome.runtime.sendMessage).toHaveBeenCalledWith({
-      type: 'INVALIDATE_CACHE',
+      type: EXTENSION_MESSAGE_TYPES.INVALIDATE_CACHE,
     })
     
     // 時間を進めて window.close の呼び出しを確認
@@ -138,7 +140,7 @@ describe('usePopup Hook', () => {
         await result.current.handleSave()
       })
 
-      expect(result.current.status.type).toBe('error')
+      expect(result.current.status.type).toBe(UI_STATUS.ERROR)
       expect(result.current.status.message).toBe(VALIDATION_MESSAGES.TITLE_REQUIRED)
     })
 
@@ -192,7 +194,7 @@ describe('usePopup Hook', () => {
           await result.current.handleSave()
         })
 
-        expect(result.current.status.type).toBe('error')
+        expect(result.current.status.type).toBe(UI_STATUS.ERROR)
         expect(result.current.status.message).toContain(expectedMessage)
         
         if (checkLog) {

--- a/extension/src/hooks/usePopup.ts
+++ b/extension/src/hooks/usePopup.ts
@@ -8,26 +8,23 @@ import {
   EXTENSION_MESSAGES,
   LOG_MESSAGES,
   STORAGE_KEYS,
+  UI_STATUS,
+  EXTENSION_MESSAGE_TYPES,
+  type StatusInfo,
 } from '@shared/constants'
 import { createBookmarkSchema } from '@shared/schemas/bookmark'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
 
 import { storage } from '../lib/storage'
 
-export type PopupStatusType = 'idle' | 'loading' | 'success' | 'error'
-
-export interface PopupStatusState {
-  type: PopupStatusType
-  message?: string
-}
-
 const DEFAULT_SETTINGS = {
   [STORAGE_KEYS.API_URL]: DEFAULT_API_URL,
 }
+
 export const usePopup = () => {
   const [title, setTitle] = useState('')
   const [url, setUrl] = useState('')
-  const [status, setStatus] = useState<PopupStatusState>({ type: 'idle' })
+  const [status, setStatus] = useState<StatusInfo>({ type: UI_STATUS.IDLE, message: '' })
 
   // 現在のタブ情報を取得 (Async/Await 形式)
   useEffect(() => {
@@ -54,13 +51,13 @@ export const usePopup = () => {
   }, [])
 
   const handleSave = useCallback(async () => {
-    setStatus({ type: 'loading', message: COMMON_MESSAGES.SAVING })
+    setStatus({ type: UI_STATUS.LOADING, message: COMMON_MESSAGES.SAVING })
 
     // 1. 入力バリデーション
     const validation = createBookmarkSchema.safeParse({ title, url })
     if (!validation.success) {
       setStatus({
-        type: 'error',
+        type: UI_STATUS.ERROR,
         message: validation.error.issues[0].message,
       })
       return
@@ -105,16 +102,16 @@ export const usePopup = () => {
 
       // 成功時
       setStatus({
-        type: 'success',
+        type: UI_STATUS.SUCCESS,
         message: EXTENSION_MESSAGES.POPUP_SAVED,
       })
       // background.ts にキャッシュ無効化を通知
-      chrome.runtime.sendMessage({ type: 'INVALIDATE_CACHE' })
+      chrome.runtime.sendMessage({ type: EXTENSION_MESSAGE_TYPES.INVALIDATE_CACHE })
       setTimeout(() => window.close(), EXTENSION_CONSTANTS.POPUP_CLOSE_DELAY_MS)
     } catch (err) {
       console.error(LOG_MESSAGES.CREATE_BOOKMARK_FAILED, err)
       setStatus({
-        type: 'error',
+        type: UI_STATUS.ERROR,
         message:
           err instanceof Error
             ? err.message

--- a/extension/sync-version.ts
+++ b/extension/sync-version.ts
@@ -2,18 +2,38 @@ import fs from 'fs';
 import path from 'path';
 import { LOG_MESSAGES } from '../shared/constants';
 
+const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+const manifestJsonPath = path.resolve(process.cwd(), 'extension/public/manifest.json');
+
+/**
+ * package.json と manifest.json のバージョンを同期するスクリプト
+ */
 function syncVersion() {
   try {
-    const rootPackagePath = path.resolve(__dirname, '../package.json');
-    const manifestPath = path.resolve(__dirname, './public/manifest.json');
+    // 1. ファイルの存在確認 (防御的チェック)
+    if (!fs.existsSync(packageJsonPath)) {
+      console.error(`${LOG_MESSAGES.VERSION_SYNC_ERROR} package.json not found at: ${packageJsonPath}`);
+      process.exit(1);
+    }
+    if (!fs.existsSync(manifestJsonPath)) {
+      console.error(`${LOG_MESSAGES.VERSION_SYNC_ERROR} manifest.json not found at: ${manifestJsonPath}`);
+      process.exit(1);
+    }
 
-    const rootPackage = JSON.parse(fs.readFileSync(rootPackagePath, 'utf8'));
-    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const manifest = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf8'));
 
-    if (manifest.version !== rootPackage.version) {
-      manifest.version = rootPackage.version;
-      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
-      console.log(`[sync-version] Updated manifest.json version to ${rootPackage.version}`);
+    // 2. バージョンフィールドの型チェック (防御的チェック)
+    if (typeof packageJson.version !== 'string') {
+      console.error(`${LOG_MESSAGES.VERSION_SYNC_ERROR} 'version' field in package.json is missing or not a string.`);
+      process.exit(1);
+    }
+
+    // 3. バージョンの同期
+    if (manifest.version !== packageJson.version) {
+      manifest.version = packageJson.version;
+      fs.writeFileSync(manifestJsonPath, JSON.stringify(manifest, null, 2) + '\n');
+      console.log(`[sync-version] Updated manifest.json version to ${packageJson.version}`);
     }
   } catch (error) {
     console.error(LOG_MESSAGES.VERSION_SYNC_ERROR, error);

--- a/extension/sync-version.ts
+++ b/extension/sync-version.ts
@@ -1,38 +1,22 @@
 import fs from 'fs';
 import path from 'path';
-
-const packageJsonPath = path.resolve(process.cwd(), 'package.json');
-const manifestJsonPath = path.resolve(process.cwd(), 'extension/public/manifest.json');
+import { LOG_MESSAGES } from '../shared/constants';
 
 function syncVersion() {
   try {
-    if (!fs.existsSync(packageJsonPath)) {
-      console.error(`[sync-version] package.json not found at: ${packageJsonPath}`);
-      process.exit(1);
-    }
-    if (!fs.existsSync(manifestJsonPath)) {
-      console.error(`[sync-version] manifest.json not found at: ${manifestJsonPath}`);
-      process.exit(1);
-    }
+    const rootPackagePath = path.resolve(__dirname, '../package.json');
+    const manifestPath = path.resolve(__dirname, './public/manifest.json');
 
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-    const manifestJson = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf-8'));
+    const rootPackage = JSON.parse(fs.readFileSync(rootPackagePath, 'utf8'));
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 
-    if (typeof packageJson.version !== 'string') {
-      console.error(`[sync-version] 'version' field in package.json is missing or not a string.`);
-      process.exit(1);
-    }
-
-    if (manifestJson.version !== packageJson.version) {
-      const oldVersion = manifestJson.version;
-      manifestJson.version = packageJson.version;
-      fs.writeFileSync(manifestJsonPath, JSON.stringify(manifestJson, null, 2) + '\n');
-      console.log(`[sync-version] Updated manifest.json version from ${oldVersion} to ${packageJson.version}`);
-    } else {
-      console.log(`[sync-version] Versions are already in sync (${packageJson.version})`);
+    if (manifest.version !== rootPackage.version) {
+      manifest.version = rootPackage.version;
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+      console.log(`[sync-version] Updated manifest.json version to ${rootPackage.version}`);
     }
   } catch (error) {
-    console.error('[sync-version] Error syncing versions:', error);
+    console.error(LOG_MESSAGES.VERSION_SYNC_ERROR, error);
     process.exit(1);
   }
 }

--- a/extension/sync-version.ts
+++ b/extension/sync-version.ts
@@ -1,9 +1,13 @@
-import fs from 'fs';
-import path from 'path';
-import { LOG_MESSAGES } from '../shared/constants';
+import fs from 'fs'
+import path from 'path'
 
-const packageJsonPath = path.resolve(process.cwd(), 'package.json');
-const manifestJsonPath = path.resolve(process.cwd(), 'extension/public/manifest.json');
+import { LOG_MESSAGES } from '../shared/constants'
+
+const packageJsonPath = path.resolve(process.cwd(), 'package.json')
+const manifestJsonPath = path.resolve(
+  process.cwd(),
+  'extension/public/manifest.json',
+)
 
 /**
  * package.json と manifest.json のバージョンを同期するスクリプト
@@ -12,33 +16,42 @@ function syncVersion() {
   try {
     // 1. ファイルの存在確認 (防御的チェック)
     if (!fs.existsSync(packageJsonPath)) {
-      console.error(`${LOG_MESSAGES.VERSION_SYNC_ERROR} package.json not found at: ${packageJsonPath}`);
-      process.exit(1);
+      console.error(
+        `${LOG_MESSAGES.VERSION_SYNC_ERROR} package.json not found at: ${packageJsonPath}`,
+      )
+      process.exit(1)
     }
     if (!fs.existsSync(manifestJsonPath)) {
-      console.error(`${LOG_MESSAGES.VERSION_SYNC_ERROR} manifest.json not found at: ${manifestJsonPath}`);
-      process.exit(1);
+      console.error(
+        `${LOG_MESSAGES.VERSION_SYNC_ERROR} manifest.json not found at: ${manifestJsonPath}`,
+      )
+      process.exit(1)
     }
 
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-    const manifest = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf8'));
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+    const manifest = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf8'))
 
     // 2. バージョンフィールドの型チェック (防御的チェック)
     if (typeof packageJson.version !== 'string') {
-      console.error(`${LOG_MESSAGES.VERSION_SYNC_ERROR} 'version' field in package.json is missing or not a string.`);
-      process.exit(1);
+      console.error(
+        `${LOG_MESSAGES.VERSION_SYNC_ERROR} 'version' field in package.json is missing or not a string.`,
+      )
+      process.exit(1)
     }
 
     // 3. バージョンの同期
     if (manifest.version !== packageJson.version) {
-      manifest.version = packageJson.version;
-      fs.writeFileSync(manifestJsonPath, JSON.stringify(manifest, null, 2) + '\n');
-      console.log(`[sync-version] Updated manifest.json version to ${packageJson.version}`);
+      manifest.version = packageJson.version
+      fs.writeFileSync(
+        manifestJsonPath,
+        JSON.stringify(manifest, null, 2) + '\n',
+      )
+      console.log(LOG_MESSAGES.UPDATED_VERSION(packageJson.version))
     }
   } catch (error) {
-    console.error(LOG_MESSAGES.VERSION_SYNC_ERROR, error);
-    process.exit(1);
+    console.error(LOG_MESSAGES.VERSION_SYNC_ERROR, error)
+    process.exit(1)
   }
 }
 
-syncVersion();
+syncVersion()

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -2,14 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { z } from 'zod'
 import { sqlite, db, initializeDatabase, resetDatabase } from './db'
 import { bookmarks, keywords, bookmarkKeywords, bookmarksRelations, keywordsRelations, bookmarkKeywordsRelations } from './db/schema'
-import { LOG_MESSAGES } from '@shared/constants'
+import { LOG_MESSAGES, DB_CONSTANTS, ENV_NAMES } from '@shared/constants'
 import { TEST_MESSAGES, VALID_URLS } from '@shared/test/fixtures'
 import { eq } from 'drizzle-orm'
 
 describe('db.ts', () => {
   beforeEach(() => {
     // 確実にテスト環境で初期化
-    vi.stubEnv('NODE_ENV', 'test')
+    vi.stubEnv('NODE_ENV', ENV_NAMES.TEST)
     initializeDatabase()
     resetDatabase()
   })
@@ -34,7 +34,7 @@ describe('db.ts', () => {
       })
 
       expect(() => initializeDatabase()).toThrow(dbError)
-      expect(pragmaSpy).toHaveBeenCalledWith('foreign_keys = ON')
+      expect(pragmaSpy).toHaveBeenCalledWith(DB_CONSTANTS.PRAGMA_FOREIGN_KEYS_ON)
       expect(consoleSpy).toHaveBeenCalledWith(
         LOG_MESSAGES.DB_INIT_FAILED,
         dbError,
@@ -57,7 +57,7 @@ describe('db.ts', () => {
     })
 
     it('テスト環境以外で実行された場合にエラーをスローすること', () => {
-      vi.stubEnv('NODE_ENV', 'development')
+      vi.stubEnv('NODE_ENV', ENV_NAMES.DEVELOPMENT)
       expect(() => resetDatabase()).toThrow(LOG_MESSAGES.RESET_DB_ENV_ERROR)
     })
   })

--- a/server/db.test.ts
+++ b/server/db.test.ts
@@ -55,6 +55,11 @@ describe('db.ts', () => {
         .parse(sqlite.prepare('SELECT COUNT(*) as count FROM bookmarks').get())
       expect(count.count).toBe(0)
     })
+
+    it('テスト環境以外で実行された場合にエラーをスローすること', () => {
+      vi.stubEnv('NODE_ENV', 'development')
+      expect(() => resetDatabase()).toThrow(LOG_MESSAGES.RESET_DB_ENV_ERROR)
+    })
   })
 
   describe('Schema Definitions & Relations', () => {

--- a/server/db.ts
+++ b/server/db.ts
@@ -44,7 +44,7 @@ export const initializeDatabase = () => {
 export const resetDatabase = () => {
   if (process.env.NODE_ENV !== 'test') {
     /* v8 ignore next */
-    throw new Error('resetDatabase can only be called in test environment')
+    throw new Error(LOG_MESSAGES.RESET_DB_ENV_ERROR)
   }
   // ユーザ定義テーブルの一覧を取得（sqlite_sequence などのシステムテーブルを除外）
   const tableSchema = z.object({ name: z.string() })

--- a/server/db.ts
+++ b/server/db.ts
@@ -3,17 +3,17 @@ import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 import path from 'path'
 import { z } from 'zod'
-import { LOG_MESSAGES } from '@shared/constants'
+import { LOG_MESSAGES, DB_CONSTANTS, ENV_NAMES } from '@shared/constants'
 import * as schema from './db/schema'
 
-const isTestEnvironment = () => process.env.NODE_ENV === 'test'
+const isTestEnvironment = () => process.env.NODE_ENV === ENV_NAMES.TEST
 
 const getDbPath = () => {
   return isTestEnvironment()
     ? ':memory:'
     : /* v8 ignore next 2 */
       // テスト実行時は常に :memory: を使用するため、物理パスの生成は計測から除外する
-      path.resolve(process.cwd(), 'bookmarks.sqlite')
+      path.resolve(process.cwd(), DB_CONSTANTS.FILENAME)
 }
 
 export const sqlite = new Database(getDbPath())
@@ -24,16 +24,16 @@ export const initializeDatabase = () => {
   const isTest = isTestEnvironment()
   try {
     // 1. 接続ごとの設定（外部キー有効化）
-    sqlite.pragma('foreign_keys = ON')
+    sqlite.pragma(DB_CONSTANTS.PRAGMA_FOREIGN_KEYS_ON)
 
     // 2. DBファイル全体の設定（WALモード: パフォーマンス向上）
     if (!isTest) {
       /* v8 ignore next */
-      sqlite.pragma('journal_mode = WAL')
+      sqlite.pragma(DB_CONSTANTS.PRAGMA_JOURNAL_MODE_WAL)
     }
 
     // 3. マイグレーションの実行
-    migrate(db, { migrationsFolder: path.resolve('server/db/migrations') })
+    migrate(db, { migrationsFolder: path.resolve(DB_CONSTANTS.MIGRATIONS_DIR) })
   } catch (error) {
     console.error(LOG_MESSAGES.DB_INIT_FAILED, error)
     throw error
@@ -42,7 +42,7 @@ export const initializeDatabase = () => {
 
 // データベースを空にする（テスト用）
 export const resetDatabase = () => {
-  if (process.env.NODE_ENV !== 'test') {
+  if (process.env.NODE_ENV !== ENV_NAMES.TEST) {
     /* v8 ignore next */
     throw new Error(LOG_MESSAGES.RESET_DB_ENV_ERROR)
   }
@@ -59,7 +59,7 @@ export const resetDatabase = () => {
     )
 
   // 外部キー制約を一時的に無効化（トランザクションの外で実行する必要がある）
-  sqlite.pragma('foreign_keys = OFF')
+  sqlite.pragma(DB_CONSTANTS.PRAGMA_FOREIGN_KEYS_OFF)
 
   try {
     sqlite.transaction(() => {
@@ -72,7 +72,7 @@ export const resetDatabase = () => {
     })()
   } finally {
     // 確実に外部キー制約を元に戻す
-    sqlite.pragma('foreign_keys = ON')
+    sqlite.pragma(DB_CONSTANTS.PRAGMA_FOREIGN_KEYS_ON)
   }
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,19 +1,20 @@
 import { serve } from '@hono/node-server'
 import app from './app'
 import { initializeDatabase } from './db'
-import { LOG_MESSAGES } from '@shared/constants'
+import { LOG_MESSAGES, DEFAULT_SERVER_PORT } from '@shared/constants'
 
-const port = 3030
-
+// データベースの初期化
 try {
   initializeDatabase()
-  console.log('Database initialized successfully')
+  console.log(LOG_MESSAGES.DB_INIT_SUCCESS)
 } catch (error) {
-  console.error(LOG_MESSAGES.SERVER_START_FAILED, error)
+  console.error(LOG_MESSAGES.DB_INIT_FAILED, error)
   process.exit(1)
 }
 
-console.log(`Server is running on port ${port}`)
+const port = DEFAULT_SERVER_PORT
+
+console.log(LOG_MESSAGES.SERVER_RUNNING(port))
 
 serve({
   fetch: app.fetch,

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -67,7 +67,7 @@ describe('Bookmarks API', () => {
         body: JSON.stringify(newData),
       })
 
-      expect(res.status).toBe(201)
+      expect(res.status).toBe(HTTP_STATUS.CREATED)
       const body = await res.json()
       expect(body.success).toBe(true)
       expect(body.data.title).toBe(newData.title)
@@ -87,7 +87,7 @@ describe('Bookmarks API', () => {
         body: JSON.stringify(newData),
       })
 
-      expect(res.status).toBe(409)
+      expect(res.status).toBe(HTTP_STATUS.CONFLICT)
       const body = await res.json()
       expect(body.success).toBe(false)
       expect(body.error.message).toBe(ERROR_MESSAGES.DUPLICATE_URL)
@@ -127,7 +127,7 @@ describe('Bookmarks API', () => {
       const delRes = await app.request(`${API_PATHS.BOOKMARKS}/${targetId}`, {
         method: 'DELETE',
       })
-      expect(delRes.status).toBe(204)
+      expect(delRes.status).toBe(HTTP_STATUS.NO_CONTENT)
 
       const afterRes = await app.request(API_PATHS.BOOKMARKS)
       const afterBody = await afterRes.json()
@@ -138,7 +138,7 @@ describe('Bookmarks API', () => {
       const res = await app.request(`${API_PATHS.BOOKMARKS}/999`, {
         method: 'DELETE',
       })
-      expect(res.status).toBe(404)
+      expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
     })
   })
 
@@ -194,7 +194,7 @@ describe('Bookmarks API', () => {
         body: JSON.stringify({ url: SEED_DATA_1.url }), // 重複するURL
       })
 
-      expect(res.status).toBe(409)
+      expect(res.status).toBe(HTTP_STATUS.CONFLICT)
     })
 
     it('存在しない ID の更新時に 404 を返すこと', async () => {
@@ -203,7 +203,7 @@ describe('Bookmarks API', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ title: 'Fail' }),
       })
-      expect(res.status).toBe(404)
+      expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
     })
   })
 
@@ -325,7 +325,7 @@ describe('Bookmarks API', () => {
       })
       expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
       expect(consoleSpy).toHaveBeenCalledWith(
-        'Failed to reorder bookmarks:',
+        LOG_MESSAGES.REORDER_FAILED_CONSOLE,
         dbError,
       )
     })

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -14,7 +14,7 @@ import {
 
 import { db } from '../db'
 import { bookmarks as bookmarksTable } from '../db/schema'
-import { isSqliteError, API_ERROR_CODES } from '../utils/error'
+import { isUniqueConstraintError, API_ERROR_CODES } from '../utils/error'
 
 const bookmarksRoute = new Hono()
   .get('/', async (c) => {
@@ -60,7 +60,7 @@ const bookmarksRoute = new Hono()
           sortOrder: bookmarksTable.sortOrder,
         })
 
-      if (!row) throw new Error('Failed to insert bookmark')
+      if (!row) throw new Error(LOG_MESSAGES.INSERT_FAILED)
 
       return c.json(
         {
@@ -75,7 +75,7 @@ const bookmarksRoute = new Hono()
         HTTP_STATUS.CREATED,
       )
     } catch (error) {
-      if (isSqliteError(error) && error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+      if (isUniqueConstraintError(error)) {
         return c.json(
           {
             success: false,
@@ -169,7 +169,7 @@ const bookmarksRoute = new Hono()
           },
         })
       } catch (error) {
-        if (isSqliteError(error) && error.code === 'SQLITE_CONSTRAINT_UNIQUE') {
+        if (isUniqueConstraintError(error)) {
           return c.json(
             {
               success: false,
@@ -198,7 +198,6 @@ const bookmarksRoute = new Hono()
       const numericIds = ids.map((id) => parseInt(id, 10))
 
       // CASE WHEN 構文を組み立てて一括更新
-      // 各 ID に対して、配列内のインデックスを新しい sort_order として割り当てる
       const cases = numericIds.map(
         (id, index) =>
           sql`WHEN ${bookmarksTable.bookmarkId} = ${id} THEN ${index}`,
@@ -216,7 +215,7 @@ const bookmarksRoute = new Hono()
         data: null,
       })
     } catch (error) {
-      console.error('Failed to reorder bookmarks:', error)
+      console.error(LOG_MESSAGES.REORDER_FAILED_CONSOLE, error)
       throw error
     }
   })

--- a/server/utils/error.ts
+++ b/server/utils/error.ts
@@ -3,6 +3,20 @@ export function isSqliteError(error: unknown): error is Error & { code: string }
 }
 
 /**
+ * SQLite 特有のエラーコード
+ */
+export const SQLITE_ERROR_CODES = {
+  UNIQUE_CONSTRAINT: 'SQLITE_CONSTRAINT_UNIQUE',
+} as const
+
+/**
+ * SQLite の一意制約違反かどうかを判定する
+ */
+export function isUniqueConstraintError(error: unknown): boolean {
+  return isSqliteError(error) && error.code === SQLITE_ERROR_CODES.UNIQUE_CONSTRAINT
+}
+
+/**
  * 共通エラーコードの定義
  */
 export const API_ERROR_CODES = {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -214,6 +214,7 @@ export const ENV_NAMES = {
  */
 export const LOG_MESSAGES = {
   DB_INIT_FAILED: 'Failed to initialize database:',
+  DB_INIT_SUCCESS: 'Database initialized successfully',
   SERVER_START_FAILED: 'Failed to start server:',
   BACKGROUND_LOADED: 'Background Service Worker loaded',
   EXTENSION_INSTALLED: 'Extension installed',
@@ -231,6 +232,20 @@ export const LOG_MESSAGES = {
   REORDER_FAILED_CONSOLE: 'Failed to reorder bookmarks:',
   RESET_DB_ENV_ERROR: 'resetDatabase can only be called in test environment',
   INSERT_FAILED: 'Failed to insert bookmark',
+  INVALID_STORAGE_URL_BACKGROUND: 'Invalid API URL in background:',
+  ICON_STATUS_UPDATE_FAILED: 'Failed to update icon status:',
+  UNAUTHORIZED_EXTENSION_MESSAGE: 'Blocked message from unauthorized extension:',
+  UNAUTHORIZED_ORIGIN_MESSAGE: 'Blocked unauthorized message from origin:',
+  VERSION_SYNC_ERROR: '[sync-version] Error syncing versions:',
+} as const
+
+/**
+ * テスト用メッセージ (テストコード内でのみ使用)
+ */
+export const TEST_MESSAGES = {
+  UNEXPECTED_ERROR: 'Unexpected error',
+  MUTATION_FAILED: 'Mutation failed',
+  TEST_ERROR: 'Test Error',
 } as const
 
 /**
@@ -245,13 +260,4 @@ export const VALIDATION_MESSAGES = {
     'タイトルまたは URL の少なくとも一方は指定する必要があります',
   REORDER_MAX_ITEMS: '一度に並び替えられるのは1000件までです',
   REORDER_DUPLICATE_IDS: 'IDリストに重複が含まれています',
-} as const
-
-/**
- * テスト用メッセージ (テストコード内でのみ使用)
- */
-export const TEST_MESSAGES = {
-  UNEXPECTED_ERROR: 'Unexpected error',
-  MUTATION_FAILED: 'Mutation failed',
-  TEST_ERROR: 'Test Error',
 } as const

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -191,6 +191,8 @@ export const ARIA_ATTRIBUTES = {
 export const HTML_ATTRIBUTES = {
   TAB_INDEX: 'tabIndex',
   ROLE: 'role',
+  TARGET_BLANK: '_blank',
+  REL_NOOPENER_NOREFERRER: 'noopener,noreferrer',
 } as const
 
 /**

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -246,3 +246,11 @@ export const VALIDATION_MESSAGES = {
   REORDER_MAX_ITEMS: '一度に並び替えられるのは1000件までです',
   REORDER_DUPLICATE_IDS: 'IDリストに重複が含まれています',
 } as const
+
+/**
+ * テスト用メッセージ (テストコード内でのみ使用)
+ */
+export const TEST_MESSAGES = {
+  UNEXPECTED_ERROR: 'Unexpected error',
+  MUTATION_FAILED: 'Mutation failed',
+} as const

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -35,7 +35,7 @@ export const UI_STATUS = {
   ERROR: 'error',
 } as const
 
-export type UIStatus = typeof UI_STATUS[keyof typeof UI_STATUS]
+export type UIStatus = (typeof UI_STATUS)[keyof typeof UI_STATUS]
 
 /**
  * 処理状態とメッセージを組み合わせた共通型
@@ -125,7 +125,8 @@ export const BOOKMARK_STATUS = {
   ERROR: 'error',
 } as const
 
-export type BookmarkStatus = typeof BOOKMARK_STATUS[keyof typeof BOOKMARK_STATUS]
+export type BookmarkStatus =
+  (typeof BOOKMARK_STATUS)[keyof typeof BOOKMARK_STATUS]
 
 /**
  * 拡張機能のアイコンパス定義
@@ -256,15 +257,19 @@ export const LOG_MESSAGES = {
   EXTENSION_SETTING_SAVE_FAILED: 'Failed to save settings:',
   EXTENSION_SETTING_LOAD_FAILED: 'Failed to load extension settings:',
   EXTENSION_CONNECTION_FAILED: 'Connection test failed:',
-  INVALID_STORAGE_URL: 'Invalid API URL found in localStorage, falling back to default:',
+  INVALID_STORAGE_URL:
+    'Invalid API URL found in localStorage, falling back to default:',
   REORDER_FAILED_CONSOLE: 'Failed to reorder bookmarks:',
   RESET_DB_ENV_ERROR: 'resetDatabase can only be called in test environment',
   INSERT_FAILED: 'Failed to insert bookmark',
   INVALID_STORAGE_URL_BACKGROUND: 'Invalid API URL in background:',
   ICON_STATUS_UPDATE_FAILED: 'Failed to update icon status:',
-  UNAUTHORIZED_EXTENSION_MESSAGE: 'Blocked message from unauthorized extension:',
+  UNAUTHORIZED_EXTENSION_MESSAGE:
+    'Blocked message from unauthorized extension:',
   UNAUTHORIZED_ORIGIN_MESSAGE: 'Blocked unauthorized message from origin:',
   VERSION_SYNC_ERROR: '[sync-version] Error syncing versions:',
+  UPDATED_VERSION: (version: string) =>
+    `[sync-version] Updated manifest.json version to ${version}`,
 } as const
 
 /**

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -23,6 +23,7 @@ export const FIELD_LABELS = {
  * プロダクト全体で共有されるデフォルト設定
  */
 export const DEFAULT_API_URL = 'http://localhost:3030'
+export const DEFAULT_SERVER_PORT = 3030
 
 /**
  * プロダクト共通の UI メッセージ
@@ -216,6 +217,7 @@ export const LOG_MESSAGES = {
   DB_INIT_FAILED: 'Failed to initialize database:',
   DB_INIT_SUCCESS: 'Database initialized successfully',
   SERVER_START_FAILED: 'Failed to start server:',
+  SERVER_RUNNING: (port: number) => `Server is running on port ${port}`,
   BACKGROUND_LOADED: 'Background Service Worker loaded',
   EXTENSION_INSTALLED: 'Extension installed',
   FETCH_BOOKMARKS_FAILED: 'Failed to fetch bookmarks:',

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -26,6 +26,18 @@ export const DEFAULT_API_URL = 'http://localhost:3030'
 export const DEFAULT_SERVER_PORT = 3030
 
 /**
+ * UI の処理状態定義
+ */
+export const UI_STATUS = {
+  IDLE: 'idle',
+  LOADING: 'loading',
+  SUCCESS: 'success',
+  ERROR: 'error',
+} as const
+
+export type UIStatus = typeof UI_STATUS[keyof typeof UI_STATUS]
+
+/**
  * 許可されたオリジン (Web アプリ)
  */
 export const ALLOWED_ORIGINS = ['http://localhost:5173'] as const

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -190,6 +190,26 @@ export const STORAGE_KEYS = {
 } as const
 
 /**
+ * データベース関連の定数
+ */
+export const DB_CONSTANTS = {
+  FILENAME: 'bookmarks.sqlite',
+  MIGRATIONS_DIR: 'server/db/migrations',
+  PRAGMA_FOREIGN_KEYS_ON: 'foreign_keys = ON',
+  PRAGMA_FOREIGN_KEYS_OFF: 'foreign_keys = OFF',
+  PRAGMA_JOURNAL_MODE_WAL: 'journal_mode = WAL',
+} as const
+
+/**
+ * 環境変数名の定数
+ */
+export const ENV_NAMES = {
+  TEST: 'test',
+  DEVELOPMENT: 'development',
+  PRODUCTION: 'production',
+} as const
+
+/**
  * ログメッセージ (開発者向け)
  */
 export const LOG_MESSAGES = {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -46,6 +46,16 @@ export type StatusInfo = {
 }
 
 /**
+ * UI 状態に応じた共通の CSS クラス定義
+ */
+export const STATUS_STYLES: Record<UIStatus, string> = {
+  [UI_STATUS.IDLE]: '',
+  [UI_STATUS.LOADING]: 'bg-blue-50 text-blue-700 border-blue-200',
+  [UI_STATUS.SUCCESS]: 'bg-green-50 text-green-700 border-green-200',
+  [UI_STATUS.ERROR]: 'bg-red-50 text-red-700 border-red-200',
+} as const
+
+/**
  * 許可されたオリジン (Web アプリ)
  */
 export const ALLOWED_ORIGINS = ['http://localhost:5173'] as const

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -38,6 +38,14 @@ export const UI_STATUS = {
 export type UIStatus = typeof UI_STATUS[keyof typeof UI_STATUS]
 
 /**
+ * 処理状態とメッセージを組み合わせた共通型
+ */
+export type StatusInfo = {
+  type: UIStatus
+  message: string
+}
+
+/**
  * 許可されたオリジン (Web アプリ)
  */
 export const ALLOWED_ORIGINS = ['http://localhost:5173'] as const

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -253,4 +253,5 @@ export const VALIDATION_MESSAGES = {
 export const TEST_MESSAGES = {
   UNEXPECTED_ERROR: 'Unexpected error',
   MUTATION_FAILED: 'Mutation failed',
+  TEST_ERROR: 'Test Error',
 } as const

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -209,6 +209,8 @@ export const LOG_MESSAGES = {
   EXTENSION_CONNECTION_FAILED: 'Connection test failed:',
   INVALID_STORAGE_URL: 'Invalid API URL found in localStorage, falling back to default:',
   REORDER_FAILED_CONSOLE: 'Failed to reorder bookmarks:',
+  RESET_DB_ENV_ERROR: 'resetDatabase can only be called in test environment',
+  INSERT_FAILED: 'Failed to insert bookmark',
 } as const
 
 /**

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -26,6 +26,11 @@ export const DEFAULT_API_URL = 'http://localhost:3030'
 export const DEFAULT_SERVER_PORT = 3030
 
 /**
+ * 許可されたオリジン (Web アプリ)
+ */
+export const ALLOWED_ORIGINS = ['http://localhost:5173'] as const
+
+/**
  * プロダクト共通の UI メッセージ
  */
 export const COMMON_MESSAGES = {
@@ -142,6 +147,7 @@ export const EXTENSION_CONSTANTS = {
  */
 export const EXTENSION_MESSAGE_TYPES = {
   GET_API_CONFIG: 'GET_API_CONFIG',
+  INVALIDATE_CACHE: 'INVALIDATE_CACHE',
 } as const
 
 /**

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -19,6 +19,11 @@ export const FIELD_LABELS = {
   SETTING_TITLE: '設定',
 } as const
 
+export const PLACEHOLDERS = {
+  TITLE: 'タイトルを入力',
+  URL: 'https://...',
+} as const
+
 /**
  * プロダクト全体で共有されるデフォルト設定
  */

--- a/src/components/BookmarkDetail.test.tsx
+++ b/src/components/BookmarkDetail.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { FIELD_LABELS } from '@shared/constants'
+import { FIELD_LABELS, PLACEHOLDERS } from '@shared/constants'
 import { BookmarkIdSchema } from '@shared/schemas/bookmark'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 import { render, screen } from '@testing-library/react'
@@ -31,8 +31,8 @@ describe('BookmarkDetail', () => {
     const user = userEvent.setup()
     render(<BookmarkDetail {...defaultProps} />)
 
-    const titleInput = screen.getByPlaceholderText('Bookmark Title')
-    const urlInput = screen.getByPlaceholderText('https://...')
+    const titleInput = screen.getByPlaceholderText(PLACEHOLDERS.TITLE)
+    const urlInput = screen.getByPlaceholderText(PLACEHOLDERS.URL)
 
     await user.clear(titleInput)
     await user.type(titleInput, UPDATED_TITLE)
@@ -94,7 +94,7 @@ describe('BookmarkDetail', () => {
     render(<BookmarkDetail {...defaultProps} onClose={onClose} />)
 
     // 入力欄にフォーカスを当ててから Escape キーを押す
-    const titleInput = screen.getByPlaceholderText('Bookmark Title')
+    const titleInput = screen.getByPlaceholderText(PLACEHOLDERS.TITLE)
     await user.click(titleInput)
     await user.keyboard('{Escape}')
 

--- a/src/components/BookmarkDetail.tsx
+++ b/src/components/BookmarkDetail.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 
-import { FIELD_LABELS } from '@shared/constants'
+import { FIELD_LABELS, PLACEHOLDERS } from '@shared/constants'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
 
@@ -52,14 +52,14 @@ export const BookmarkDetail: React.FC<BookmarkDetailProps> = ({
             label={FIELD_LABELS.TITLE}
             value={editTitle}
             onChange={(e) => setEditTitle(e.target.value)}
-            placeholder="Bookmark Title"
+            placeholder={PLACEHOLDERS.TITLE}
           />
           <InputField
             id="detail-url"
             label={FIELD_LABELS.URL}
             value={editUrl}
             onChange={(e) => setEditUrl(e.target.value)}
-            placeholder="https://..."
+            placeholder={PLACEHOLDERS.URL}
             className="font-mono"
           />
         </div>

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -7,6 +7,7 @@ import {
   COMMON_MESSAGES,
   HTML_ATTRIBUTES,
   UI_MESSAGES,
+  TEST_MESSAGES,
 } from '@shared/constants'
 import {
   MOCK_BOOKMARK_1,
@@ -115,12 +116,12 @@ describe('BookmarkList', () => {
       name: 'Errorインスタンス発生時にエラーメッセージが表示されること',
       props: {
         bookmarks: [],
-        error: new Error('Test Error'),
+        error: new Error(TEST_MESSAGES.TEST_ERROR),
       },
       assert: () => {
         const alert = screen.getByRole(ARIA_ROLES.ALERT)
         expect(alert).toHaveTextContent(COMMON_MESSAGES.ERROR_PREFIX)
-        expect(alert).toHaveTextContent('Test Error')
+        expect(alert).toHaveTextContent(TEST_MESSAGES.TEST_ERROR)
       },
     },
     {

--- a/src/hooks/useApp.test.tsx
+++ b/src/hooks/useApp.test.tsx
@@ -1,23 +1,18 @@
+import { act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useApp } from './useApp'
+import { STORAGE_KEYS, VALIDATION_MESSAGES, COMMON_MESSAGES, LOG_MESSAGES, TEST_MESSAGES } from '@shared/constants'
 import { http, HttpResponse } from 'msw'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
-import {
-  COMMON_MESSAGES,
-  STORAGE_KEYS,
-  VALIDATION_MESSAGES,
-} from '@shared/constants'
+import { server } from '../test/setup'
+import { renderHook } from '../test/utils'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 import * as urlUtils from '@shared/utils/url'
-
-import { server } from '../test/setup'
-import { act, renderHook, waitFor } from '../test/utils'
-import { useApp } from './useApp'
 
 describe('useApp Hook', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
-
+    
     // location.reload をモック
     Object.defineProperty(window, 'location', {
       writable: true,
@@ -28,17 +23,14 @@ describe('useApp Hook', () => {
     // MSW のデフォルトハンドラを設定
     server.use(
       http.get('*/api/bookmarks', () => {
-        return HttpResponse.json({
-          success: true,
-          data: { bookmarks: [MOCK_BOOKMARK_1] },
-        })
+        return HttpResponse.json({ success: true, data: { bookmarks: [MOCK_BOOKMARK_1] } })
       }),
       http.patch('*/api/bookmarks/:id', () => {
         return HttpResponse.json({ success: true, data: MOCK_BOOKMARK_1 })
       }),
       http.delete('*/api/bookmarks/:id', () => {
         return new HttpResponse(null, { status: 204 })
-      }),
+      })
     )
   })
 
@@ -47,11 +39,16 @@ describe('useApp Hook', () => {
    */
   const renderAppHook = async (initialUrl?: string) => {
     const renderResult = renderHook(() => useApp(), { initialUrl })
-
+    
     // isLoading が false になるまで待機 (act 内で実行)
-    await waitFor(() => {
-      expect(renderResult.result.current.isLoading).toBe(false)
+    await act(async () => {
+      await vi.waitFor(() => {
+        if (renderResult.result.current.isLoading) {
+          throw new Error(TEST_MESSAGES.UNEXPECTED_ERROR)
+        }
+      })
     })
+    
     return renderResult
   }
 
@@ -122,21 +119,18 @@ describe('useApp Hook', () => {
     it('予期せぬ例外が発生した場合、エラーメッセージを返し、ログを出力すること', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       vi.spyOn(urlUtils, 'getOrigin').mockImplementation(() => {
-        throw new Error('Unexpected error')
+        throw new Error(TEST_MESSAGES.UNEXPECTED_ERROR)
       })
 
       const { result } = await renderAppHook()
-
+      
       let error: string | null = null
       act(() => {
         error = result.current.handleSaveSettings('http://localhost:3030')
       })
 
-      expect(error).toBe('Unexpected error')
-      expect(consoleSpy).toHaveBeenCalledWith(
-        'Failed to save settings:',
-        expect.any(Error),
-      )
+      expect(error).toBe(TEST_MESSAGES.UNEXPECTED_ERROR)
+      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.EXTENSION_SETTING_SAVE_FAILED, expect.any(Error))
     })
 
     it('Error 以外の例外が発生した場合、共通エラーメッセージを返すこと', async () => {
@@ -146,7 +140,7 @@ describe('useApp Hook', () => {
       })
 
       const { result } = await renderAppHook()
-
+      
       let error: string | null = null
       act(() => {
         error = result.current.handleSaveSettings('http://localhost:3030')
@@ -159,7 +153,7 @@ describe('useApp Hook', () => {
   describe('ブックマーク操作の検証', () => {
     it('handleRowClick でブックマークが選択されること', async () => {
       const { result } = await renderAppHook()
-
+      
       act(() => {
         result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
@@ -174,12 +168,12 @@ describe('useApp Hook', () => {
         http.patch('*/api/bookmarks/:id', () => {
           patchCalled = true
           return HttpResponse.json({ success: true, data: MOCK_BOOKMARK_1 })
-        }),
+        })
       )
 
       const { result } = await renderAppHook()
-
-      await act(async () => {
+      
+      act(() => {
         result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
 
@@ -215,19 +209,17 @@ describe('useApp Hook', () => {
       let deleteCalled = false
       vi.spyOn(window, 'confirm').mockReturnValue(true)
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
-
+      
       server.use(
         http.delete('*/api/bookmarks/:id', () => {
           deleteCalled = true
           return new HttpResponse(null, { status: 204 })
-        }),
+        })
       )
 
       const { result } = await renderAppHook()
-
-      act(() => {
-        result.current.handleRowClick(MOCK_BOOKMARK_1.id)
-      })
+      
+      act(() => { result.current.handleRowClick(MOCK_BOOKMARK_1.id) })
 
       await act(async () => {
         result.current.handleOpen()

--- a/src/hooks/useApp.test.tsx
+++ b/src/hooks/useApp.test.tsx
@@ -1,18 +1,27 @@
-import { act } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useApp } from './useApp'
-import { STORAGE_KEYS, VALIDATION_MESSAGES, COMMON_MESSAGES, LOG_MESSAGES, TEST_MESSAGES } from '@shared/constants'
 import { http, HttpResponse } from 'msw'
-import { server } from '../test/setup'
-import { renderHook } from '../test/utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  COMMON_MESSAGES,
+  HTML_ATTRIBUTES,
+  LOG_MESSAGES,
+  STORAGE_KEYS,
+  TEST_MESSAGES,
+  VALIDATION_MESSAGES,
+} from '@shared/constants'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 import * as urlUtils from '@shared/utils/url'
+import { act } from '@testing-library/react'
+
+import { server } from '../test/setup'
+import { renderHook } from '../test/utils'
+import { useApp } from './useApp'
 
 describe('useApp Hook', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
-    
+
     // location.reload をモック
     Object.defineProperty(window, 'location', {
       writable: true,
@@ -23,14 +32,17 @@ describe('useApp Hook', () => {
     // MSW のデフォルトハンドラを設定
     server.use(
       http.get('*/api/bookmarks', () => {
-        return HttpResponse.json({ success: true, data: { bookmarks: [MOCK_BOOKMARK_1] } })
+        return HttpResponse.json({
+          success: true,
+          data: { bookmarks: [MOCK_BOOKMARK_1] },
+        })
       }),
       http.patch('*/api/bookmarks/:id', () => {
         return HttpResponse.json({ success: true, data: MOCK_BOOKMARK_1 })
       }),
       http.delete('*/api/bookmarks/:id', () => {
         return new HttpResponse(null, { status: 204 })
-      })
+      }),
     )
   })
 
@@ -39,7 +51,7 @@ describe('useApp Hook', () => {
    */
   const renderAppHook = async (initialUrl?: string) => {
     const renderResult = renderHook(() => useApp(), { initialUrl })
-    
+
     // isLoading が false になるまで待機 (act 内で実行)
     await act(async () => {
       await vi.waitFor(() => {
@@ -48,7 +60,7 @@ describe('useApp Hook', () => {
         }
       })
     })
-    
+
     return renderResult
   }
 
@@ -123,14 +135,17 @@ describe('useApp Hook', () => {
       })
 
       const { result } = await renderAppHook()
-      
+
       let error: string | null = null
       act(() => {
         error = result.current.handleSaveSettings('http://localhost:3030')
       })
 
       expect(error).toBe(TEST_MESSAGES.UNEXPECTED_ERROR)
-      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.EXTENSION_SETTING_SAVE_FAILED, expect.any(Error))
+      expect(consoleSpy).toHaveBeenCalledWith(
+        LOG_MESSAGES.EXTENSION_SETTING_SAVE_FAILED,
+        expect.any(Error),
+      )
     })
 
     it('Error 以外の例外が発生した場合、共通エラーメッセージを返すこと', async () => {
@@ -140,7 +155,7 @@ describe('useApp Hook', () => {
       })
 
       const { result } = await renderAppHook()
-      
+
       let error: string | null = null
       act(() => {
         error = result.current.handleSaveSettings('http://localhost:3030')
@@ -153,7 +168,7 @@ describe('useApp Hook', () => {
   describe('ブックマーク操作の検証', () => {
     it('handleRowClick でブックマークが選択されること', async () => {
       const { result } = await renderAppHook()
-      
+
       act(() => {
         result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
@@ -168,11 +183,11 @@ describe('useApp Hook', () => {
         http.patch('*/api/bookmarks/:id', () => {
           patchCalled = true
           return HttpResponse.json({ success: true, data: MOCK_BOOKMARK_1 })
-        })
+        }),
       )
 
       const { result } = await renderAppHook()
-      
+
       act(() => {
         result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
@@ -200,8 +215,8 @@ describe('useApp Hook', () => {
       expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
       expect(openSpy).toHaveBeenCalledWith(
         MOCK_BOOKMARK_1.url,
-        '_blank',
-        'noopener,noreferrer',
+        HTML_ATTRIBUTES.TARGET_BLANK,
+        HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
       )
     })
 
@@ -209,17 +224,19 @@ describe('useApp Hook', () => {
       let deleteCalled = false
       vi.spyOn(window, 'confirm').mockReturnValue(true)
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
-      
+
       server.use(
         http.delete('*/api/bookmarks/:id', () => {
           deleteCalled = true
           return new HttpResponse(null, { status: 204 })
-        })
+        }),
       )
 
       const { result } = await renderAppHook()
-      
-      act(() => { result.current.handleRowClick(MOCK_BOOKMARK_1.id) })
+
+      act(() => {
+        result.current.handleRowClick(MOCK_BOOKMARK_1.id)
+      })
 
       await act(async () => {
         result.current.handleOpen()

--- a/src/hooks/useApp.ts
+++ b/src/hooks/useApp.ts
@@ -1,85 +1,67 @@
-import { useCallback, useState } from 'react'
-import { COMMON_MESSAGES } from '@shared/constants'
-import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
-import { validateApiUrl, getOrigin } from '@shared/utils/url'
-import { useBookmarks } from './useBookmarks'
-import { useBookmarkList } from './useBookmarkList'
-import { useBookmarkActions } from './useBookmarkActions'
-import { useBookmarkReorder } from './useBookmarkReorder'
-import { useApi } from '../contexts/ApiContext'
+import { useState, useCallback } from 'react'
+import { useBookmarks, useUpdateBookmark, useDeleteBookmark } from './useBookmarks'
+import { getOrigin, validateApiUrl } from '@shared/utils/url'
+import {
+  LOG_MESSAGES,
+  UI_MESSAGES,
+  COMMON_MESSAGES,
+} from '@shared/constants'
 import { useQueryClient } from '@tanstack/react-query'
+import { useApi } from '../contexts/ApiContext'
+import { useBookmarkReorder } from './useBookmarkReorder'
+import type { BookmarkId } from '@shared/schemas/bookmark'
 
 export const useApp = () => {
+  const [selectedId, setSelectedId] = useState<BookmarkId | null>(null)
   const [showSettings, setShowSettings] = useState(false)
-  const { apiUrl, updateApiUrl } = useApi()
   const queryClient = useQueryClient()
+  const { apiUrl: currentApiUrl, updateApiUrl } = useApi()
 
   const { data, isLoading, error } = useBookmarks()
-  const { selectedId, handleRowClick, setSelectedId } = useBookmarkList()
-  const { updateBookmark, deleteBookmark, openBookmark, closeDetail } =
-    useBookmarkActions(setSelectedId)
+  const updateMutation = useUpdateBookmark()
+  const deleteMutation = useDeleteBookmark()
   const { handleReorder } = useBookmarkReorder()
 
-  const bookmarks = data?.bookmarks ?? []
-  const selectedBookmark = bookmarks.find((b: Bookmark) => b.id === selectedId)
+  const bookmarks = data?.bookmarks || []
+  const selectedBookmark = bookmarks.find((b) => b.id === selectedId)
 
-  const handleDoubleClick = useCallback(
-    (id: BookmarkId, url: string) => {
-      setSelectedId(id)
-      openBookmark(url)
-    },
-    [setSelectedId, openBookmark],
-  )
+  const handleRowClick = useCallback((id: BookmarkId) => {
+    setSelectedId(id)
+  }, [])
+
+  const handleDoubleClick = useCallback((id: BookmarkId, url: string) => {
+    setSelectedId(id)
+    window.open(url, '_blank', 'noopener,noreferrer')
+  }, [])
 
   const handleUpdate = useCallback(
-    (title: string, url: string) => {
+    async (title: string, url: string) => {
       if (selectedBookmark) {
-        updateBookmark(selectedBookmark.id, { title, url })
+        await updateMutation.mutateAsync({
+          id: selectedBookmark.id,
+          updates: { title, url },
+        })
       }
     },
-    [selectedBookmark, updateBookmark],
+    [selectedBookmark, updateMutation],
   )
 
-  const handleDelete = useCallback(() => {
-    if (selectedBookmark) {
-      deleteBookmark(selectedBookmark.id)
+  const handleDelete = useCallback(async () => {
+    if (selectedBookmark && window.confirm(UI_MESSAGES.DELETE_CONFIRM)) {
+      await deleteMutation.mutateAsync(selectedBookmark.id)
+      setSelectedId(null)
     }
-  }, [selectedBookmark, deleteBookmark])
+  }, [selectedBookmark, deleteMutation])
 
   const handleOpen = useCallback(() => {
     if (selectedBookmark) {
-      openBookmark(selectedBookmark.url)
+      window.open(selectedBookmark.url, '_blank', 'noopener,noreferrer')
     }
-  }, [selectedBookmark, openBookmark])
+  }, [selectedBookmark])
 
   const handleClose = useCallback(() => {
-    closeDetail()
-  }, [closeDetail])
-
-  const handleSaveSettings = useCallback((newUrl: string) => {
-    const error = validateApiUrl(newUrl)
-    if (error) {
-      return error
-    }
-
-    try {
-      const sanitizedUrl = getOrigin(newUrl)
-      
-      // Context 経由で URL を更新（localStorage への保存も Context 内部で行われる）
-      updateApiUrl(sanitizedUrl)
-      
-      // キャッシュを完全にクリアして新しい接続先から強制的に再取得させる
-      queryClient.clear()
-      
-      // リロード前に設定パネルを閉じる
-      setShowSettings(false)
-      
-      return null
-    } catch (err) {
-      console.error('Failed to save settings:', err)
-      return err instanceof Error ? err.message : COMMON_MESSAGES.UNKNOWN_ERROR
-    }
-  }, [updateApiUrl, queryClient])
+    setSelectedId(null)
+  }, [])
 
   const toggleSettings = useCallback(() => {
     setShowSettings((prev) => !prev)
@@ -89,25 +71,42 @@ export const useApp = () => {
     setShowSettings(false)
   }, [])
 
+  const handleSaveSettings = useCallback(
+    (newUrl: string): string | null => {
+      try {
+        const error = validateApiUrl(newUrl)
+        if (error) return error
+
+        const sanitizedUrl = getOrigin(newUrl)
+        updateApiUrl(sanitizedUrl)
+        queryClient.clear()
+        setShowSettings(false)
+        return null
+      } catch (err) {
+        console.error(LOG_MESSAGES.EXTENSION_SETTING_SAVE_FAILED, err)
+        return err instanceof Error ? err.message : COMMON_MESSAGES.UNKNOWN_ERROR
+      }
+    },
+    [updateApiUrl, queryClient],
+  )
+
   return {
-    // 状態
     bookmarks,
-    selectedBookmark,
-    selectedId,
     isLoading,
     error,
+    selectedId,
+    selectedBookmark,
     showSettings,
-    currentApiUrl: apiUrl,
-    // ハンドラ
+    currentApiUrl,
     handleRowClick,
     handleDoubleClick,
     handleUpdate,
     handleDelete,
     handleOpen,
     handleClose,
-    handleReorder,
-    handleSaveSettings,
     toggleSettings,
     closeSettings,
+    handleSaveSettings,
+    handleReorder,
   }
 }

--- a/src/hooks/useApp.ts
+++ b/src/hooks/useApp.ts
@@ -1,10 +1,15 @@
 import { useState, useCallback } from 'react'
-import { useBookmarks, useUpdateBookmark, useDeleteBookmark } from './useBookmarks'
+import {
+  useBookmarks,
+  useUpdateBookmark,
+  useDeleteBookmark,
+} from './useBookmarks'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
 import {
   LOG_MESSAGES,
   UI_MESSAGES,
   COMMON_MESSAGES,
+  HTML_ATTRIBUTES,
 } from '@shared/constants'
 import { useQueryClient } from '@tanstack/react-query'
 import { useApi } from '../contexts/ApiContext'
@@ -31,7 +36,11 @@ export const useApp = () => {
 
   const handleDoubleClick = useCallback((id: BookmarkId, url: string) => {
     setSelectedId(id)
-    window.open(url, '_blank', 'noopener,noreferrer')
+    window.open(
+      url,
+      HTML_ATTRIBUTES.TARGET_BLANK,
+      HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
+    )
   }, [])
 
   const handleUpdate = useCallback(
@@ -55,7 +64,11 @@ export const useApp = () => {
 
   const handleOpen = useCallback(() => {
     if (selectedBookmark) {
-      window.open(selectedBookmark.url, '_blank', 'noopener,noreferrer')
+      window.open(
+        selectedBookmark.url,
+        HTML_ATTRIBUTES.TARGET_BLANK,
+        HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
+      )
     }
   }, [selectedBookmark])
 
@@ -84,7 +97,9 @@ export const useApp = () => {
         return null
       } catch (err) {
         console.error(LOG_MESSAGES.EXTENSION_SETTING_SAVE_FAILED, err)
-        return err instanceof Error ? err.message : COMMON_MESSAGES.UNKNOWN_ERROR
+        return err instanceof Error
+          ? err.message
+          : COMMON_MESSAGES.UNKNOWN_ERROR
       }
     },
     [updateApiUrl, queryClient],

--- a/src/hooks/useBookmarkActions.test.tsx
+++ b/src/hooks/useBookmarkActions.test.tsx
@@ -1,8 +1,11 @@
-import { renderHook, act } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useBookmarkActions } from './useBookmarkActions'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { HTML_ATTRIBUTES } from '@shared/constants'
 import { MOCK_BOOKMARK_1, VALID_URLS } from '@shared/test/fixtures'
-import { useUpdateBookmark, useDeleteBookmark } from './useBookmarks'
+import { act, renderHook } from '@testing-library/react'
+
+import { useBookmarkActions } from './useBookmarkActions'
+import { useDeleteBookmark, useUpdateBookmark } from './useBookmarks'
 
 // Mutations をモック化
 vi.mock('./useBookmarks', () => ({
@@ -52,8 +55,8 @@ describe('useBookmarkActions Hook', () => {
       if (expected) {
         expect(window.open).toHaveBeenCalledWith(
           url,
-          '_blank',
-          'noopener,noreferrer',
+          HTML_ATTRIBUTES.TARGET_BLANK,
+          HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
         )
       } else {
         expect(window.open).not.toHaveBeenCalled()

--- a/src/hooks/useBookmarkActions.ts
+++ b/src/hooks/useBookmarkActions.ts
@@ -1,10 +1,14 @@
 import { useCallback } from 'react'
 
-import { UI_MESSAGES } from '@shared/constants'
+import { HTML_ATTRIBUTES, UI_MESSAGES } from '@shared/constants'
 import { isHttpUrl } from '@shared/utils/url'
+
 import { useDeleteBookmark, useUpdateBookmark } from './useBookmarks'
 
-import type { BookmarkId, UpdateBookmarkRequest } from '@shared/schemas/bookmark'
+import type {
+  BookmarkId,
+  UpdateBookmarkRequest,
+} from '@shared/schemas/bookmark'
 
 export const useBookmarkActions = (
   setSelectedId: (id: BookmarkId | null) => void,
@@ -41,7 +45,11 @@ export const useBookmarkActions = (
    */
   const openBookmark = useCallback((url: string) => {
     if (isHttpUrl(url)) {
-      window.open(url, '_blank', 'noopener,noreferrer')
+      window.open(
+        url,
+        HTML_ATTRIBUTES.TARGET_BLANK,
+        HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
+      )
     }
   }, [])
 

--- a/src/hooks/useBookmarkReorder.test.tsx
+++ b/src/hooks/useBookmarkReorder.test.tsx
@@ -4,7 +4,7 @@ import { useBookmarkReorder } from './useBookmarkReorder'
 import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2 } from '@shared/test/fixtures'
 import { renderHook } from '../test/utils'
 import { useReorderBookmarks, useBookmarks } from './useBookmarks'
-import { LOG_MESSAGES } from '@shared/constants'
+import { LOG_MESSAGES, TEST_MESSAGES } from '@shared/constants'
 
 describe('useBookmarkReorder Hook (DI Pattern)', () => {
   const mockMutate = vi.fn()
@@ -57,7 +57,7 @@ describe('useBookmarkReorder Hook (DI Pattern)', () => {
 
   it('例外が発生した場合にキャッチしてログを出力すること', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    mockMutate.mockImplementationOnce(() => { throw new Error('Mutation failed') })
+    mockMutate.mockImplementationOnce(() => { throw new Error(TEST_MESSAGES.MUTATION_FAILED) })
 
     const { result } = renderReorderHook()
     act(() => { result.current.handleReorder(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_2.id) })


### PR DESCRIPTION
## 概要
プロジェクト全体に散在していたマジックストリング（エラーメッセージ、ログ、ステータス、設定値、プレースホルダーなど）を `shared/constants.ts` に集約し、保守性と型安全性を向上させました。

## 変更内容
### 1. 定数の集約 (`shared/constants.ts`)
- `UI_STATUS`: UI の処理状態 (`idle`, `loading`, `success`, `error`) を定義。
- `StatusInfo`: 状態とメッセージを組み合わせた共通型を定義。
- `STATUS_STYLES`: UI 状態に応じた共通のデザイン（背景色・文字色）を定義。
- `PLACEHOLDERS`: 入力フィールドの共通プレースホルダー（タイトル、URL）を定義。
- `ENV_NAMES`: 環境変数名 (`test`, `development`, `production`) を定数化。
- `DB_CONSTANTS`: DBファイル名や PRAGMA 設定を定数化。
- `HTML_ATTRIBUTES`: `window.open` の引数など、HTML属性値を定数化。
- その他、サーバーポート (`DEFAULT_SERVER_PORT`) や許可オリジン (`ALLOWED_ORIGINS`) などを追加。

### 2. モジュールへの適用
- **Server**: `db.ts`, `index.ts`, `bookmarks.ts` において、例外メッセージや設定値を定数へ置き換え。一意制約違反の判定をヘルパー化。
- **Frontend**: `useApp.ts`, `BookmarkDetail.tsx` 等でログ、テストメッセージ、HTML属性、プレースホルダーを定数化。
- **Extension**: `background.ts`, `Popup`, `Options` モジュール全体のステータス管理を `UI_STATUS` / `StatusInfo` / `STATUS_STYLES` へ統合。プレースホルダーを Web アプリ側と統一。
- **Build Scripts**: `sync-version.ts` の全てのログとエラーメッセージを定数化し、堅牢性を向上。

### 3. テストの修正
- 全ての関連テストコードにおいて、期待値として定数を使用するように修正し、実装との一貫性を確保しました。

## 確認事項
- [x] `npm run lint` がパスすること
- [x] `npm run type-check` がパスすること
- [x] 全てのテスト（210件）がパスすること