### PR TITLE
Issue #134: 一覧の状態管理の useBookmarkListState への分離

### DIFF
--- a/src/hooks/useApp.ts
+++ b/src/hooks/useApp.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useCallback } from 'react'
 import {
   useBookmarks,
   useUpdateBookmark,
@@ -8,12 +8,11 @@ import {
   UI_MESSAGES,
   HTML_ATTRIBUTES,
 } from '@shared/constants'
-import { useBookmarkReorder } from './useBookmarkReorder'
 import { useSettings } from './useSettings'
+import { useBookmarkListState } from './useBookmarkListState'
 import type { BookmarkId } from '@shared/schemas/bookmark'
 
 export const useApp = () => {
-  const [selectedId, setSelectedId] = useState<BookmarkId | null>(null)
   const {
     showSettings,
     currentApiUrl,
@@ -22,17 +21,19 @@ export const useApp = () => {
     handleSaveSettings,
   } = useSettings()
 
+  const {
+    selectedId,
+    setSelectedId,
+    handleRowClick,
+    handleReorder,
+  } = useBookmarkListState()
+
   const { data, isLoading, error } = useBookmarks()
   const updateMutation = useUpdateBookmark()
   const deleteMutation = useDeleteBookmark()
-  const { handleReorder } = useBookmarkReorder()
 
   const bookmarks = data?.bookmarks || []
   const selectedBookmark = bookmarks.find((b) => b.id === selectedId)
-
-  const handleRowClick = useCallback((id: BookmarkId) => {
-    setSelectedId(id)
-  }, [])
 
   const handleDoubleClick = useCallback((id: BookmarkId, url: string) => {
     setSelectedId(id)
@@ -41,7 +42,7 @@ export const useApp = () => {
       HTML_ATTRIBUTES.TARGET_BLANK,
       HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
     )
-  }, [])
+  }, [setSelectedId])
 
   const handleUpdate = useCallback(
     async (title: string, url: string) => {
@@ -60,7 +61,7 @@ export const useApp = () => {
       await deleteMutation.mutateAsync(selectedBookmark.id)
       setSelectedId(null)
     }
-  }, [selectedBookmark, deleteMutation])
+  }, [selectedBookmark, deleteMutation, setSelectedId])
 
   const handleOpen = useCallback(() => {
     if (selectedBookmark) {
@@ -74,7 +75,7 @@ export const useApp = () => {
 
   const handleClose = useCallback(() => {
     setSelectedId(null)
-  }, [])
+  }, [setSelectedId])
 
   return {
     bookmarks,

--- a/src/hooks/useBookmarkListState.test.ts
+++ b/src/hooks/useBookmarkListState.test.ts
@@ -1,0 +1,43 @@
+import { act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useBookmarkListState } from './useBookmarkListState'
+import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
+import { renderHook } from '../test/utils'
+
+// useBookmarkReorder をモック化して、余計なフェッチが発生しないようにする
+vi.mock('./useBookmarkReorder', () => ({
+  useBookmarkReorder: vi.fn(() => ({
+    handleReorder: vi.fn(),
+  })),
+}))
+
+describe('useBookmarkListState Hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('初期状態で selectedId が null であること', () => {
+    const { result } = renderHook(() => useBookmarkListState())
+    expect(result.current.selectedId).toBeNull()
+  })
+
+  it('handleRowClick で selectedId が更新されること', () => {
+    const { result } = renderHook(() => useBookmarkListState())
+
+    act(() => {
+      result.current.handleRowClick(MOCK_BOOKMARK_1.id)
+    })
+
+    expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
+  })
+
+  it('setSelectedId を直接呼んで更新できること', () => {
+    const { result } = renderHook(() => useBookmarkListState())
+
+    act(() => {
+      result.current.setSelectedId(MOCK_BOOKMARK_1.id)
+    })
+
+    expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
+  })
+})

--- a/src/hooks/useBookmarkListState.ts
+++ b/src/hooks/useBookmarkListState.ts
@@ -1,0 +1,22 @@
+import { useState, useCallback } from 'react'
+import { useBookmarkReorder } from './useBookmarkReorder'
+import type { BookmarkId } from '@shared/schemas/bookmark'
+
+/**
+ * ブックマーク一覧の表示状態（選択、並び替え）を管理するフック
+ */
+export const useBookmarkListState = () => {
+  const [selectedId, setSelectedId] = useState<BookmarkId | null>(null)
+  const { handleReorder } = useBookmarkReorder()
+
+  const handleRowClick = useCallback((id: BookmarkId) => {
+    setSelectedId(id)
+  }, [])
+
+  return {
+    selectedId,
+    setSelectedId,
+    handleRowClick,
+    handleReorder,
+  }
+}


### PR DESCRIPTION
## 概要
`src/hooks/useApp.ts` に含まれていた「ブックマーク一覧の選択状態」および「並び替えロジック」を、独立したカスタムフック `useBookmarkListState.ts` へ分離しました。

## 変更内容
### 1. 新しいフックの導入
- **`useBookmarkListState.ts`**: 以下の責務を担当。
    - 選択中のブックマーク ID (`selectedId`) の管理。
    - 行クリック時の状態更新 (`handleRowClick`)。
    - 並び替え実行のハンドラ (`handleReorder`)。

### 2. コードの整理
- **`useApp.ts`**: リスト管理のロジックを新フックへ委譲し、コードの見通しをさらに改善。
- **テストの追加**: 新フックに対する単体テストを追加し、カバレッジ 100% を達成。テスト実行時の MSW 警告も解消済み。

## 確認事項
- [x] `npm run lint` がパスすること
- [x] `npm run type-check` がパスすること
- [x] 全てのテスト（203件）が正常にパスすること
- [x] カバレッジが劣化していないことを確認済み