### PR TITLE
Issue #139: useBookmarkListState の純粋化

### DIFF
--- a/src/hooks/useApp.ts
+++ b/src/hooks/useApp.ts
@@ -10,6 +10,7 @@ import {
 } from '@shared/constants'
 import { useSettings } from './useSettings'
 import { useBookmarkListState } from './useBookmarkListState'
+import { useBookmarkReorder } from './useBookmarkReorder'
 import type { BookmarkId } from '@shared/schemas/bookmark'
 
 export const useApp = () => {
@@ -25,12 +26,12 @@ export const useApp = () => {
     selectedId,
     setSelectedId,
     handleRowClick,
-    handleReorder,
   } = useBookmarkListState()
 
   const { data, isLoading, error } = useBookmarks()
   const updateMutation = useUpdateBookmark()
   const deleteMutation = useDeleteBookmark()
+  const { handleReorder } = useBookmarkReorder()
 
   const bookmarks = data?.bookmarks || []
   const selectedBookmark = bookmarks.find((b) => b.id === selectedId)

--- a/src/hooks/useBookmarkListState.test.ts
+++ b/src/hooks/useBookmarkListState.test.ts
@@ -4,13 +4,6 @@ import { useBookmarkListState } from './useBookmarkListState'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 import { renderHook } from '../test/utils'
 
-// useBookmarkReorder をモック化して、余計なフェッチが発生しないようにする
-vi.mock('./useBookmarkReorder', () => ({
-  useBookmarkReorder: vi.fn(() => ({
-    handleReorder: vi.fn(),
-  })),
-}))
-
 describe('useBookmarkListState Hook', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/hooks/useBookmarkListState.ts
+++ b/src/hooks/useBookmarkListState.ts
@@ -1,13 +1,12 @@
 import { useState, useCallback } from 'react'
-import { useBookmarkReorder } from './useBookmarkReorder'
 import type { BookmarkId } from '@shared/schemas/bookmark'
 
 /**
- * ブックマーク一覧の表示状態（選択、並び替え）を管理するフック
+ * ブックマーク一覧の表示状態（選択）を管理するフック
+ * API 操作を含まない純粋な UI 状態管理に専念する
  */
 export const useBookmarkListState = () => {
   const [selectedId, setSelectedId] = useState<BookmarkId | null>(null)
-  const { handleReorder } = useBookmarkReorder()
 
   const handleRowClick = useCallback((id: BookmarkId) => {
     setSelectedId(id)
@@ -17,6 +16,5 @@ export const useBookmarkListState = () => {
     selectedId,
     setSelectedId,
     handleRowClick,
-    handleReorder,
   }
 }


### PR DESCRIPTION
## 概要
`src/hooks/useBookmarkListState.ts` フックから API 操作（並び替え実行）の依存を排除し、純粋な UI 状態管理（選択 ID の管理等）のみを担当するフックにリファクタリングしました。

## 変更内容
### 1. フックの純粋化
- **`useBookmarkListState.ts`**: `useBookmarkReorder` の呼び出しを削除し、`selectedId` とそのハンドラのみを提供するように修正。
- **`useBookmarkListState.test.ts`**: 外部依存（モック）を排除し、純粋なロジックテストとして再構成。

### 2. useApp の調整
- **`useApp.ts`**: 並び替えロジック (`handleReorder`) を、`useBookmarkReorder` から直接取得するように修正。これは将来的に `useBookmarkCommands` へ集約するための準備段階です。

## 確認事項
- [x] `npm run lint` がパスすること
- [x] `npm run type-check` がパスすること
- [x] 全てのテスト（203件）が正常にパスすること