### PR TITLE
Issue #126: window.open 実行前の URL バリデーションの徹底

### DIFF
--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -287,6 +287,7 @@ export const LOG_MESSAGES = {
   VERSION_SYNC_ERROR: '[sync-version] Error syncing versions:',
   UPDATED_VERSION: (version: string) =>
     `[sync-version] Updated manifest.json version to ${version}`,
+  BLOCKED_NON_HTTP_URL: (url: string) => `Blocked opening non-HTTP URL: ${url}`,
 } as const
 
 /**

--- a/shared/utils/url.test.ts
+++ b/shared/utils/url.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect } from 'vitest'
-import { isHttpUrl, getOrigin, validateApiUrl } from './url'
-import { ERROR_MESSAGES, VALIDATION_MESSAGES } from '@shared/constants'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { isHttpUrl, getOrigin, validateApiUrl, openUrlInNewTab } from './url'
+import {
+  ERROR_MESSAGES,
+  VALIDATION_MESSAGES,
+  HTML_ATTRIBUTES,
+  LOG_MESSAGES,
+} from '@shared/constants'
 import { VALID_URLS, INVALID_URLS } from '@shared/test/fixtures'
 
 describe('url utilities', () => {
@@ -98,5 +103,58 @@ describe('url utilities', () => {
     it.each(validateTestData)('$name', ({ url, message }) => {
       expect(validateApiUrl(url)).toBe(message)
     })
+  })
+
+  describe('openUrlInNewTab', () => {
+    beforeEach(() => {
+      vi.stubGlobal('window', { open: vi.fn() })
+      vi.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    it.each([
+      {
+        name: 'http',
+        url: VALID_URLS.HTTP,
+      },
+      {
+        name: 'https',
+        url: VALID_URLS.HTTPS,
+      },
+    ])('有効な $name URL の場合に window.open を呼び出すこと', ({ url }) => {
+      openUrlInNewTab(url)
+      expect(window.open).toHaveBeenCalledWith(
+        url,
+        HTML_ATTRIBUTES.TARGET_BLANK,
+        HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
+      )
+    })
+
+    it.each([
+      {
+        name: 'FTP',
+        url: INVALID_URLS.FTP,
+      },
+      {
+        name: 'JAVASCRIPT',
+        url: INVALID_URLS.JAVASCRIPT,
+      },
+      {
+        name: 'NO_PROTOCOL',
+        url: INVALID_URLS.NO_PROTOCOL,
+      },
+      {
+        name: 'MALFORMED',
+        url: INVALID_URLS.MALFORMED,
+      },
+    ])(
+      '不適切な URL ($name) の場合にブロックし、警告を出力すること',
+      ({ url }) => {
+        openUrlInNewTab(url)
+        expect(window.open).not.toHaveBeenCalled()
+        expect(console.warn).toHaveBeenCalledWith(
+          LOG_MESSAGES.BLOCKED_NON_HTTP_URL(url),
+        )
+      },
+    )
   })
 })

--- a/shared/utils/url.ts
+++ b/shared/utils/url.ts
@@ -1,10 +1,30 @@
-import { ERROR_MESSAGES, VALIDATION_MESSAGES } from '@shared/constants'
+import {
+  ERROR_MESSAGES,
+  VALIDATION_MESSAGES,
+  HTML_ATTRIBUTES,
+  LOG_MESSAGES,
+} from '@shared/constants'
 
 /**
  * URL が http:// または https:// で始まっているかを確認する
  */
 export const isHttpUrl = (url: string): boolean => {
   return /^https?:\/\//.test(url)
+}
+
+/**
+ * セキュリティチェックを行った上で URL を新しいタブで開く
+ */
+export const openUrlInNewTab = (url: string) => {
+  if (isHttpUrl(url)) {
+    window.open(
+      url,
+      HTML_ATTRIBUTES.TARGET_BLANK,
+      HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
+    )
+  } else {
+    console.warn(LOG_MESSAGES.BLOCKED_NON_HTTP_URL(url))
+  }
 }
 
 /**

--- a/src/hooks/useApp.test.tsx
+++ b/src/hooks/useApp.test.tsx
@@ -1,11 +1,7 @@
 import { act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useApp } from './useApp'
-import {
-  VALIDATION_MESSAGES,
-  TEST_MESSAGES,
-  HTML_ATTRIBUTES,
-} from '@shared/constants'
+import { VALIDATION_MESSAGES, TEST_MESSAGES, HTML_ATTRIBUTES, LOG_MESSAGES } from '@shared/constants'
 import { http, HttpResponse } from 'msw'
 import { server } from '../test/setup'
 import { renderHook } from '../test/utils'
@@ -15,7 +11,7 @@ describe('useApp Hook (Integration)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     localStorage.clear()
-
+    
     // location.reload をモック
     Object.defineProperty(window, 'location', {
       writable: true,
@@ -26,17 +22,14 @@ describe('useApp Hook (Integration)', () => {
     // MSW のデフォルトハンドラを設定
     server.use(
       http.get('*/api/bookmarks', () => {
-        return HttpResponse.json({
-          success: true,
-          data: { bookmarks: [MOCK_BOOKMARK_1] },
-        })
+        return HttpResponse.json({ success: true, data: { bookmarks: [MOCK_BOOKMARK_1] } })
       }),
       http.patch('*/api/bookmarks/:id', () => {
         return HttpResponse.json({ success: true, data: MOCK_BOOKMARK_1 })
       }),
       http.delete('*/api/bookmarks/:id', () => {
         return new HttpResponse(null, { status: 204 })
-      }),
+      })
     )
   })
 
@@ -45,7 +38,7 @@ describe('useApp Hook (Integration)', () => {
    */
   const renderAppHook = async (initialUrl?: string) => {
     const renderResult = renderHook(() => useApp(), { initialUrl })
-
+    
     // isLoading が false になるまで待機 (act 内で実行)
     await act(async () => {
       await vi.waitFor(() => {
@@ -54,7 +47,7 @@ describe('useApp Hook (Integration)', () => {
         }
       })
     })
-
+    
     return renderResult
   }
 
@@ -63,14 +56,10 @@ describe('useApp Hook (Integration)', () => {
 
     expect(result.current.showSettings).toBe(false)
 
-    act(() => {
-      result.current.toggleSettings()
-    })
+    act(() => { result.current.toggleSettings() })
     expect(result.current.showSettings).toBe(true)
 
-    act(() => {
-      result.current.closeSettings()
-    })
+    act(() => { result.current.closeSettings() })
     expect(result.current.showSettings).toBe(false)
   })
 
@@ -80,17 +69,17 @@ describe('useApp Hook (Integration)', () => {
       http.patch('*/api/bookmarks/:id', () => {
         patchCalled = true
         return HttpResponse.json({ success: true, data: MOCK_BOOKMARK_1 })
-      }),
+      })
     )
 
     const { result } = await renderAppHook()
-
+    
     act(() => {
       result.current.handleRowClick(MOCK_BOOKMARK_1.id)
     })
 
     await act(async () => {
-      result.current.handleUpdate('New Title', 'http://new.com')
+      await result.current.handleUpdate('New Title', 'http://new.com')
     })
 
     // 副作用 (API 呼び出し) を検証
@@ -113,7 +102,7 @@ describe('useApp Hook (Integration)', () => {
   describe('ブックマーク操作の検証', () => {
     it('handleRowClick でブックマークが選択されること', async () => {
       const { result } = await renderAppHook()
-
+      
       act(() => {
         result.current.handleRowClick(MOCK_BOOKMARK_1.id)
       })
@@ -127,37 +116,46 @@ describe('useApp Hook (Integration)', () => {
       const { result } = await renderAppHook()
 
       act(() => {
-        result.current.handleDoubleClick(
-          MOCK_BOOKMARK_1.id,
-          MOCK_BOOKMARK_1.url,
-        )
+        result.current.handleDoubleClick(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_1.url)
       })
 
       expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
       expect(openSpy).toHaveBeenCalledWith(
-        MOCK_BOOKMARK_1.url,
-        HTML_ATTRIBUTES.TARGET_BLANK,
-        HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
+        MOCK_BOOKMARK_1.url, 
+        HTML_ATTRIBUTES.TARGET_BLANK, 
+        HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER
       )
+    })
+
+    it('不正な URL の場合は handleDoubleClick で window.open が呼ばれず、警告ログが出ること', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { result } = await renderAppHook()
+      const maliciousUrl = 'javascript:alert(1)'
+
+      act(() => {
+        result.current.handleDoubleClick(MOCK_BOOKMARK_1.id, maliciousUrl)
+      })
+
+      expect(openSpy).not.toHaveBeenCalled()
+      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.BLOCKED_NON_HTTP_URL(maliciousUrl))
     })
 
     it('handleDelete, handleOpen, handleClose が正しく動作すること', async () => {
       let deleteCalled = false
       vi.spyOn(window, 'confirm').mockReturnValue(true)
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
-
+      
       server.use(
         http.delete('*/api/bookmarks/:id', () => {
           deleteCalled = true
           return new HttpResponse(null, { status: 204 })
-        }),
+        })
       )
 
       const { result } = await renderAppHook()
-
-      act(() => {
-        result.current.handleRowClick(MOCK_BOOKMARK_1.id)
-      })
+      
+      act(() => { result.current.handleRowClick(MOCK_BOOKMARK_1.id) })
 
       await act(async () => {
         result.current.handleOpen()
@@ -165,7 +163,11 @@ describe('useApp Hook (Integration)', () => {
         result.current.handleClose()
       })
 
-      expect(openSpy).toHaveBeenCalled()
+      expect(openSpy).toHaveBeenCalledWith(
+        MOCK_BOOKMARK_1.url,
+        HTML_ATTRIBUTES.TARGET_BLANK,
+        HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER
+      )
       expect(deleteCalled).toBe(true)
       expect(result.current.selectedId).toBeNull()
     })

--- a/src/hooks/useApp.ts
+++ b/src/hooks/useApp.ts
@@ -6,11 +6,11 @@ import {
 } from './useBookmarks'
 import {
   UI_MESSAGES,
-  HTML_ATTRIBUTES,
 } from '@shared/constants'
 import { useSettings } from './useSettings'
 import { useBookmarkListState } from './useBookmarkListState'
 import { useBookmarkReorder } from './useBookmarkReorder'
+import { openUrlInNewTab } from '@shared/utils/url'
 import type { BookmarkId } from '@shared/schemas/bookmark'
 
 export const useApp = () => {
@@ -38,11 +38,7 @@ export const useApp = () => {
 
   const handleDoubleClick = useCallback((id: BookmarkId, url: string) => {
     setSelectedId(id)
-    window.open(
-      url,
-      HTML_ATTRIBUTES.TARGET_BLANK,
-      HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
-    )
+    openUrlInNewTab(url)
   }, [setSelectedId])
 
   const handleUpdate = useCallback(
@@ -66,11 +62,7 @@ export const useApp = () => {
 
   const handleOpen = useCallback(() => {
     if (selectedBookmark) {
-      window.open(
-        selectedBookmark.url,
-        HTML_ATTRIBUTES.TARGET_BLANK,
-        HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
-      )
+      openUrlInNewTab(selectedBookmark.url)
     }
   }, [selectedBookmark])
 


### PR DESCRIPTION
## 概要
セキュリティ向上のため、`window.open` を使用して外部 URL を開く際、事前に `isHttpUrl` による検証を行う仕組みを導入しました。

Closes #126

## 変更内容
### 1. ヘルパー関数の導入 (`shared/utils/url.ts`)
- **`openUrlInNewTab(url: string)`**:
    - `isHttpUrl(url)` を使用して、`http:` または `https:` プロトコルのみを許可。
    - 検証を通過した場合のみ、安全な属性（`noopener,noreferrer`）を付与して `window.open` を実行。
    - 検証に失敗した場合は警告ログを出力。

### 2. アプリケーションへの適用
- **`src/hooks/useApp.ts`**: 既存の `window.open` 呼び出し箇所を全て `openUrlInNewTab` に置き換え。

### 3. テストの拡充
- **`url.test.ts`**: `openUrlInNewTab` の正常系（許可）および異常系（拒否）のユニットテストを追加。
- **`useApp.test.tsx`**: 不正なブックマーク URL を開こうとした際に、`window.open` が呼ばれないことを統合テストで確認。

## 確認事項
- [x] `npm run lint` がパスすること
- [x] `npm run type-check` がパスすること
- [x] 全てのテスト（206件）が正常にパスすること