### PR TITLE
Issue #130: コンポーネント定義のモダン化 (React.FC 廃止)

### DIFF
--- a/shared/components/ui/Button.tsx
+++ b/shared/components/ui/Button.tsx
@@ -9,13 +9,13 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode
 }
 
-export const Button: React.FC<ButtonProps> = ({
+export const Button = ({
   variant = 'primary',
   size = 'small',
   children,
   className = '',
   ...props
-}) => {
+}: ButtonProps) => {
   const sizeStyles: Record<ButtonSize, string> = {
     small: 'h-5 px-1 text-[10px] transform scale-90 origin-right',
     medium: 'h-10 px-4 text-xs',

--- a/shared/components/ui/InputField.tsx
+++ b/shared/components/ui/InputField.tsx
@@ -5,12 +5,12 @@ interface InputFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
   id: string
 }
 
-export const InputField: React.FC<InputFieldProps> = ({
+export const InputField = ({
   label,
   id,
   className = '',
   ...props
-}) => {
+}: InputFieldProps) => {
   return (
     <div className="flex items-center gap-4">
       <label

--- a/src/components/BookmarkDetail.tsx
+++ b/src/components/BookmarkDetail.tsx
@@ -14,13 +14,13 @@ interface BookmarkDetailProps {
   onClose: () => void
 }
 
-export const BookmarkDetail: React.FC<BookmarkDetailProps> = ({
+export const BookmarkDetail = ({
   bookmark,
   onUpdate,
   onDelete,
   onOpen,
   onClose,
-}) => {
+}: BookmarkDetailProps) => {
   const [editTitle, setEditTitle] = useState(bookmark.title)
   const [editUrl, setEditUrl] = useState(bookmark.url)
 

--- a/src/components/BookmarkItem.tsx
+++ b/src/components/BookmarkItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import { memo } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { ARIA_ROLES, ARIA_ATTRIBUTES, HTML_ATTRIBUTES } from '@shared/constants'
@@ -13,7 +13,7 @@ interface BookmarkItemProps {
   onClose: () => void
 }
 
-export const BookmarkItem: React.FC<BookmarkItemProps> = memo(
+export const BookmarkItem = memo(
   ({
     bookmark,
     isSelected,
@@ -21,7 +21,7 @@ export const BookmarkItem: React.FC<BookmarkItemProps> = memo(
     onRowClick,
     onDoubleClick,
     onClose,
-  }) => {
+  }: BookmarkItemProps) => {
     const {
       attributes,
       listeners,

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useExtensionSync } from '../hooks/useExtensionSync'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
@@ -10,11 +10,11 @@ interface SettingsPanelProps {
   currentApiUrl: string
 }
 
-export const SettingsPanel: React.FC<SettingsPanelProps> = ({
+export const SettingsPanel = ({
   onClose,
   onSave,
   currentApiUrl,
-}) => {
+}: SettingsPanelProps) => {
   const [url, setUrl] = useState(currentApiUrl)
   const { syncFromExtension, isSyncing, syncError } = useExtensionSync()
   const [localMessage, setLocalMessage] = useState<string | null>(null)


### PR DESCRIPTION
## 概要
現在プロジェクト内で一部使用されていた `React.FC` 型によるコンポーネント定義を、よりモダンで推奨される「標準的な関数形式（Props に直接型を付ける形式）」へリファクタリングしました。

## 変更内容
### 1. リファクタリング対象ファイル
- `shared/components/ui/InputField.tsx`
- `shared/components/ui/Button.tsx`
- `src/components/BookmarkDetail.tsx`
- `src/components/SettingsPanel.tsx`
- `src/components/BookmarkItem.tsx`

### 2. 修正内容
- `React.FC<Props>` の記述を削除。
- 引数部分に直接型を指定 (`({ prop }: Props) => ...`)。
- それに伴い、未使用となった `import React` を削除。

## 確認事項
- [x] `npm run lint` がパスすること
- [x] `npm run type-check` がパスすること
- [x] 全てのテスト（217件）が正常にパスすること