### PR TITLE
Issue #150: 拡張機能エントリポイントのリファクタリング

### DIFF
--- a/extension/src/main-options.tsx
+++ b/extension/src/main-options.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Options } from './Options'
 import './style.css'
@@ -6,8 +6,8 @@ import './style.css'
 const root = document.getElementById('root')
 if (root) {
   createRoot(root).render(
-    <React.StrictMode>
+    <StrictMode>
       <Options />
-    </React.StrictMode>
+    </StrictMode>,
   )
 }

--- a/extension/src/main-popup.tsx
+++ b/extension/src/main-popup.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { Popup } from './Popup'
 import './style.css'
@@ -6,8 +6,8 @@ import './style.css'
 const root = document.getElementById('root')
 if (root) {
   createRoot(root).render(
-    <React.StrictMode>
+    <StrictMode>
       <Popup />
-    </React.StrictMode>,
+    </StrictMode>,
   )
 }


### PR DESCRIPTION
## 概要
拡張機能のエントリポイントにおける React 参照を、モダンな名前付きインポート形式に統一しました。

Closes #150

## 変更内容
- `extension/src/main-popup.tsx` および `main-options.tsx` において、`React.StrictMode` を `import { StrictMode } from 'react'` による参照に変更。
- 未使用になったデフォルトインポート (`import React`) を削除。

## 確認事項
- [x] `npm run lint` がパスすること
- [x] `extension:build` が正常に完了すること
- [x] 拡張機能に関連するテスト（48件）が正常にパスすること