### PR TITLE
Issue #158: Context/Hook テストの共通ユーティリティへの移行

### DIFF
--- a/src/contexts/ApiContext.test.tsx
+++ b/src/contexts/ApiContext.test.tsx
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, act } from '@testing-library/react'
-import { ApiProvider, useApi } from './ApiContext'
+import { act, renderHook as renderHookOriginal } from '@testing-library/react'
+import { useApi } from './ApiContext'
 import { STORAGE_KEYS, DEFAULT_API_URL, LOG_MESSAGES, ERROR_MESSAGES } from '@shared/constants'
-import { type ReactNode } from 'react'
+import { renderHook } from '../test/utils'
 
 describe('ApiContext', () => {
   beforeEach(() => {
@@ -13,10 +13,7 @@ describe('ApiContext', () => {
   })
 
   it('デフォルトの API URL で初期化されること', () => {
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <ApiProvider>{children}</ApiProvider>
-    )
-    const { result } = renderHook(() => useApi(), { wrapper })
+    const { result } = renderHook(() => useApi())
 
     expect(result.current.apiUrl).toBe(DEFAULT_API_URL)
     expect(result.current.client).toBeDefined()
@@ -26,10 +23,7 @@ describe('ApiContext', () => {
     const savedUrl = 'http://localhost:4000'
     localStorage.setItem(STORAGE_KEYS.API_URL, savedUrl)
 
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <ApiProvider>{children}</ApiProvider>
-    )
-    const { result } = renderHook(() => useApi(), { wrapper })
+    const { result } = renderHook(() => useApi())
 
     expect(result.current.apiUrl).toBe(savedUrl)
   })
@@ -38,10 +32,7 @@ describe('ApiContext', () => {
     const invalidUrl = 'ftp://invalid-protocol'
     localStorage.setItem(STORAGE_KEYS.API_URL, invalidUrl)
 
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <ApiProvider>{children}</ApiProvider>
-    )
-    const { result } = renderHook(() => useApi(), { wrapper })
+    const { result } = renderHook(() => useApi())
 
     expect(result.current.apiUrl).toBe(DEFAULT_API_URL)
     expect(console.warn).toHaveBeenCalledWith(
@@ -54,19 +45,13 @@ describe('ApiContext', () => {
     const initialUrl = 'http://localhost:5000'
     localStorage.setItem(STORAGE_KEYS.API_URL, 'http://localhost:4000')
 
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <ApiProvider initialUrl={initialUrl}>{children}</ApiProvider>
-    )
-    const { result } = renderHook(() => useApi(), { wrapper })
+    const { result } = renderHook(() => useApi(), { initialUrl })
 
     expect(result.current.apiUrl).toBe(initialUrl)
   })
 
   it('updateApiUrl で URL が更新され、localStorage に保存されること', () => {
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <ApiProvider>{children}</ApiProvider>
-    )
-    const { result } = renderHook(() => useApi(), { wrapper })
+    const { result } = renderHook(() => useApi())
 
     const newUrl = 'http://localhost:6000'
     act(() => {
@@ -79,10 +64,7 @@ describe('ApiContext', () => {
 
   it('updateApiUrl に不正な URL を渡した場合、更新を中断しエラーをログ出力すること', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    const wrapper = ({ children }: { children: ReactNode }) => (
-      <ApiProvider>{children}</ApiProvider>
-    )
-    const { result } = renderHook(() => useApi(), { wrapper })
+    const { result } = renderHook(() => useApi())
 
     const invalidUrl = 'not-a-url'
     act(() => {
@@ -101,8 +83,9 @@ describe('ApiContext', () => {
     // コンソール出力を抑制
     vi.spyOn(console, 'error').mockImplementation(() => {})
     
+    // カスタムラッパーを介さず、本体の renderHook を使用
     expect(() => {
-      renderHook(() => useApi())
+      renderHookOriginal(() => useApi())
     }).toThrow(ERROR_MESSAGES.API_PROVIDER_REQUIRED)
   })
 })

--- a/src/hooks/useBookmarks.test.tsx
+++ b/src/hooks/useBookmarks.test.tsx
@@ -1,11 +1,9 @@
 import { http, HttpResponse } from 'msw'
-import { type ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { API_PATHS, LOG_MESSAGES } from '@shared/constants'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor } from '../test/utils'
 
 import { server } from '../test/setup'
 import {
@@ -15,25 +13,7 @@ import {
   useReorderBookmarks,
   useUpdateBookmark,
 } from './useBookmarks'
-import { ApiProvider } from '../contexts/ApiContext'
 import type { BookmarkId } from '@shared/schemas/bookmark'
-
-const createTestQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  })
-
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <ApiProvider>
-    <QueryClientProvider client={createTestQueryClient()}>
-      {children}
-    </QueryClientProvider>
-  </ApiProvider>
-)
 
 describe('useBookmarks Hook', () => {
   it('useBookmarks が正常にデータを取得すること', async () => {
@@ -46,7 +26,7 @@ describe('useBookmarks Hook', () => {
       }),
     )
 
-    const { result } = renderHook(() => useBookmarks(), { wrapper })
+    const { result } = renderHook(() => useBookmarks())
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data?.bookmarks).toHaveLength(1)
@@ -66,7 +46,7 @@ describe('useBookmarks Hook', () => {
       }),
     )
 
-    const { result } = renderHook(() => useBookmarks(), { wrapper })
+    const { result } = renderHook(() => useBookmarks())
 
     await waitFor(() => expect(result.current.isError).toBe(true))
     expect(result.current.error).toBeInstanceOf(BookmarkApiError)
@@ -82,7 +62,7 @@ describe('useBookmarks Hook', () => {
       }),
     )
 
-    const { result } = renderHook(() => useBookmarks(), { wrapper })
+    const { result } = renderHook(() => useBookmarks())
 
     await waitFor(() => expect(result.current.isError).toBe(true))
     expect(result.current.error?.message).toContain('失敗')
@@ -97,7 +77,7 @@ describe('useBookmarks Hook', () => {
       }),
     )
 
-    const { result } = renderHook(() => useUpdateBookmark(), { wrapper })
+    const { result } = renderHook(() => useUpdateBookmark())
 
     result.current.mutate({ id: MOCK_BOOKMARK_1.id, updates: { title: 'New' } })
 
@@ -113,7 +93,7 @@ describe('useBookmarks Hook', () => {
       }),
     )
 
-    const { result } = renderHook(() => useDeleteBookmark(), { wrapper })
+    const { result } = renderHook(() => useDeleteBookmark())
 
     result.current.mutate(MOCK_BOOKMARK_1.id)
 
@@ -130,7 +110,7 @@ describe('useBookmarks Hook', () => {
       }),
     )
 
-    const { result } = renderHook(() => useDeleteBookmark(), { wrapper })
+    const { result } = renderHook(() => useDeleteBookmark())
 
     result.current.mutate(MOCK_BOOKMARK_1.id)
 
@@ -152,7 +132,7 @@ describe('useBookmarks Hook', () => {
         }),
       )
 
-      const { result } = renderHook(() => useReorderBookmarks(), { wrapper })
+      const { result } = renderHook(() => useReorderBookmarks())
 
       result.current.mutate({ ids: ['2' as BookmarkId, '1' as BookmarkId] })
 


### PR DESCRIPTION
## 概要
`src/contexts/ApiContext.test.tsx` および `src/hooks/useBookmarks.test.tsx` において手動で定義されていた `wrapper` を削除し、`src/test/utils.tsx` のカスタム `renderHook` を使用するようにリファクタリングしました。

Closes #158

## 変更内容
- **`src/contexts/ApiContext.test.tsx`**: 
    - カスタム `renderHook` を導入し、ローカルの `wrapper` 一掃。
    - Provider 外での呼び出しテスト用に、本体の `renderHook` を `renderHookOriginal` として別名インポートして使用。
- **`src/hooks/useBookmarks.test.tsx`**:
    - カスタム `renderHook` に移行し、重複した `wrapper` と `QueryClient` 定義を削除。

## 確認事項
- [x] `npm run lint` がパスすること
- [x] `npm run type-check` がパスすること
- [x] 全てのテスト（217件）が正常にパスすること