### PR TITLE
[Refactor] テストユーティリティの機能強化 (custom wrapper 対応)

### DIFF
--- a/src/test/utils.test.tsx
+++ b/src/test/utils.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from './utils'
+import { type ReactNode } from 'react'
+
+describe('src/test/utils.tsx functional verification', () => {
+  it('customRender supports additional wrapper', () => {
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <div data-testid="custom-wrapper">{children}</div>
+    )
+
+    render(<div data-testid="content">Hello</div>, { wrapper: Wrapper })
+
+    expect(screen.getByTestId('custom-wrapper')).toBeInTheDocument()
+    expect(screen.getByTestId('content')).toBeInTheDocument()
+    expect(screen.getByTestId('custom-wrapper')).toContainElement(screen.getByTestId('content'))
+  })
+
+  it('customRender still provides AllTheProviders context', () => {
+    // ApiProvider が提供する data-testid を確認（実装に依存するが、
+    // ここではラップされていること自体を検証）
+    // ApiProvider は children をそのまま返すか、特定のタグで囲む可能性がある
+    render(<div data-testid="content">Hello</div>)
+    expect(screen.getByTestId('content')).toBeInTheDocument()
+  })
+})

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -47,12 +47,16 @@ export const AllTheProviders = ({
  */
 const customRender = (
   ui: ReactElement,
-  options?: Omit<RenderOptions, 'wrapper'> & { initialUrl?: string }
+  options?: RenderOptions & { initialUrl?: string }
 ) => {
-  const wrapper = (props: { children: ReactNode }) => (
-    <AllTheProviders {...props} initialUrl={options?.initialUrl} />
+  const { wrapper: Wrapper, initialUrl, ...rest } = options || {}
+
+  const CombinedWrapper = ({ children }: { children: ReactNode }) => (
+    <AllTheProviders initialUrl={initialUrl}>
+      {Wrapper ? <Wrapper>{children}</Wrapper> : children}
+    </AllTheProviders>
   )
-  return render(ui, { wrapper, ...options })
+  return render(ui, { wrapper: CombinedWrapper, ...rest })
 }
 
 /**
@@ -60,12 +64,16 @@ const customRender = (
  */
 const customRenderHook = <Result, Props>(
   hookRender: (initialProps: Props) => Result,
-  options?: Omit<RenderHookOptions<Props>, 'wrapper'> & { initialUrl?: string }
+  options?: RenderHookOptions<Props> & { initialUrl?: string }
 ) => {
-  const wrapper = (props: { children: ReactNode }) => (
-    <AllTheProviders {...props} initialUrl={options?.initialUrl} />
+  const { wrapper: Wrapper, initialUrl, ...rest } = options || {}
+
+  const CombinedWrapper = ({ children }: { children: ReactNode }) => (
+    <AllTheProviders initialUrl={initialUrl}>
+      {Wrapper ? <Wrapper>{children}</Wrapper> : children}
+    </AllTheProviders>
   )
-  return renderHook(hookRender, { wrapper, ...options })
+  return renderHook(hookRender, { wrapper: CombinedWrapper, ...rest })
 }
 
 // eslint-disable-next-line react-refresh/only-export-components


### PR DESCRIPTION
### 概要
src/test/utils.tsx の  および  において、 オプションをサポートするように機能を拡張しました。

### 変更内容
-  および  のオプションから  を削除し、 を受け取れるように変更。
- 渡された  を  の内側でラップして実行する  を実装。
-  自体の動作を検証する  を追加。

これにより、Issue #159 や #160 で必要となる  などの追加ラッパーを、共通ユーティリティを使いつつ指定できるようになります。

Closes #162