### PR TITLE
[Refactor] App 統合テストを共通ユーティリティへ移行 (DRY)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -10,12 +10,10 @@ import {
   DEFAULT_API_URL,
 } from '@shared/constants'
 import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2 } from '@shared/test/fixtures'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from './test/utils'
 import userEvent from '@testing-library/user-event'
 
 import App from './App'
-import { ApiProvider } from './contexts/ApiContext'
 import { server } from './test/setup'
 
 import type { UpdateBookmarkRequest } from '@shared/schemas/bookmark'
@@ -60,23 +58,6 @@ vi.mock('@dnd-kit/core', async () => {
   }
 })
 
-const createTestQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  })
-
-const wrapper = ({ children }: { children: ReactNode }) => (
-  <ApiProvider initialUrl={DEFAULT_API_URL}>
-    <QueryClientProvider client={createTestQueryClient()}>
-      {children}
-    </QueryClientProvider>
-  </ApiProvider>
-)
-
 describe('App Integration', () => {
   beforeEach(() => {
     vi.stubGlobal('open', vi.fn())
@@ -110,7 +91,7 @@ describe('App Integration', () => {
         })
       }),
     )
-    render(<App />, { wrapper })
+    render(<App />, { initialUrl: DEFAULT_API_URL })
     return { user }
   }
 
@@ -134,7 +115,7 @@ describe('App Integration', () => {
         )
       }),
     )
-    render(<App />, { wrapper })
+    render(<App />, { initialUrl: DEFAULT_API_URL })
 
     expect(await screen.findByRole(ARIA_ROLES.ALERT)).toBeInTheDocument()
   })


### PR DESCRIPTION
### 概要
src/App.test.tsx において手動定義されていた wrapper を削除し、src/test/utils.tsx のカスタム render を使用するようにリファクタリングしました。

### 変更内容
- render, screen, waitFor のインポート元を ./test/utils に変更。
- 手動定義されていた createTestQueryClient および wrapper を削除。
- render 呼び出しを customRender の引数形式に変更。
- initialUrl オプションを活用してテストケースを簡略化。

これにより、統合テストとしての可読性とメンテナンス性が向上しました。

Closes #160