### PR TITLE
[Refactor] ApiContext.updateApiUrl のシグネチャ変更 (バリデーションエラー返却対応)

### DIFF
--- a/src/contexts/ApiContext.test.tsx
+++ b/src/contexts/ApiContext.test.tsx
@@ -54,24 +54,29 @@ describe('ApiContext', () => {
     const { result } = renderHook(() => useApi())
 
     const newUrl = 'http://localhost:6000'
+    let updateResult: string | null = null
     act(() => {
-      result.current.updateApiUrl(newUrl)
+      updateResult = result.current.updateApiUrl(newUrl)
     })
 
+    expect(updateResult).toBeNull()
     expect(result.current.apiUrl).toBe(newUrl)
     expect(localStorage.getItem(STORAGE_KEYS.API_URL)).toBe(newUrl)
   })
 
-  it('updateApiUrl に不正な URL を渡した場合、更新を中断しエラーをログ出力すること', () => {
+  it('updateApiUrl に不正な URL を渡した場合、更新を中断しエラーを返しログ出力すること', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { result } = renderHook(() => useApi())
 
     const invalidUrl = 'not-a-url'
+    let updateResult: string | null = null
     act(() => {
-      result.current.updateApiUrl(invalidUrl)
+      updateResult = result.current.updateApiUrl(invalidUrl)
     })
 
     // URL は初期値のまま
+    expect(updateResult).not.toBeNull()
+    expect(typeof updateResult).toBe('string')
     expect(result.current.apiUrl).toBe(DEFAULT_API_URL)
     expect(consoleSpy).toHaveBeenCalledWith(
       ERROR_MESSAGES.UPDATE_API_URL_FAILED,

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -16,7 +16,7 @@ import type { AppType } from '../../server/app'
 interface ApiContextType {
   client: ReturnType<typeof hc<AppType>>
   apiUrl: string
-  updateApiUrl: (newUrl: string) => void
+  updateApiUrl: (newUrl: string) => string | null
 }
 
 /**
@@ -68,7 +68,7 @@ export const ApiProvider = ({ children, initialUrl }: ApiProviderProps) => {
     const error = validateApiUrl(newUrl)
     if (error) {
       console.error(ERROR_MESSAGES.UPDATE_API_URL_FAILED, error)
-      return
+      return error
     }
 
     const sanitizedUrl = getOrigin(newUrl)
@@ -76,6 +76,7 @@ export const ApiProvider = ({ children, initialUrl }: ApiProviderProps) => {
     if (typeof window !== 'undefined') {
       localStorage.setItem(STORAGE_KEYS.API_URL, sanitizedUrl)
     }
+    return null
   }, [])
 
   return (


### PR DESCRIPTION
### 概要
 のシグネチャを変更し、バリデーションエラーが発生した場合にエラーメッセージを返せるようにしました。

### 変更内容
-  インターフェースの  の戻り値を  に変更。
-  実装でバリデーションエラー時にエラーを 、成功時に  を  するように変更。
-  を修正し、新しい戻り値の挙動を検証するテストを追加・修正。

### 今後の作業
この変更により、Issue #137 において  等の呼び出し側で  からのフィードバックを利用できるようになり、呼び出し側での重複したバリデーションを削除することが可能になります。

Closes #166