### PR TITLE
[Refactor] ApiContext のバリデーション責務の集約と重複排除

### DIFF
--- a/src/hooks/useSettings.test.ts
+++ b/src/hooks/useSettings.test.ts
@@ -5,15 +5,14 @@ import {
   DEFAULT_API_URL,
   LOG_MESSAGES,
   STORAGE_KEYS,
-  TEST_MESSAGES,
   VALIDATION_MESSAGES,
 } from '@shared/constants'
 import { INVALID_URLS } from '@shared/test/fixtures'
-import * as urlUtils from '@shared/utils/url'
 import { act } from '@testing-library/react'
 
 import { renderHook } from '../test/utils'
 import { useSettings } from './useSettings'
+import * as apiContext from '../contexts/ApiContext'
 
 describe('useSettings Hook', () => {
   beforeEach(() => {
@@ -59,6 +58,14 @@ describe('useSettings Hook', () => {
   })
 
   describe('handleSaveSettings', () => {
+    const setupUseApiMock = (updateApiUrlImpl: () => never) => {
+      vi.spyOn(apiContext, 'useApi').mockReturnValue({
+        apiUrl: DEFAULT_API_URL,
+        client: {} as never,
+        updateApiUrl: vi.fn(updateApiUrlImpl),
+      })
+    }
+
     it('有効な URL の場合、localStorage が更新されること', async () => {
       const { result } = renderHook(() => useSettings())
       const inputUrl = 'http://localhost:4000/path'
@@ -87,8 +94,10 @@ describe('useSettings Hook', () => {
 
     it('例外が発生した場合、エラーメッセージを返し、ログを出力すること', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      vi.spyOn(urlUtils, 'getOrigin').mockImplementation(() => {
-        throw new Error(TEST_MESSAGES.UNEXPECTED_ERROR)
+      const TEST_ERROR = 'Unexpected Error'
+
+      setupUseApiMock(() => {
+        throw new Error(TEST_ERROR)
       })
 
       const { result } = renderHook(() => useSettings())
@@ -98,7 +107,7 @@ describe('useSettings Hook', () => {
         error = result.current.handleSaveSettings(DEFAULT_API_URL)
       })
 
-      expect(error).toBe(TEST_MESSAGES.UNEXPECTED_ERROR)
+      expect(error).toBe(TEST_ERROR)
       expect(consoleSpy).toHaveBeenCalledWith(
         LOG_MESSAGES.EXTENSION_SETTING_SAVE_FAILED,
         expect.any(Error),
@@ -107,7 +116,8 @@ describe('useSettings Hook', () => {
 
     it('Error 以外の例外が発生した場合、共通エラーメッセージを返すこと', () => {
       vi.spyOn(console, 'error').mockImplementation(() => {})
-      vi.spyOn(urlUtils, 'getOrigin').mockImplementation(() => {
+
+      setupUseApiMock(() => {
         throw 'String Error'
       })
 

--- a/src/hooks/useSettings.test.ts
+++ b/src/hooks/useSettings.test.ts
@@ -6,6 +6,7 @@ import {
   LOG_MESSAGES,
   STORAGE_KEYS,
   VALIDATION_MESSAGES,
+  TEST_MESSAGES,
 } from '@shared/constants'
 import { INVALID_URLS } from '@shared/test/fixtures'
 import { act } from '@testing-library/react'
@@ -58,11 +59,13 @@ describe('useSettings Hook', () => {
   })
 
   describe('handleSaveSettings', () => {
-    const setupUseApiMock = (updateApiUrlImpl: () => never) => {
+    const setupUseApiMock = (
+      updateApiUrlImpl: (newUrl: string) => string | null,
+    ) => {
       vi.spyOn(apiContext, 'useApi').mockReturnValue({
         apiUrl: DEFAULT_API_URL,
         client: {} as never,
-        updateApiUrl: vi.fn(updateApiUrlImpl),
+        updateApiUrl: vi.fn().mockImplementation(updateApiUrlImpl),
       })
     }
 
@@ -94,10 +97,9 @@ describe('useSettings Hook', () => {
 
     it('例外が発生した場合、エラーメッセージを返し、ログを出力すること', () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      const TEST_ERROR = 'Unexpected Error'
 
       setupUseApiMock(() => {
-        throw new Error(TEST_ERROR)
+        throw new Error(TEST_MESSAGES.TEST_ERROR)
       })
 
       const { result } = renderHook(() => useSettings())
@@ -107,7 +109,7 @@ describe('useSettings Hook', () => {
         error = result.current.handleSaveSettings(DEFAULT_API_URL)
       })
 
-      expect(error).toBe(TEST_ERROR)
+      expect(error).toBe(TEST_MESSAGES.TEST_ERROR)
       expect(consoleSpy).toHaveBeenCalledWith(
         LOG_MESSAGES.EXTENSION_SETTING_SAVE_FAILED,
         expect.any(Error),

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,7 +1,6 @@
 import { useCallback, useState } from 'react'
 
 import { COMMON_MESSAGES, LOG_MESSAGES } from '@shared/constants'
-import { getOrigin, validateApiUrl } from '@shared/utils/url'
 import { useQueryClient } from '@tanstack/react-query'
 
 import { useApi } from '../contexts/ApiContext'
@@ -25,11 +24,8 @@ export const useSettings = () => {
   const handleSaveSettings = useCallback(
     (newUrl: string): string | null => {
       try {
-        const error = validateApiUrl(newUrl)
+        const error = updateApiUrl(newUrl)
         if (error) return error
-
-        const sanitizedUrl = getOrigin(newUrl)
-        updateApiUrl(sanitizedUrl)
 
         // 設定変更時はキャッシュをクリアして再取得を促す
         queryClient.clear()


### PR DESCRIPTION
### 概要
ApiContext.updateApiUrl の戻り値を利用するように useSettings を修正し、バリデーションの責務を ApiContext に集約しました。

### 変更内容
- useSettings.ts において、手動で行っていた validateApiUrl と getOrigin の呼び出しを削除。
- updateApiUrl の戻り値（バリデーションエラーまたは null）をそのまま利用するように変更。
- useSettings.test.ts を修正し、updateApiUrl 経由でバリデーションや例外が正しくハンドルされることを検証するようにテストを更新。

これにより、API URL のバリデーションロジックが ApiContext に一本化され、DRY 原則が適用されました。

Closes #137