### PR TITLE
[Refactor] useBookmarks フック等の新 QueryKey 定数への移行 (Step 2)

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -9,6 +9,7 @@ import {
 } from '@shared/constants'
 import type { Bookmark, BookmarksResponse } from '@shared/schemas/bookmark'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
+import { QUERY_KEYS } from '../../src/lib/queryKeys'
 
 /**
  * 拡張機能のバックグラウンドプロセス
@@ -68,7 +69,7 @@ const updateIconStatus = async (
 
     // 3. ブックマーク一覧を取得
     const data = await queryClient.fetchQuery<BookmarksResponse>({
-      queryKey: ['bookmarks', sanitizedBaseUrl],
+      queryKey: [...QUERY_KEYS.BOOKMARKS.ALL, sanitizedBaseUrl],
       queryFn: async () => {
         const res = await fetch(`${sanitizedBaseUrl}/api/bookmarks`)
         if (!res.ok) throw new Error(`HTTP Error: ${res.status}`)
@@ -185,7 +186,7 @@ chrome.runtime.onMessageExternal.addListener(
  */
 chrome.runtime.onMessage.addListener((message) => {
   if (message.type === EXTENSION_MESSAGE_TYPES.INVALIDATE_CACHE) {
-    queryClient.invalidateQueries({ queryKey: ['bookmarks'] })
+    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.BOOKMARKS.ALL })
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       const tab = tabs[0]
       if (tab?.id) updateIconStatus(tab.id, tab.url, tab.title)

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -2,7 +2,7 @@ import { HTTP_STATUS, LOG_MESSAGES, UI_MESSAGES } from '@shared/constants'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { useApi } from '../contexts/ApiContext'
-import { bookmarkKeys } from '../lib/queryKeys'
+import { QUERY_KEYS } from '../lib/queryKeys'
 
 import type {
   BookmarkId,
@@ -57,7 +57,7 @@ export const useBookmarks = () => {
   const { client } = useApi()
   
   return useQuery({
-    queryKey: bookmarkKeys.lists(),
+    queryKey: QUERY_KEYS.BOOKMARKS.LIST(),
     queryFn: async () => {
       const res = await client.api.bookmarks.$get()
       return await parseResponse<BookmarksResponse>(res, UI_MESSAGES.FETCH_FAILED)
@@ -88,7 +88,7 @@ export const useUpdateBookmark = () => {
       )
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: bookmarkKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.BOOKMARKS.LIST() })
     },
   })
 }
@@ -110,7 +110,7 @@ export const useDeleteBookmark = () => {
       return await parseResponse<void>(res, UI_MESSAGES.DELETE_FAILED)
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: bookmarkKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.BOOKMARKS.LIST() })
     },
   })
 }
@@ -129,11 +129,11 @@ export const useReorderBookmarks = () => {
     },
     onMutate: async (variables) => {
       // 1. 進行中のクエリを確実にキャンセル（競合防止）
-      await queryClient.cancelQueries({ queryKey: bookmarkKeys.lists() })
+      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.BOOKMARKS.LIST() })
 
       // 2. 現在の状態を保存
       const previousData = queryClient.getQueryData<BookmarksResponse>(
-        bookmarkKeys.lists(),
+        QUERY_KEYS.BOOKMARKS.LIST(),
       )
 
       // 3. 楽観的に更新
@@ -143,7 +143,7 @@ export const useReorderBookmarks = () => {
           .map((id) => bookmarkMap.get(id))
           .filter((b): b is import('@shared/schemas/bookmark').Bookmark => !!b)
 
-        queryClient.setQueryData<BookmarksResponse>(bookmarkKeys.lists(), {
+        queryClient.setQueryData<BookmarksResponse>(QUERY_KEYS.BOOKMARKS.LIST(), {
           ...previousData,
           bookmarks: newBookmarks,
         })
@@ -159,12 +159,12 @@ export const useReorderBookmarks = () => {
 
       // 5. ロールバック
       if (context?.previousData) {
-        queryClient.setQueryData(bookmarkKeys.lists(), context.previousData)
+        queryClient.setQueryData(QUERY_KEYS.BOOKMARKS.LIST(), context.previousData)
       }
     },
     onSettled: () => {
       // 6. 成功・失敗に関わらず最終的な整合性をサーバーと同期
-      queryClient.invalidateQueries({ queryKey: bookmarkKeys.lists() })
+      queryClient.invalidateQueries({ queryKey: QUERY_KEYS.BOOKMARKS.LIST() })
     },
   })
 }


### PR DESCRIPTION
### 概要
Step 1 で導入された `QUERY_KEYS` 定数構造を使用して、既存の `useQuery` や `invalidateQueries` の呼び出し箇所を移行しました。

### 変更内容
- `src/hooks/useBookmarks.ts` 内の `bookmarkKeys.lists()` を `QUERY_KEYS.BOOKMARKS.LIST()` に変更。
- `extension/src/background.ts` 内のハードコードされたクエリキーを `QUERY_KEYS.BOOKMARKS.ALL` を使用するように変更。

### 検証内容
- `src/hooks/useBookmarks.test.tsx` がパスすることを確認。
- `extension/src/background.test.ts` がパスすることを確認。
- `lint` および `type-check` がパスすることを確認。

Closes #169