### PR TITLE
[Refactor] 旧 QueryKey 定数の削除とクリーンアップ (Step 3)

### DIFF
--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -11,9 +11,3 @@ export const QUERY_KEYS = {
       [...QUERY_KEYS.BOOKMARKS.DETAILS(), String(id)] as const,
   },
 } as const
-
-// Step 2 での移行完了後に削除予定
-export const bookmarkKeys = {
-  all: ['bookmarks'] as const,
-  lists: () => [...bookmarkKeys.all, 'list'] as const,
-}


### PR DESCRIPTION
### 概要
新しい `QUERY_KEYS` 定数への移行（Step 2）が完了したため、不要になった古い `bookmarkKeys` 定数を削除しました。

### 変更内容
- `src/lib/queryKeys.ts` から `bookmarkKeys` 定数定義を削除。
- プロジェクト全体を検索し、古い定数への参照が残っていないことを確認。

### 検証内容
- 全てのテスト（219件）がパスすることを確認。
- `lint` および `type-check` がパスすることを確認。

Closes #170