### PR TITLE
[Refactor] ポート番号の検証ロジックを共通関数として切り出し

### DIFF
--- a/shared/utils/url.test.ts
+++ b/shared/utils/url.test.ts
@@ -52,6 +52,7 @@ describe('url utilities', () => {
       { port: 65536, expected: ERROR_MESSAGES.INVALID_PORT },
       { port: 'invalid', expected: ERROR_MESSAGES.INVALID_PORT },
       { port: NaN, expected: ERROR_MESSAGES.INVALID_PORT },
+      { port: 3000.5, expected: ERROR_MESSAGES.INVALID_PORT },
     ]
 
     it.each(portTestData)(

--- a/shared/utils/url.test.ts
+++ b/shared/utils/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { isHttpUrl, getOrigin, validateApiUrl, openUrlInNewTab } from './url'
+import { isHttpUrl, getOrigin, validateApiUrl, openUrlInNewTab, validatePort } from './url'
 import {
   ERROR_MESSAGES,
   VALIDATION_MESSAGES,
@@ -39,6 +39,27 @@ describe('url utilities', () => {
         ERROR_MESSAGES.INVALID_URL,
       )
     })
+  })
+
+  describe('validatePort', () => {
+    const portTestData = [
+      { port: 1024, expected: null },
+      { port: 3000, expected: null },
+      { port: 65535, expected: null },
+      { port: '3030', expected: null },
+      { port: 80, expected: ERROR_MESSAGES.INVALID_PORT },
+      { port: 1023, expected: ERROR_MESSAGES.INVALID_PORT },
+      { port: 65536, expected: ERROR_MESSAGES.INVALID_PORT },
+      { port: 'invalid', expected: ERROR_MESSAGES.INVALID_PORT },
+      { port: NaN, expected: ERROR_MESSAGES.INVALID_PORT },
+    ]
+
+    it.each(portTestData)(
+      'ポート "$port" の場合に $expected を返すこと',
+      ({ port, expected }) => {
+        expect(validatePort(port)).toBe(expected)
+      },
+    )
   })
 
   describe('validateApiUrl', () => {

--- a/shared/utils/url.ts
+++ b/shared/utils/url.ts
@@ -46,7 +46,12 @@ export const getOrigin = (url: string): string => {
 export const validatePort = (port: number | string): string | null => {
   const portNumber = typeof port === 'string' ? Number(port) : port
 
-  if (isNaN(portNumber) || portNumber < 1024 || portNumber > 65535) {
+  if (
+    isNaN(portNumber) ||
+    !Number.isInteger(portNumber) ||
+    portNumber < 1024 ||
+    portNumber > 65535
+  ) {
     return ERROR_MESSAGES.INVALID_PORT
   }
 

--- a/shared/utils/url.ts
+++ b/shared/utils/url.ts
@@ -44,7 +44,7 @@ export const getOrigin = (url: string): string => {
  * 1024-65535 の範囲内であることを確認（特権ポートを制限）
  */
 export const validatePort = (port: number | string): string | null => {
-  const portNumber = typeof port === 'string' ? Number(port) : port
+  const portNumber = Number(port)
 
   if (
     isNaN(portNumber) ||

--- a/shared/utils/url.ts
+++ b/shared/utils/url.ts
@@ -40,6 +40,20 @@ export const getOrigin = (url: string): string => {
 }
 
 /**
+ * ポート番号の妥当性を検証する (SSRF対策を含む)
+ * 1024-65535 の範囲内であることを確認（特権ポートを制限）
+ */
+export const validatePort = (port: number | string): string | null => {
+  const portNumber = typeof port === 'string' ? Number(port) : port
+
+  if (isNaN(portNumber) || portNumber < 1024 || portNumber > 65535) {
+    return ERROR_MESSAGES.INVALID_PORT
+  }
+
+  return null
+}
+
+/**
  * API URL の妥当性を検証する (SSRF対策を含む)
  */
 export const validateApiUrl = (apiUrl: string): string | null => {
@@ -61,13 +75,8 @@ export const validateApiUrl = (apiUrl: string): string | null => {
     // ポート番号の取得 (明示的な指定がない場合はプロトコルから推測)
     const portString =
       parsed.port || (parsed.protocol === 'https:' ? '443' : '80')
-    const port = Number(portString)
 
-    if (isNaN(port) || port < 1024 || port > 65535) {
-      return ERROR_MESSAGES.INVALID_PORT
-    }
-
-    return null
+    return validatePort(portString)
   } catch {
     return ERROR_MESSAGES.INVALID_URL
   }


### PR DESCRIPTION
### 概要
`shared/utils/url.ts` の `validateApiUrl` 内に含まれていたポート番号の検証ロジックを、独立した共通関数 `validatePort` として切り出しました。

### 変更内容
- `shared/utils/url.ts` に `validatePort` 関数を定義（1024-65535 の範囲チェック）。
- `validateApiUrl` をリファクタリングし、内部で `validatePort` を使用するように変更。
- `shared/utils/url.test.ts` に `validatePort` のユニットテストを追加。

### 背景・目的
今後実施予定のサーバーポート環境変数化（Issue #128）において、サーバー側のポート番号検証でも同じロジックを再利用できるようにすることを目的としています。

Closes #177