### PR TITLE
[Chore] サーバーのポート番号を環境変数 SERVER_PORT で指定可能にする (v1.3.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,8 @@ BOOKMARK_PAGE_FRONTEND_URL=http://localhost:5173
 # ブラウザ拡張機能との連携用 ID
 VITE_EXTENSION_ID=your-extension-id-here
 
+# サーバーの起動ポート番号 (デフォルト: 3030)
+# SERVER_PORT=3030
+
 # データベースファイル名の指定 (デフォルト: bookmarks.sqlite)
 # DB_FILENAME=my-custom-database.sqlite

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ cp .env.example .env
 | `BOOKMARK_PAGE_FRONTEND_URL` | CORS許可オリジン設定用 | `http://localhost:5173` |
 | `VITE_EXTENSION_ID`          | 連携する拡張機能の ID  | (なし)                  |
 | `DB_FILENAME`                | データベースファイル名 | `bookmarks.sqlite`      |
+| `SERVER_PORT`                | サーバー起動ポート番号 | `3030`                  |
 
 補足: この環境変数が設定されていない場合、バックエンドはデフォルト値を使用します。
 
@@ -89,10 +90,16 @@ Frontend (Vite) と Backend (Hono) を同時に起動します。
 npm run dev
 ```
 
-起動後、以下のURLでアクセスできます：
+起動後、以下のURLでアクセスできます（デフォルト設定の場合）：
 
 - Frontend: `http://localhost:5173`
 - Backend API: `http://localhost:3030`
+
+ポート番号を変更して起動することも可能です：
+
+```bash
+SERVER_PORT=4000 npm run dev
+```
 
 #### ブラウザ拡張機能
 拡張機能のビルドとウォッチを開始します。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bookmark-page",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bookmark-page",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "license": "MIT",
   "type": "module",
   "overrides": {

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,12 +20,14 @@ try {
  */
 const getPort = (): number => {
   const envPort = process.env.SERVER_PORT
-  if (envPort) {
-    const portNumber = Number(envPort)
-    const validationError = validatePort(portNumber)
-    if (validationError === null) {
-      return portNumber
-    }
+  if (!envPort) {
+    return DEFAULT_SERVER_PORT
+  }
+
+  const portNumber = Number(envPort)
+  const validationError = validatePort(portNumber)
+
+  if (validationError) {
     // 無効なポートが指定された場合に警告を出力
     console.warn(
       LOG_MESSAGES.INVALID_SERVER_PORT(
@@ -34,8 +36,10 @@ const getPort = (): number => {
         DEFAULT_SERVER_PORT,
       ),
     )
+    return DEFAULT_SERVER_PORT
   }
-  return DEFAULT_SERVER_PORT
+
+  return portNumber
 }
 
 const port = getPort()

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import { serve } from '@hono/node-server'
 import app from './app'
 import { initializeDatabase } from './db'
 import { LOG_MESSAGES, DEFAULT_SERVER_PORT } from '@shared/constants'
+import { validatePort } from '@shared/utils/url'
 
 // データベースの初期化
 try {
@@ -12,7 +13,20 @@ try {
   process.exit(1)
 }
 
-const port = DEFAULT_SERVER_PORT
+/**
+ * 起動ポート番号の取得
+ * 環境変数 SERVER_PORT が有効な場合はそれを使用し、
+ * そうでない場合は DEFAULT_SERVER_PORT にフォールバックする。
+ */
+const getPort = (): number => {
+  const envPort = process.env.SERVER_PORT
+  if (envPort && validatePort(envPort) === null) {
+    return Number(envPort)
+  }
+  return DEFAULT_SERVER_PORT
+}
+
+const port = getPort()
 
 console.log(LOG_MESSAGES.SERVER_RUNNING(port))
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,8 +20,20 @@ try {
  */
 const getPort = (): number => {
   const envPort = process.env.SERVER_PORT
-  if (envPort && validatePort(envPort) === null) {
-    return Number(envPort)
+  if (envPort) {
+    const portNumber = Number(envPort)
+    const validationError = validatePort(portNumber)
+    if (validationError === null) {
+      return portNumber
+    }
+    // 無効なポートが指定された場合に警告を出力
+    console.warn(
+      LOG_MESSAGES.INVALID_SERVER_PORT(
+        envPort,
+        validationError,
+        DEFAULT_SERVER_PORT,
+      ),
+    )
   }
   return DEFAULT_SERVER_PORT
 }

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -276,6 +276,8 @@ export const LOG_MESSAGES = {
   EXTENSION_CONNECTION_FAILED: 'Connection test failed:',
   INVALID_STORAGE_URL:
     'Invalid API URL found in localStorage, falling back to default:',
+  INVALID_SERVER_PORT: (val: string, error: string, defaultPort: number) =>
+    `[Server] Invalid SERVER_PORT value: "${val}". ${error} Falling back to default port ${defaultPort}.`,
   REORDER_FAILED_CONSOLE: 'Failed to reorder bookmarks:',
   RESET_DB_ENV_ERROR: 'resetDatabase can only be called in test environment',
   INSERT_FAILED: 'Failed to insert bookmark',


### PR DESCRIPTION
### 概要
サーバーの起動ポート番号を環境変数 `SERVER_PORT` で柔軟に指定できるようにしました。
これに伴い、後方互換性のある新機能としてセマンティックバージョニングに基づきバージョンを `1.3.0` に更新しました。

### 変更内容
- `server/index.ts` を修正し、`process.env.SERVER_PORT` を参照するように変更。
- 共通検証関数 `validatePort` を使用して、指定されたポート番号の妥当性をチェック。
- 不正な値や未設定時はデフォルトの `3030` にフォールバック。
- `.env.example` および `README.md` に `SERVER_PORT` の設定項目と説明を追加。
- `package.json` を `1.3.0` に更新。

### 検証内容
- `lint` および `type-check` がパスすることを確認。
- プロジェクト全体のテストがパスすることを確認。

Closes #128