### PR TITLE
[Refactor] URL からポート番号を抽出する共通ユーティリティの追加 (Step 1)

### DIFF
--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -25,10 +25,18 @@ export const PLACEHOLDERS = {
 } as const
 
 /**
+ * デフォルトのポート番号
+ */
+export const DEFAULT_PORTS = {
+  FRONTEND: 5173,
+  BACKEND: 3030,
+} as const
+
+/**
  * プロダクト全体で共有されるデフォルト設定
  */
-export const DEFAULT_API_URL = 'http://localhost:3030'
-export const DEFAULT_SERVER_PORT = 3030
+export const DEFAULT_API_URL = `http://localhost:${DEFAULT_PORTS.BACKEND}`
+export const DEFAULT_SERVER_PORT = DEFAULT_PORTS.BACKEND
 
 /**
  * UI の処理状態定義
@@ -63,7 +71,9 @@ export const STATUS_STYLES: Record<UIStatus, string> = {
 /**
  * 許可されたオリジン (Web アプリ)
  */
-export const ALLOWED_ORIGINS = ['http://localhost:5173'] as const
+export const ALLOWED_ORIGINS = [
+  `http://localhost:${DEFAULT_PORTS.FRONTEND}`,
+] as const
 
 /**
  * プロダクト共通の UI メッセージ

--- a/shared/utils/url.test.ts
+++ b/shared/utils/url.test.ts
@@ -12,6 +12,7 @@ import {
   VALIDATION_MESSAGES,
   HTML_ATTRIBUTES,
   LOG_MESSAGES,
+  DEFAULT_PORTS,
 } from '@shared/constants'
 import { VALID_URLS, INVALID_URLS } from '@shared/test/fixtures'
 
@@ -73,25 +74,29 @@ describe('url utilities', () => {
   describe('getPortFromUrl', () => {
     it('URL からポート番号を正しく抽出できること', () => {
       expect(getPortFromUrl('http://localhost:4000')).toBe(4000)
-      expect(getPortFromUrl('http://localhost:5173')).toBe(5173)
+      expect(getPortFromUrl(`http://localhost:${DEFAULT_PORTS.FRONTEND}`)).toBe(
+        DEFAULT_PORTS.FRONTEND,
+      )
     })
 
     it('ポートが明示されていない場合、特権ポート（80/443）を拒否してデフォルトを返すこと', () => {
-      const defaultPort = 5173
+      const defaultPort = DEFAULT_PORTS.FRONTEND
       expect(getPortFromUrl('http://localhost', defaultPort)).toBe(defaultPort)
       expect(getPortFromUrl('https://localhost', defaultPort)).toBe(defaultPort)
     })
 
     it('1024 未満の明示的な特権ポートを拒否してデフォルトを返すこと', () => {
-      const defaultPort = 5173
-      expect(getPortFromUrl('http://localhost:80', defaultPort)).toBe(defaultPort)
+      const defaultPort = DEFAULT_PORTS.FRONTEND
+      expect(getPortFromUrl('http://localhost:80', defaultPort)).toBe(
+        defaultPort,
+      )
       expect(getPortFromUrl('http://localhost:1023', defaultPort)).toBe(
         defaultPort,
       )
     })
 
     it('無効な URL や空文字の場合、デフォルトを返すこと', () => {
-      const defaultPort = 5173
+      const defaultPort = DEFAULT_PORTS.FRONTEND
       expect(getPortFromUrl('', defaultPort)).toBe(defaultPort)
       expect(getPortFromUrl(undefined, defaultPort)).toBe(defaultPort)
       expect(getPortFromUrl('not-a-url', defaultPort)).toBe(defaultPort)

--- a/shared/utils/url.test.ts
+++ b/shared/utils/url.test.ts
@@ -72,40 +72,77 @@ describe('url utilities', () => {
   })
 
   describe('getPortFromUrl', () => {
-    it('URL からポート番号を正しく抽出できること', () => {
-      expect(getPortFromUrl('http://localhost:4000')).toBe(4000)
-      expect(getPortFromUrl(`http://localhost:${DEFAULT_PORTS.FRONTEND}`)).toBe(
-        DEFAULT_PORTS.FRONTEND,
-      )
+    it.each([
+      { url: 'http://localhost:4000', port: 4000 },
+      {
+        url: `http://localhost:${DEFAULT_PORTS.FRONTEND}`,
+        port: DEFAULT_PORTS.FRONTEND,
+      },
+    ])('URL からポート番号($port)を正しく抽出できること', ({ url, port }) => {
+      expect(getPortFromUrl(url)).toBe(port)
     })
 
-    it('ポートが明示されていない場合、特権ポート（80/443）を拒否してデフォルトを返すこと', () => {
-      const defaultPort = DEFAULT_PORTS.FRONTEND
-      expect(getPortFromUrl('http://localhost', defaultPort)).toBe(defaultPort)
-      expect(getPortFromUrl('https://localhost', defaultPort)).toBe(defaultPort)
+    it.each([
+      {
+        protocol: 'http/80',
+        url: 'http://localhost',
+        port: DEFAULT_PORTS.FRONTEND,
+      },
+      {
+        protocol: 'https/443',
+        url: 'https://localhost',
+        port: DEFAULT_PORTS.FRONTEND,
+      },
+    ])(
+      'ポートが明示されていない場合、特権ポート（$protocol）を拒否してデフォルトを返すこと',
+      ({ url, port }) => {
+        expect(getPortFromUrl(url, port)).toBe(port)
+      },
+    )
+
+    it.each([
+      {
+        privilegedPort: 'http/80',
+        url: 'http://localhost:80',
+        port: DEFAULT_PORTS.FRONTEND,
+      },
+      {
+        privilegedPort: 'http/1023',
+        url: 'http://localhost:1023',
+        port: DEFAULT_PORTS.FRONTEND,
+      },
+    ])(
+      '1024 未満の明示的な特権ポート ( $privilegedPort ) を拒否してデフォルトを返すこと',
+      ({ url, port }) => {
+        expect(getPortFromUrl(url, port)).toBe(port)
+      },
+    )
+
+    it.each([
+      { name: '空白', url: '', port: DEFAULT_PORTS.FRONTEND },
+      {
+        name: '未定義',
+        url: undefined,
+        port: DEFAULT_PORTS.FRONTEND,
+      },
+      {
+        name: 'not-a-url',
+        url: 'not-a-url',
+        port: DEFAULT_PORTS.FRONTEND,
+      },
+    ])('$name の場合、デフォルトを返すこと', ({ url, port }) => {
+      expect(getPortFromUrl(url)).toBe(port)
     })
 
-    it('1024 未満の明示的な特権ポートを拒否してデフォルトを返すこと', () => {
-      const defaultPort = DEFAULT_PORTS.FRONTEND
-      expect(getPortFromUrl('http://localhost:80', defaultPort)).toBe(
-        defaultPort,
-      )
-      expect(getPortFromUrl('http://localhost:1023', defaultPort)).toBe(
-        defaultPort,
-      )
-    })
-
-    it('無効な URL や空文字の場合、デフォルトを返すこと', () => {
-      const defaultPort = DEFAULT_PORTS.FRONTEND
-      expect(getPortFromUrl('', defaultPort)).toBe(defaultPort)
-      expect(getPortFromUrl(undefined, defaultPort)).toBe(defaultPort)
-      expect(getPortFromUrl('not-a-url', defaultPort)).toBe(defaultPort)
-    })
-
-    it('カスタムのデフォルトポートが正しく機能すること', () => {
-      expect(getPortFromUrl('http://localhost:80', 3000)).toBe(3000)
-      expect(getPortFromUrl('', 3030)).toBe(3030)
-    })
+    it.each([
+      { name: '特権ポート', url: 'http://localhost:80', port: 3000 },
+      { name: '空白', url: '', port: 3030 },
+    ])(
+      '$nameの場合、カスタムのデフォルトポートが正しく機能すること',
+      ({ url, port }) => {
+        expect(getPortFromUrl(url, port)).toBe(port)
+      },
+    )
   })
 
   describe('validateApiUrl', () => {

--- a/shared/utils/url.test.ts
+++ b/shared/utils/url.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { isHttpUrl, getOrigin, validateApiUrl, openUrlInNewTab, validatePort } from './url'
+import {
+  isHttpUrl,
+  getOrigin,
+  validateApiUrl,
+  openUrlInNewTab,
+  validatePort,
+  getPortFromUrl,
+} from './url'
 import {
   ERROR_MESSAGES,
   VALIDATION_MESSAGES,
@@ -61,6 +68,39 @@ describe('url utilities', () => {
         expect(validatePort(port)).toBe(expected)
       },
     )
+  })
+
+  describe('getPortFromUrl', () => {
+    it('URL からポート番号を正しく抽出できること', () => {
+      expect(getPortFromUrl('http://localhost:4000')).toBe(4000)
+      expect(getPortFromUrl('http://localhost:5173')).toBe(5173)
+    })
+
+    it('ポートが明示されていない場合、特権ポート（80/443）を拒否してデフォルトを返すこと', () => {
+      const defaultPort = 5173
+      expect(getPortFromUrl('http://localhost', defaultPort)).toBe(defaultPort)
+      expect(getPortFromUrl('https://localhost', defaultPort)).toBe(defaultPort)
+    })
+
+    it('1024 未満の明示的な特権ポートを拒否してデフォルトを返すこと', () => {
+      const defaultPort = 5173
+      expect(getPortFromUrl('http://localhost:80', defaultPort)).toBe(defaultPort)
+      expect(getPortFromUrl('http://localhost:1023', defaultPort)).toBe(
+        defaultPort,
+      )
+    })
+
+    it('無効な URL や空文字の場合、デフォルトを返すこと', () => {
+      const defaultPort = 5173
+      expect(getPortFromUrl('', defaultPort)).toBe(defaultPort)
+      expect(getPortFromUrl(undefined, defaultPort)).toBe(defaultPort)
+      expect(getPortFromUrl('not-a-url', defaultPort)).toBe(defaultPort)
+    })
+
+    it('カスタムのデフォルトポートが正しく機能すること', () => {
+      expect(getPortFromUrl('http://localhost:80', 3000)).toBe(3000)
+      expect(getPortFromUrl('', 3030)).toBe(3030)
+    })
   })
 
   describe('validateApiUrl', () => {

--- a/shared/utils/url.ts
+++ b/shared/utils/url.ts
@@ -3,6 +3,7 @@ import {
   VALIDATION_MESSAGES,
   HTML_ATTRIBUTES,
   LOG_MESSAGES,
+  DEFAULT_PORTS,
 } from '@shared/constants'
 
 /**
@@ -92,7 +93,10 @@ export const validateApiUrl = (apiUrl: string): string | null => {
  * 指定がない場合や、1024 未満の特権ポートである場合は、
  * セキュリティと安全性の観点から引数の defaultPort を返す。
  */
-export const getPortFromUrl = (url?: string, defaultPort = 5173): number => {
+export const getPortFromUrl = (
+  url?: string,
+  defaultPort: number = DEFAULT_PORTS.FRONTEND,
+): number => {
   if (!url) return defaultPort
   try {
     const parsed = new URL(url)

--- a/shared/utils/url.ts
+++ b/shared/utils/url.ts
@@ -99,16 +99,12 @@ export const getPortFromUrl = (
 ): number => {
   if (!url) return defaultPort
   try {
-    const parsed = new URL(url)
-    const portString =
-      parsed.port || (parsed.protocol === 'https:' ? '443' : '80')
-
-    // 1024 未満のポートや無効なポートは拒否してデフォルトへ
-    if (validatePort(portString) !== null) {
-      return defaultPort
+    const portString = new URL(url).port
+    // ポートが明示的に指定されており、かつ妥当な（特権ポートでない）場合にのみそのポートを返す
+    if (portString && validatePort(portString) === null) {
+      return Number(portString)
     }
-
-    return Number(portString)
+    return defaultPort
   } catch {
     return defaultPort
   }

--- a/shared/utils/url.ts
+++ b/shared/utils/url.ts
@@ -86,3 +86,26 @@ export const validateApiUrl = (apiUrl: string): string | null => {
     return ERROR_MESSAGES.INVALID_URL
   }
 }
+
+/**
+ * URL 文字列からポート番号を抽出する (Vite 起動ポート決定用)
+ * 指定がない場合や、1024 未満の特権ポートである場合は、
+ * セキュリティと安全性の観点から引数の defaultPort を返す。
+ */
+export const getPortFromUrl = (url?: string, defaultPort = 5173): number => {
+  if (!url) return defaultPort
+  try {
+    const parsed = new URL(url)
+    const portString =
+      parsed.port || (parsed.protocol === 'https:' ? '443' : '80')
+
+    // 1024 未満のポートや無効なポートは拒否してデフォルトへ
+    if (validatePort(portString) !== null) {
+      return defaultPort
+    }
+
+    return Number(portString)
+  } catch {
+    return defaultPort
+  }
+}


### PR DESCRIPTION
### 概要
URL 文字列からポート番号を安全に抽出する共通関数 `getPortFromUrl` を `shared/utils/url.ts` に追加し、ユニットテストを整備しました。また、プロジェクト全体のポート番号定数を整理しました。

### 変更内容
- **定数の整理**: `shared/constants.ts` に `DEFAULT_PORTS` を導入。
  - `ALLOWED_ORIGINS`, `DEFAULT_API_URL`, `DEFAULT_SERVER_PORT` をこの定数を用いて再定義し、重複を排除。
- **ユーティリティの追加**: `shared/utils/url.ts` に `getPortFromUrl` 関数を実装。
  - 特権ポート (1024未満) の拒否ロジックを `validatePort` を用いて導入。
- **テストの追加・改善**: `shared/utils/url.test.ts` に網羅的なテストを追加。
  - `it.each` を使用したテーブル駆動テスト形式を採用し、可読性を向上。

### 背景・目的
Issue #129 において、`BOOKMARK_PAGE_FRONTEND_URL` からポート番号を自動抽出して Vite に適用するための基盤となります。

Closes #181