### PR TITLE
[Chore] 抽出したポート番号を Web アプリ (Vite) に適用する (Step 2) (v1.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ cp .env.example .env
 
 | 変数名                       | 説明                   | デフォルト値            |
 | ---------------------------- | ---------------------- | ----------------------- |
-| `BOOKMARK_PAGE_FRONTEND_URL` | CORS許可オリジン設定用 | `http://localhost:5173` |
-| `VITE_EXTENSION_ID`          | 連携する拡張機能の ID  | (なし)                  |
-| `DB_FILENAME`                | データベースファイル名 | `bookmarks.sqlite`      |
-| `SERVER_PORT`                | サーバー起動ポート番号 | `3030`                  |
+| `BOOKMARK_PAGE_FRONTEND_URL` | CORS許可オリジン設定用 / Webアプリの起動ポート決定用 | `http://localhost:5173` |
+| `VITE_EXTENSION_ID`          | 連携する拡張機能의 ID                                | (なし)                  |
+| `DB_FILENAME`                | データベースファイル名                               | `bookmarks.sqlite`      |
+| `SERVER_PORT`                | サーバー起動ポート番号                               | `3030`                  |
 
-補足: この環境変数が設定されていない場合、バックエンドはデフォルト値を使用します。
+補足: `BOOKMARK_PAGE_FRONTEND_URL` にポート番号を指定すると、Web アプリ (Vite) の起動ポートに自動的に反映されます。1024 未満の特権ポートが指定された場合などは、デフォルト値が使用されます。
 
 ### 開発サーバー起動 (Development)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bookmark-page",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bookmark-page",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bookmark-page",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "type": "module",
   "overrides": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,57 +1,87 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
+/**
+ * 環境変数からフロントエンドのポート番号を抽出する
+ * 
+ * 注意: この関数は shared/utils/url.ts の getPortFromUrl と重複しています。
+ * vite.config.ts の実行フェーズでは、shared 配下のモジュールが使用している
+ * パスエイリアス (@shared/*) を解決できないため、自己完結させる必要があります。
+ */
+const getFrontendPort = (url: string | undefined): number => {
+  const defaultPort = 5173
+  if (!url) return defaultPort
+  try {
+    const parsed = new URL(url)
+    const portString = parsed.port
+    if (portString) {
+      const p = Number(portString)
+      // 1024 未満の特権ポートはセキュリティ上の理由により除外しデフォルトを使用
+      if (p >= 1024 && p <= 65535) return p
+    }
+  } catch {
+    // 無効な URL 形式の場合はデフォルトを使用
+  }
+  return defaultPort
+}
+
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss(), tsconfigPaths()],
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3030',
-        changeOrigin: true,
-      },
-    },
-  },
-  // @ts-expect-error - Vitest types are needed but might conflict with Vite types in some setups
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts', './extension/test/setup.ts'],
-    coverage: {
-      provider: 'v8',
-      clean: true,
-      all: true,
-      reporter: ['text', 'json', 'html'],
-      include: [
-        'server/**/*.ts',
-        'shared/**/*.ts',
-        'src/**/*.ts',
-        'src/**/*.tsx',
-        'extension/**/*.ts',
-        'extension/**/*.tsx',
-      ],
-      exclude: [
-        '**/*.test.ts',
-        '**/*.test.tsx',
-        'src/test/**',
-        'extension/test/**',
-        'vite.config.ts',
-        'server/index.ts',
-        'src/main.tsx',
-        'extension/sync-version.ts',
-        'extension/src/main-options.tsx',
-        'extension/src/main-popup.tsx',
-      ],
-      thresholds: {
-        global: {
-          lines: 90,
-          branches: 80,
-          functions: 90,
-          statements: 90,
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const frontendUrl = env.BOOKMARK_PAGE_FRONTEND_URL
+  const port = getFrontendPort(frontendUrl)
+
+  return {
+    plugins: [react(), tailwindcss(), tsconfigPaths()],
+    server: {
+      port,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:3030',
+          changeOrigin: true,
         },
       },
     },
-  },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./src/test/setup.ts', './extension/test/setup.ts'],
+      coverage: {
+        provider: 'v8',
+        clean: true,
+        all: true,
+        reporter: ['text', 'json', 'html'],
+        include: [
+          'server/**/*.ts',
+          'shared/**/*.ts',
+          'src/**/*.ts',
+          'src/**/*.tsx',
+          'extension/**/*.ts',
+          'extension/**/*.tsx',
+        ],
+        exclude: [
+          '**/*.test.ts',
+          '**/*.test.tsx',
+          'src/test/**',
+          'extension/test/**',
+          'vite.config.ts',
+          'server/index.ts',
+          'src/main.tsx',
+          'extension/sync-version.ts',
+          'extension/src/main-options.tsx',
+          'extension/src/main-popup.tsx',
+        ],
+        thresholds: {
+          global: {
+            lines: 90,
+            branches: 80,
+            functions: 90,
+            statements: 90,
+          },
+        },
+      },
+    },
+  }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,8 @@ const getFrontendPort = (url: string | undefined): number => {
     const portString = parsed.port
     if (portString) {
       const p = Number(portString)
-      // 1024 未満の特権ポートはセキュリティ上の理由により除外しデフォルトを使用
+      // 1024 未満の特権ポートはセキュリティ上の理由により除外し、
+      // 65535 (TCP ポートの最大値) を超える値も無効としてデフォルトを使用。
       if (p >= 1024 && p <= 65535) return p
     }
   } catch {
@@ -30,7 +31,7 @@ const getFrontendPort = (url: string | undefined): number => {
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
-  const frontendUrl = env.BOOKMARK_PAGE_FRONTEND_URL
+  const frontendUrl = env.BOOKMARK_PAGE_FRONTEND_URL || ''
   const port = getFrontendPort(frontendUrl)
 
   return {


### PR DESCRIPTION
### 概要
環境変数 `BOOKMARK_PAGE_FRONTEND_URL` からポート番号を自動抽出し、Web アプリ (Vite) の起動ポートとして適用しました。これに伴い、バージョンを `1.4.0` に更新しました。

### 変更内容
- `vite.config.ts` を修正し、`BOOKMARK_PAGE_FRONTEND_URL` からポートを抽出して `server.port` に設定。
- **実装上の注意**: `vite.config.ts` 実行フェーズではパスエイリアスが解決できないため、ポート抽出ロジック (`getFrontendPort`) を設定ファイル内に独立して定義しました。これは `shared/utils/url.ts` の `getPortFromUrl` とロジックが重複しています。
- 型推論の改善により不要となった `@ts-expect-error` を削除。
- `README.md` の環境変数テーブルを更新し、ポート自動反映の補足を追記。
- `package.json` を `1.4.0` に更新。

### 背景・目的
サーバー側の CORS 設定とフロントエンドの起動ポートを常に一致させ、個別の環境変数管理を不要にすることを目的としています。

Closes #129