### PR TITLE
[Refactor] ポート関連ユーティリティの独立と定義重複の解消

### DIFF
--- a/shared/utils/port.ts
+++ b/shared/utils/port.ts
@@ -1,0 +1,42 @@
+import { ERROR_MESSAGES, DEFAULT_PORTS } from '../constants'
+
+/**
+ * ポート番号の妥当性を検証する (SSRF対策を含む)
+ * 1024-65535 の範囲内であることを確認（特権ポートを制限）
+ */
+export const validatePort = (port: number | string): string | null => {
+  const portNumber = Number(port)
+
+  if (
+    isNaN(portNumber) ||
+    !Number.isInteger(portNumber) ||
+    portNumber < 1024 ||
+    portNumber > 65535
+  ) {
+    return ERROR_MESSAGES.INVALID_PORT
+  }
+
+  return null
+}
+
+/**
+ * URL 文字列からポート番号を抽出する (Vite 起動ポート決定用)
+ * 指定がない場合や、1024 未満の特権ポートである場合は、
+ * セキュリティと安全性の観点から引数の defaultPort を返す。
+ */
+export const getPortFromUrl = (
+  url?: string,
+  defaultPort: number = DEFAULT_PORTS.FRONTEND,
+): number => {
+  if (!url) return defaultPort
+  try {
+    const portString = new URL(url).port
+    // ポートが明示的に指定されており、かつ妥当な（特権ポートでない）場合にのみそのポートを返す
+    if (portString && validatePort(portString) === null) {
+      return Number(portString)
+    }
+    return defaultPort
+  } catch {
+    return defaultPort
+  }
+}

--- a/shared/utils/url.ts
+++ b/shared/utils/url.ts
@@ -3,8 +3,9 @@ import {
   VALIDATION_MESSAGES,
   HTML_ATTRIBUTES,
   LOG_MESSAGES,
-  DEFAULT_PORTS,
 } from '@shared/constants'
+
+export * from './port'
 
 /**
  * URL が http:// または https:// で始まっているかを確認する
@@ -41,25 +42,6 @@ export const getOrigin = (url: string): string => {
 }
 
 /**
- * ポート番号の妥当性を検証する (SSRF対策を含む)
- * 1024-65535 の範囲内であることを確認（特権ポートを制限）
- */
-export const validatePort = (port: number | string): string | null => {
-  const portNumber = Number(port)
-
-  if (
-    isNaN(portNumber) ||
-    !Number.isInteger(portNumber) ||
-    portNumber < 1024 ||
-    portNumber > 65535
-  ) {
-    return ERROR_MESSAGES.INVALID_PORT
-  }
-
-  return null
-}
-
-/**
  * API URL の妥当性を検証する (SSRF対策を含む)
  */
 export const validateApiUrl = (apiUrl: string): string | null => {
@@ -82,30 +64,14 @@ export const validateApiUrl = (apiUrl: string): string | null => {
     const portString =
       parsed.port || (parsed.protocol === 'https:' ? '443' : '80')
 
+    // validatePort は './port' から re-export されているためそのまま使用可能
+    // ただし内部的に利用するため、このファイル内では validatePort を定義するかインポートが必要
+    // re-export しているので、同じディレクトリ内の port.ts からインポートする
     return validatePort(portString)
   } catch {
     return ERROR_MESSAGES.INVALID_URL
   }
 }
 
-/**
- * URL 文字列からポート番号を抽出する (Vite 起動ポート決定用)
- * 指定がない場合や、1024 未満の特権ポートである場合は、
- * セキュリティと安全性の観点から引数の defaultPort を返す。
- */
-export const getPortFromUrl = (
-  url?: string,
-  defaultPort: number = DEFAULT_PORTS.FRONTEND,
-): number => {
-  if (!url) return defaultPort
-  try {
-    const portString = new URL(url).port
-    // ポートが明示的に指定されており、かつ妥当な（特権ポートでない）場合にのみそのポートを返す
-    if (portString && validatePort(portString) === null) {
-      return Number(portString)
-    }
-    return defaultPort
-  } catch {
-    return defaultPort
-  }
-}
+// 内部利用のためにインポート (循環参照を避ける)
+import { validatePort } from './port'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,37 +2,14 @@ import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
-
-/**
- * 環境変数からフロントエンドのポート番号を抽出する
- * 
- * 注意: この関数は shared/utils/url.ts の getPortFromUrl と重複しています。
- * vite.config.ts の実行フェーズでは、shared 配下のモジュールが使用している
- * パスエイリアス (@shared/*) を解決できないため、自己完結させる必要があります。
- */
-const getFrontendPort = (url: string | undefined): number => {
-  const defaultPort = 5173
-  if (!url) return defaultPort
-  try {
-    const parsed = new URL(url)
-    const portString = parsed.port
-    if (portString) {
-      const p = Number(portString)
-      // 1024 未満の特権ポートはセキュリティ上の理由により除外し、
-      // 65535 (TCP ポートの最大値) を超える値も無効としてデフォルトを使用。
-      if (p >= 1024 && p <= 65535) return p
-    }
-  } catch {
-    // 無効な URL 形式の場合はデフォルトを使用
-  }
-  return defaultPort
-}
+import { getPortFromUrl } from './shared/utils/port'
+import { DEFAULT_PORTS } from './shared/constants'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   const frontendUrl = env.BOOKMARK_PAGE_FRONTEND_URL || ''
-  const port = getFrontendPort(frontendUrl)
+  const port = getPortFromUrl(frontendUrl, DEFAULT_PORTS.FRONTEND)
 
   return {
     plugins: [react(), tailwindcss(), tsconfigPaths()],


### PR DESCRIPTION
### 概要
`vite.config.ts` 内に存在していた `getFrontendPort` と、`shared/utils/url.ts` 内の `getPortFromUrl` の重複を解消しました。

### 変更内容
- **新ファイルの作成**: `shared/utils/port.ts` を作成。
  - `validatePort` および `getPortFromUrl` を移動。
  - パスエイリアスを使用せず相対パスでインポートを行うことで、Vite の設定フェーズでも解決可能な「自己完結型」のモジュールとしました。
- **既存ユーティリティの修正**: `shared/utils/url.ts` から移動した関数を削除し、`port.ts` から re-export するように変更。内部利用箇所も追従。
- **Vite 設定の修正**: `vite.config.ts` 内の重複していたロジックを削除し、`shared/utils/port.ts` からインポートするように変更。

### 効果
- 重複したロジックが一箇所に集約され、メンテナンス性が向上しました。
- 依存関係が整理され、Vite の設定ファイルから安全に共通ユーティリティを再利用できるようになりました。

Closes #184