### PR TITLE
[Quality] テスト実行時の不要なコンソール出力を抑制 (useSettings.test.ts)

### DIFF
--- a/src/hooks/useSettings.test.ts
+++ b/src/hooks/useSettings.test.ts
@@ -7,6 +7,7 @@ import {
   STORAGE_KEYS,
   VALIDATION_MESSAGES,
   TEST_MESSAGES,
+  ERROR_MESSAGES,
 } from '@shared/constants'
 import { INVALID_URLS } from '@shared/test/fixtures'
 import { act } from '@testing-library/react'
@@ -84,6 +85,7 @@ describe('useSettings Hook', () => {
     })
 
     it('無効な URL の場合、エラーを返し、保存を中断すること', () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const { result } = renderHook(() => useSettings())
       const invalidUrl = INVALID_URLS.FTP
 
@@ -93,6 +95,10 @@ describe('useSettings Hook', () => {
       })
 
       expect(error).toBe(VALIDATION_MESSAGES.URL_INVALID_PROTOCOL)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        ERROR_MESSAGES.UPDATE_API_URL_FAILED,
+        VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
+      )
     })
 
     it('例外が発生した場合、エラーメッセージを返し、ログを出力すること', () => {


### PR DESCRIPTION
### 概要
`useSettings.test.ts` 実行時に出力されていた、期待通りのバリデーションエラーに伴うコンソール出力を抑制し、テスト結果をクリーンに保つように改善しました。

### 変更内容
- `handleSaveSettings` の「無効な URL の場合」のテストケースに `vi.spyOn(console, "error")` を追加。
- 出力を抑制するだけでなく、`ERROR_MESSAGES.UPDATE_API_URL_FAILED` が正しいメッセージと共にログ出力されていることを検証するように強化。

### 背景・目的
プロジェクトの方針として、意図的なエラーに対するテストであっても stderr をクリーンに保つことで、真に異常なエラーを見逃さないようにするためです。

Closes #180