### PR TITLE
[Refactor] queryKeys.ts のマジックストリングの定数化

### DIFF
--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -2,11 +2,22 @@
  * React Query の QueryKey 管理用定数
  * TanStack Query の Query Key Factory パターンを参考に構造化しています
  */
+
+// 内部定数定義: マジックストリングを一箇所に集約し、タイポを防止。
+const SCOPE = {
+  BOOKMARKS: 'bookmarks',
+} as const
+
+const TYPE = {
+  LIST: 'list',
+  DETAIL: 'detail',
+} as const
+
 export const QUERY_KEYS = {
   BOOKMARKS: {
-    ALL: ['bookmarks'] as const,
-    LIST: () => [...QUERY_KEYS.BOOKMARKS.ALL, 'list'] as const,
-    DETAILS: () => [...QUERY_KEYS.BOOKMARKS.ALL, 'detail'] as const,
+    ALL: [SCOPE.BOOKMARKS] as const,
+    LIST: () => [...QUERY_KEYS.BOOKMARKS.ALL, TYPE.LIST] as const,
+    DETAILS: () => [...QUERY_KEYS.BOOKMARKS.ALL, TYPE.DETAIL] as const,
     DETAIL: (id: string | number) =>
       [...QUERY_KEYS.BOOKMARKS.DETAILS(), String(id)] as const,
   },


### PR DESCRIPTION
### 概要
`src/lib/queryKeys.ts` 内でリテラルとして定義されているキー文字列を内部定数として整理し、マジックストリングを排除しました。

### 変更内容
- 内部定数 `SCOPE` (`bookmarks`) および `TYPE` (`list`, `detail`) を定義。
- `QUERY_KEYS` 定数がこれらの定数を参照するように修正。
- 既存のユニットテスト (`queryKeys.test.ts`) が引き続きパスすることを確認。

### 背景・目的
リテラル文字列を直接使用するコードを減らし、タイポのリスクを排除するとともに、キー名の変更が必要になった際に一箇所で変更できるように保守性を向上させました。

Closes #187