### PR TITLE
[Quality] extension/sync-version.ts のユニットテスト追加

### DIFF
--- a/extension/sync-version.test.ts
+++ b/extension/sync-version.test.ts
@@ -8,7 +8,9 @@ describe('syncVersion', () => {
     vi.clearAllMocks()
     // fs のメソッドをデフォルトで成功するようにスパイ
     vi.spyOn(fs, 'existsSync').mockReturnValue(true)
-    vi.spyOn(fs, 'readFileSync').mockImplementation(() => '')
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() =>
+      JSON.stringify({ version: '1.2.3' }),
+    )
     vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
   })
 
@@ -39,10 +41,6 @@ describe('syncVersion', () => {
   })
 
   it('バージョンがすでに一致している場合、書き込みを行わないこと', () => {
-    vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
-      return JSON.stringify({ version: '1.2.3' })
-    })
-
     const result = syncVersion()
 
     expect(result).toBe(false)

--- a/extension/sync-version.test.ts
+++ b/extension/sync-version.test.ts
@@ -6,17 +6,16 @@ import { LOG_MESSAGES } from '../shared/constants'
 describe('syncVersion', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.spyOn(console, 'log').mockImplementation(() => {})
-    vi.spyOn(console, 'error').mockImplementation(() => {})
-    // fs のメソッドをスパイ
-    vi.spyOn(fs, 'existsSync').mockImplementation(() => true)
+    // fs のメソッドをデフォルトで成功するようにスパイ
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
     vi.spyOn(fs, 'readFileSync').mockImplementation(() => '')
     vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
   })
 
   it('package.json のバージョンが manifest.json に同期されること', () => {
-    // 1. fs の挙動をモック
-    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+    // コンソール出力のアサートが必要なテストケースでのみスパイを定義
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
     vi.spyOn(fs, 'readFileSync').mockImplementation((path) => {
       if (typeof path === 'string' && path.endsWith('package.json')) {
         return JSON.stringify({ version: '1.2.3' })
@@ -27,25 +26,21 @@ describe('syncVersion', () => {
       return ''
     })
 
-    // 2. 実行
     const result = syncVersion()
 
-    // 3. 検証
     expect(result).toBe(true)
     expect(fs.writeFileSync).toHaveBeenCalledWith(
       expect.stringContaining('manifest.json'),
       expect.stringContaining('"version": "1.2.3"'),
     )
-    expect(console.log).toHaveBeenCalledWith(
+    expect(consoleSpy).toHaveBeenCalledWith(
       LOG_MESSAGES.UPDATED_VERSION('1.2.3'),
     )
   })
 
   it('バージョンがすでに一致している場合、書き込みを行わないこと', () => {
-    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
     vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
-      const content = { version: '1.2.3' }
-      return JSON.stringify(content)
+      return JSON.stringify({ version: '1.2.3' })
     })
 
     const result = syncVersion()
@@ -71,7 +66,6 @@ describe('syncVersion', () => {
   })
 
   it('package.json にバージョンが含まれていない場合にエラーを投げること', () => {
-    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
     vi.spyOn(fs, 'readFileSync').mockImplementation((path) => {
       if (typeof path === 'string' && path.endsWith('package.json')) {
         return JSON.stringify({ name: 'test' }) // version なし
@@ -83,7 +77,6 @@ describe('syncVersion', () => {
   })
 
   it('JSON が不正な場合に JSON.parse エラーを投げること', () => {
-    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
     vi.spyOn(fs, 'readFileSync').mockReturnValue('invalid-json')
 
     expect(() => syncVersion()).toThrow(SyntaxError)

--- a/extension/sync-version.test.ts
+++ b/extension/sync-version.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import fs from 'fs'
+import { syncVersion } from './sync-version'
+import { LOG_MESSAGES } from '../shared/constants'
+
+describe('syncVersion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    // fs のメソッドをスパイ
+    vi.spyOn(fs, 'existsSync').mockImplementation(() => true)
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => '')
+    vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {})
+  })
+
+  it('package.json のバージョンが manifest.json に同期されること', () => {
+    // 1. fs の挙動をモック
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+    vi.spyOn(fs, 'readFileSync').mockImplementation((path) => {
+      if (typeof path === 'string' && path.endsWith('package.json')) {
+        return JSON.stringify({ version: '1.2.3' })
+      }
+      if (typeof path === 'string' && path.endsWith('manifest.json')) {
+        return JSON.stringify({ version: '1.0.0' })
+      }
+      return ''
+    })
+
+    // 2. 実行
+    const result = syncVersion()
+
+    // 3. 検証
+    expect(result).toBe(true)
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('manifest.json'),
+      expect.stringContaining('"version": "1.2.3"'),
+    )
+    expect(console.log).toHaveBeenCalledWith(
+      LOG_MESSAGES.UPDATED_VERSION('1.2.3'),
+    )
+  })
+
+  it('バージョンがすでに一致している場合、書き込みを行わないこと', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+    vi.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      const content = { version: '1.2.3' }
+      return JSON.stringify(content)
+    })
+
+    const result = syncVersion()
+
+    expect(result).toBe(false)
+    expect(fs.writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('package.json が存在しない場合にエラーを投げること', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation((path) => {
+      return typeof path === 'string' && !path.endsWith('package.json')
+    })
+
+    expect(() => syncVersion()).toThrow(/package.json not found/)
+  })
+
+  it('manifest.json が存在しない場合にエラーを投げること', () => {
+    vi.spyOn(fs, 'existsSync').mockImplementation((path) => {
+      return typeof path === 'string' && !path.endsWith('manifest.json')
+    })
+
+    expect(() => syncVersion()).toThrow(/manifest.json not found/)
+  })
+
+  it('package.json にバージョンが含まれていない場合にエラーを投げること', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+    vi.spyOn(fs, 'readFileSync').mockImplementation((path) => {
+      if (typeof path === 'string' && path.endsWith('package.json')) {
+        return JSON.stringify({ name: 'test' }) // version なし
+      }
+      return JSON.stringify({ version: '1.0.0' })
+    })
+
+    expect(() => syncVersion()).toThrow(/'version' field.*is missing/)
+  })
+
+  it('JSON が不正な場合に JSON.parse エラーを投げること', () => {
+    vi.spyOn(fs, 'existsSync').mockReturnValue(true)
+    vi.spyOn(fs, 'readFileSync').mockReturnValue('invalid-json')
+
+    expect(() => syncVersion()).toThrow(SyntaxError)
+  })
+})

--- a/extension/sync-version.ts
+++ b/extension/sync-version.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { fileURLToPath } from 'url'
 
 import { LOG_MESSAGES } from '../shared/constants'
 
@@ -11,47 +12,53 @@ const manifestJsonPath = path.resolve(
 
 /**
  * package.json と manifest.json のバージョンを同期するスクリプト
+ * 成功した場合は true、変更が不要な場合は false を返す。
+ * エラーが発生した場合は例外を投げる。
  */
-function syncVersion() {
+export function syncVersion(): boolean {
+  // 1. ファイルの存在確認 (防御的チェック)
+  if (!fs.existsSync(packageJsonPath)) {
+    throw new Error(
+      `${LOG_MESSAGES.VERSION_SYNC_ERROR} package.json not found at: ${packageJsonPath}`,
+    )
+  }
+  if (!fs.existsSync(manifestJsonPath)) {
+    throw new Error(
+      `${LOG_MESSAGES.VERSION_SYNC_ERROR} manifest.json not found at: ${manifestJsonPath}`,
+    )
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+  const manifest = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf8'))
+
+  // 2. バージョンフィールドの型チェック (防御的チェック)
+  if (typeof packageJson.version !== 'string') {
+    throw new Error(
+      `${LOG_MESSAGES.VERSION_SYNC_ERROR} 'version' field in package.json is missing or not a string.`,
+    )
+  }
+
+  // 3. バージョンの同期
+  if (manifest.version !== packageJson.version) {
+    manifest.version = packageJson.version
+    fs.writeFileSync(
+      manifestJsonPath,
+      JSON.stringify(manifest, null, 2) + '\n',
+    )
+    console.log(LOG_MESSAGES.UPDATED_VERSION(packageJson.version))
+    return true
+  }
+
+  return false
+}
+
+// 直接実行された場合のみ実行 (CLI としての挙動)
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+if (isMain) {
   try {
-    // 1. ファイルの存在確認 (防御的チェック)
-    if (!fs.existsSync(packageJsonPath)) {
-      console.error(
-        `${LOG_MESSAGES.VERSION_SYNC_ERROR} package.json not found at: ${packageJsonPath}`,
-      )
-      process.exit(1)
-    }
-    if (!fs.existsSync(manifestJsonPath)) {
-      console.error(
-        `${LOG_MESSAGES.VERSION_SYNC_ERROR} manifest.json not found at: ${manifestJsonPath}`,
-      )
-      process.exit(1)
-    }
-
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
-    const manifest = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf8'))
-
-    // 2. バージョンフィールドの型チェック (防御的チェック)
-    if (typeof packageJson.version !== 'string') {
-      console.error(
-        `${LOG_MESSAGES.VERSION_SYNC_ERROR} 'version' field in package.json is missing or not a string.`,
-      )
-      process.exit(1)
-    }
-
-    // 3. バージョンの同期
-    if (manifest.version !== packageJson.version) {
-      manifest.version = packageJson.version
-      fs.writeFileSync(
-        manifestJsonPath,
-        JSON.stringify(manifest, null, 2) + '\n',
-      )
-      console.log(LOG_MESSAGES.UPDATED_VERSION(packageJson.version))
-    }
+    syncVersion()
   } catch (error) {
-    console.error(LOG_MESSAGES.VERSION_SYNC_ERROR, error)
+    console.error(error instanceof Error ? error.message : error)
     process.exit(1)
   }
 }
-
-syncVersion()


### PR DESCRIPTION
### 概要
`extension/sync-version.ts` のユニットテストを追加し、あわせてテスト可能な構造へのリファクタリングを実施しました。

### 変更内容
- **リファクタリング**: `extension/sync-version.ts`
  - 同期ロジックを `syncVersion` 関数としてエクスポートし、テストから呼び出せるようにしました。
  - 直接実行時 (`isMain`) とモジュールインポート時を分離し、CLI ツールとしての挙動を維持しつつ副作用を排除しました。
  - プロセス終了 (`process.exit`) ではなく、例外のスローによるエラー通知へ変更しました。
- **テスト追加**: `extension/sync-version.test.ts`
  - `fs` モジュールのメソッド (`existsSync`, `readFileSync`, `writeFileSync`) をスパイすることで、実際のファイルを操作せずにロジックを検証可能にしました。
  - 正常な同期、変更なし、ファイル欠損、JSON不正、バージョンフィールド欠損などのケースを網羅しました。

### 背景・目的
ビルドプロセスにおけるバージョン同期の不整合を自動テストで防ぐためです。

Closes #125