### PR TITLE
[Refactor] background.test.ts のテストケースを it.each で構造化

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -280,40 +280,35 @@ describe('background service worker', () => {
       await expect(handler({ tabId: 1, windowId: 1 })).resolves.not.toThrow()
     })
 
-    it('不許可拡張機能 (sender.id あり) をブロックすること', async () => {
-      const addListenerMock = vi.mocked(chrome.runtime.onMessageExternal.addListener)
+    it.each([
+      {
+        name: '不許可拡張機能 (sender.id あり) をブロックすること',
+        sender: { id: 'other-extension-id', origin: ALLOWED_ORIGINS[0] },
+        expectedWarn: LOG_MESSAGES.UNAUTHORIZED_EXTENSION_MESSAGE,
+        expectedArg: 'other-extension-id',
+      },
+      {
+        name: '不許可オリジンをブロックすること',
+        sender: { origin: 'http://malicious.com' },
+        expectedWarn: LOG_MESSAGES.UNAUTHORIZED_ORIGIN_MESSAGE,
+        expectedArg: 'http://malicious.com',
+      },
+    ])('$name', async ({ sender, expectedWarn, expectedArg }) => {
+      const addListenerMock = vi.mocked(
+        chrome.runtime.onMessageExternal.addListener,
+      )
       const consoleSpy = vi.mocked(console.warn)
       await import('./background')
 
       const messageHandler = addListenerMock.mock.calls[0][0]
-      const sendResponse = vi.fn()
-
       const result = messageHandler(
         { type: EXTENSION_MESSAGE_TYPES.GET_API_CONFIG },
-        { id: 'other-extension-id', origin: ALLOWED_ORIGINS[0] },
-        sendResponse
+        sender,
+        vi.fn(),
       )
 
       expect(result).toBe(false)
-      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.UNAUTHORIZED_EXTENSION_MESSAGE, 'other-extension-id')
-    })
-
-    it('不許可オリジンをブロックすること', async () => {
-      const addListenerMock = vi.mocked(chrome.runtime.onMessageExternal.addListener)
-      const consoleSpy = vi.mocked(console.warn)
-      await import('./background')
-
-      const messageHandler = addListenerMock.mock.calls[0][0]
-      const sendResponse = vi.fn()
-
-      const result = messageHandler(
-        { type: EXTENSION_MESSAGE_TYPES.GET_API_CONFIG },
-        { origin: 'http://malicious.com' },
-        sendResponse
-      )
-
-      expect(result).toBe(false)
-      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.UNAUTHORIZED_ORIGIN_MESSAGE, 'http://malicious.com')
+      expect(consoleSpy).toHaveBeenCalledWith(expectedWarn, expectedArg)
     })
 
     it('GET_API_CONFIG メッセージを受信した際に設定値を返すこと', async () => {

--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -85,7 +85,7 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, { url: 'https://new-site.com', title: 'New' } as chrome.tabs.Tab)
+      handler(1, { status: 'complete' }, { url: 'https://new-site.com', title: 'New' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
@@ -100,7 +100,7 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
+      handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
@@ -115,7 +115,7 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Modified' } as chrome.tabs.Tab)
+      handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Modified' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
@@ -133,7 +133,7 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
+      handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
@@ -149,7 +149,7 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
+      handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
@@ -164,7 +164,7 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, { url: 'chrome://settings', title: 'Settings' } as chrome.tabs.Tab)
+      handler(1, { status: 'complete' }, { url: 'chrome://settings', title: 'Settings' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
@@ -182,7 +182,7 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
-      await handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
+      handler(1, { status: 'complete' }, { url: 'https://example.com', title: 'Example' } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
         expect(chrome.action.setIcon).toHaveBeenCalledWith({
@@ -256,7 +256,7 @@ describe('background service worker', () => {
       await import('./background')
 
       const handler = onActivatedMock.mock.calls[0][0]
-      await handler({ tabId: 1, windowId: 1 })
+      handler({ tabId: 1, windowId: 1 })
 
       expect(chrome.tabs.get).toHaveBeenCalledWith(1)
       


### PR DESCRIPTION
### 概要
`extension/src/background.test.ts` のリファクタリングを行い、可読性の向上と TypeScript 警告の解消を行いました。

### 変更内容
- **テーブル駆動テストへの移行**: メッセージ外部オリジン検証テストを `it.each` に統合し、整理しました。
- **不要な await の削除**: TypeScript の型定義上で `void` を返す Chrome API リスナーの呼び出し箇所から不要な `await` を一括削除し、警告を解消しました。
- **安定性の維持**: 副作用の強い `updateIconStatus` 関連のテストは、安定性を優先して個別の `it` ブロックを維持しています。

### 背景・目的
テストコードのボイラープレートを削減し、型定義に忠実な記述に修正することで、メンテナンス性を向上させるためです。

Closes #192