### PR TITLE
[Refactor] Frontend テストの非同期待機を共通ユーティリティの waitFor に統一 (Step 1)

### DIFF
--- a/src/hooks/useApp.test.tsx
+++ b/src/hooks/useApp.test.tsx
@@ -1,10 +1,9 @@
-import { act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useApp } from './useApp'
 import { TEST_MESSAGES, HTML_ATTRIBUTES } from '@shared/constants'
 import { http, HttpResponse } from 'msw'
 import { server } from '../test/setup'
-import { renderHook } from '../test/utils'
+import { renderHook, waitFor, act } from '../test/utils'
 import { MOCK_BOOKMARK_1, VALID_URLS } from '@shared/test/fixtures'
 
 describe('useApp Hook (Integration)', () => {
@@ -42,13 +41,11 @@ describe('useApp Hook (Integration)', () => {
   const renderAppHook = async (initialUrl?: string) => {
     const renderResult = renderHook(() => useApp(), { initialUrl })
 
-    // isLoading が false になるまで待機 (act 内で実行)
-    await act(async () => {
-      await vi.waitFor(() => {
-        if (renderResult.result.current.isLoading) {
-          throw new Error(TEST_MESSAGES.UNEXPECTED_ERROR)
-        }
-      })
+    // isLoading が false になるまで待機
+    await waitFor(() => {
+      if (renderResult.result.current.isLoading) {
+        throw new Error(TEST_MESSAGES.UNEXPECTED_ERROR)
+      }
     })
 
     return renderResult


### PR DESCRIPTION
### 概要
`src/` 配下のフロントエンドテストにおいて、`vi.waitFor` を使用していた箇所を共通ユーティリティの `waitFor` に統一しました。

### 変更内容
- `src/hooks/useApp.test.tsx`:
  - `vi.waitFor` を `waitFor` に置換。
  - `act` のインポート元を `../test/utils` に変更し、直接的な依存関係を整理。
  - `waitFor` が内部で `act` を考慮するため、冗長な `await act(async () => { ... })` ラッパーを削除。

### 効果
- テストコードの記述が一貫し、可読性が向上しました。
- Testing Library の標準的な記述に合わせることで、将来的なライブラリの更新にも対応しやすくなりました。

Closes #195