### PR TITLE
[Backend] ブックマーク取得 API の拡張 (キーワード情報の包含) (Step 1-A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,11 @@ import { render, renderHook } from './test/utils'
       {
         "id": "1",
         "title": "Example",
-        "url": "https://example.com"
+        "url": "https://example.com",
+        "sortOrder": 0,
+        "keywords": [
+          { "id": "10", "name": "開発" }
+        ]
       }
     ]
   }
@@ -217,7 +221,9 @@ import { render, renderHook } from './test/utils'
   "data": {
     "id": "2",
     "title": "GitHub",
-    "url": "https://github.com"
+    "url": "https://github.com",
+    "sortOrder": 1,
+    "keywords": []
   }
 }
 ```
@@ -256,7 +262,25 @@ import { render, renderHook } from './test/utils'
 
 **レスポンス:**
 
-- **200 OK**: 更新成功。更新後のオブジェクトを `data` に含めて返却
+- **200 OK**: 更新成功。更新後のオブジェクトを `data` に含めて返却。キーワード情報も含まれます。
+
+**レスポンス例:**
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "1",
+    "title": "新しいタイトル",
+    "url": "https://updated-example.com",
+    "sortOrder": 0,
+    "keywords": [
+      { "id": "10", "name": "開発" }
+    ]
+  }
+}
+```
+
 - **400 Bad Request**: リクエスト形式または ID が不正な場合
 - **404 Not Found**: 指定された ID が存在しない
 - **409 Conflict**: 更新後の URL が既に登録されている場合

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -30,7 +30,7 @@ describe('App Global Handlers', () => {
   it('未キャッチのエラーが発生した際に 500 エラーを共通形式で返すこと', async () => {
     const dbError = new Error('Test unhandled error')
     // 既存のエンドポイントでエラーを発生させる
-    vi.spyOn(db, 'select').mockImplementation(() => {
+    vi.spyOn(db.query.bookmarks, 'findMany').mockImplementation(() => {
       throw dbError
     })
 

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -35,6 +35,36 @@ describe('Bookmarks API', () => {
       .run(SEED_DATA_2.title, SEED_DATA_2.url, 1)
   }
 
+  const seedWithKeywords = () => {
+    const b1 = sqlite
+      .prepare(
+        'INSERT INTO bookmarks (title, url, sort_order) VALUES (?, ?, ?) RETURNING bookmark_id',
+      )
+      .get(SEED_DATA_1.title, SEED_DATA_1.url, 0) as { bookmark_id: number }
+
+    const k1 = sqlite
+      .prepare(
+        'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
+      )
+      .get('Tag1') as { keyword_id: number }
+    const k2 = sqlite
+      .prepare(
+        'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
+      )
+      .get('Tag2') as { keyword_id: number }
+
+    sqlite
+      .prepare(
+        'INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (?, ?)',
+      )
+      .run(b1.bookmark_id, k1.keyword_id)
+    sqlite
+      .prepare(
+        'INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (?, ?)',
+      )
+      .run(b1.bookmark_id, k2.keyword_id)
+  }
+
   describe(`GET ${API_PATHS.BOOKMARKS}`, () => {
     it('空のリストを返すこと', async () => {
       const res = await app.request(API_PATHS.BOOKMARKS)
@@ -52,6 +82,23 @@ describe('Bookmarks API', () => {
       expect(body.data.bookmarks).toHaveLength(2)
       expect(body.data.bookmarks[0].title).toBe(SEED_DATA_1.title)
       expect(body.data.bookmarks[1].title).toBe(SEED_DATA_2.title)
+    })
+
+    it('関連付けられたキーワードを含めて返却されること', async () => {
+      seedWithKeywords()
+      const res = await app.request(API_PATHS.BOOKMARKS)
+      expect(res.status).toBe(HTTP_STATUS.OK)
+      const body = await res.json()
+
+      const bookmark = body.data.bookmarks[0]
+      expect(bookmark.keywords).toBeDefined()
+      expect(bookmark.keywords).toHaveLength(2)
+      expect(bookmark.keywords).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'Tag1' }),
+          expect.objectContaining({ name: 'Tag2' }),
+        ]),
+      )
     })
   })
 
@@ -249,7 +296,7 @@ describe('Bookmarks API', () => {
 
     it('GET: データベースエラー時に 500 を返し、適切なログを出力すること', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      vi.spyOn(db, 'select').mockImplementation(() => {
+      vi.spyOn(db.query.bookmarks, 'findMany').mockImplementation(() => {
         throw dbError
       })
       const res = await app.request(API_PATHS.BOOKMARKS)

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -23,16 +23,11 @@ describe('Bookmarks API', () => {
   const SEED_DATA_2 = { title: 'Google', url: VALID_URLS.GOOGLE }
 
   const seed = () => {
-    sqlite
-      .prepare(
-        'INSERT INTO bookmarks (title, url, sort_order) VALUES (?, ?, ?)',
-      )
-      .run(SEED_DATA_1.title, SEED_DATA_1.url, 0)
-    sqlite
-      .prepare(
-        'INSERT INTO bookmarks (title, url, sort_order) VALUES (?, ?, ?)',
-      )
-      .run(SEED_DATA_2.title, SEED_DATA_2.url, 1)
+    const insertBookmarkStmt = sqlite.prepare(
+      'INSERT INTO bookmarks (title, url, sort_order) VALUES (?, ?, ?)',
+    )
+    insertBookmarkStmt.run(SEED_DATA_1.title, SEED_DATA_1.url, 0)
+    insertBookmarkStmt.run(SEED_DATA_2.title, SEED_DATA_2.url, 1)
   }
 
   const seedWithKeywords = () => {
@@ -42,27 +37,17 @@ describe('Bookmarks API', () => {
       )
       .get(SEED_DATA_1.title, SEED_DATA_1.url, 0) as { bookmark_id: number }
 
-    const k1 = sqlite
-      .prepare(
-        'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
-      )
-      .get('Tag1') as { keyword_id: number }
-    const k2 = sqlite
-      .prepare(
-        'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
-      )
-      .get('Tag2') as { keyword_id: number }
+    const insertKeywordStmt = sqlite.prepare(
+      'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
+    )
+    const k1 = insertKeywordStmt.get('Tag1') as { keyword_id: number }
+    const k2 = insertKeywordStmt.get('Tag2') as { keyword_id: number }
 
-    sqlite
-      .prepare(
-        'INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (?, ?)',
-      )
-      .run(b1.bookmark_id, k1.keyword_id)
-    sqlite
-      .prepare(
-        'INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (?, ?)',
-      )
-      .run(b1.bookmark_id, k2.keyword_id)
+    const insertRelationStmt = sqlite.prepare(
+      'INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (?, ?)',
+    )
+    insertRelationStmt.run(b1.bookmark_id, k1.keyword_id)
+    insertRelationStmt.run(b1.bookmark_id, k2.keyword_id)
   }
 
   describe(`GET ${API_PATHS.BOOKMARKS}`, () => {

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -11,11 +11,42 @@ import {
   createBookmarkSchema,
   updateBookmarkSchema,
   reorderBookmarksSchema,
+  type Bookmark,
 } from '@shared/schemas/bookmark'
 
 import { db } from '../db'
 import { bookmarks as bookmarksTable } from '../db/schema'
 import { isUniqueConstraintError, API_ERROR_CODES } from '../utils/error'
+
+/**
+ * データベースのクエリ結果（キーワード包含）の型定義
+ */
+interface BookmarkQueryResult {
+  bookmarkId: number
+  title: string
+  url: string
+  sortOrder: number
+  bookmarkKeywords: {
+    keyword: {
+      keywordId: number
+      keywordName: string
+    }
+  }[]
+}
+
+/**
+ * DB のクエリ結果から API レスポンス形式 (DTO) へ変換するヘルパー
+ */
+const toBookmarkDto = (row: BookmarkQueryResult): Bookmark => ({
+  id: BookmarkIdSchema.parse(String(row.bookmarkId)),
+  title: row.title,
+  url: row.url,
+  sortOrder: row.sortOrder,
+  keywords: row.bookmarkKeywords.map((bk) => ({
+    id: KeywordIdSchema.parse(String(bk.keyword.keywordId)),
+    name: bk.keyword.keywordName,
+  })),
+})
 
 const bookmarksRoute = new Hono()
   .get('/', async (c) => {
@@ -31,16 +62,7 @@ const bookmarksRoute = new Hono()
         orderBy: (bookmarks, { asc }) => [asc(bookmarks.sortOrder)],
       })
 
-      const bookmarks = rows.map((row) => ({
-        id: BookmarkIdSchema.parse(String(row.bookmarkId)),
-        title: row.title,
-        url: row.url,
-        sortOrder: row.sortOrder,
-        keywords: row.bookmarkKeywords.map((bk) => ({
-          id: KeywordIdSchema.parse(String(bk.keyword.keywordId)),
-          name: bk.keyword.keywordName,
-        })),
-      }))
+      const bookmarks = rows.map(toBookmarkDto)
 
       const result = bookmarksResponseSchema.parse({ bookmarks })
       return c.json({
@@ -182,16 +204,7 @@ const bookmarksRoute = new Hono()
 
         return c.json({
           success: true,
-          data: {
-            id: BookmarkIdSchema.parse(String(updatedRow.bookmarkId)),
-            title: updatedRow.title,
-            url: updatedRow.url,
-            sortOrder: updatedRow.sortOrder,
-            keywords: updatedRow.bookmarkKeywords.map((bk) => ({
-              id: KeywordIdSchema.parse(String(bk.keyword.keywordId)),
-              name: bk.keyword.keywordName,
-            })),
-          },
+          data: toBookmarkDto(updatedRow),
         })
       } catch (error) {
         if (isUniqueConstraintError(error)) {

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -1,11 +1,12 @@
 import { Hono } from 'hono'
 import { z } from 'zod'
-import { eq, asc, sql, inArray } from 'drizzle-orm'
+import { eq, sql, inArray } from 'drizzle-orm'
 
 import { zValidator } from '@hono/zod-validator'
 import { ERROR_MESSAGES, LOG_MESSAGES, HTTP_STATUS } from '@shared/constants'
 import {
   BookmarkIdSchema,
+  KeywordIdSchema,
   bookmarksResponseSchema,
   createBookmarkSchema,
   updateBookmarkSchema,
@@ -19,21 +20,26 @@ import { isUniqueConstraintError, API_ERROR_CODES } from '../utils/error'
 const bookmarksRoute = new Hono()
   .get('/', async (c) => {
     try {
-      const rows = await db
-        .select({
-          id: bookmarksTable.bookmarkId,
-          title: bookmarksTable.title,
-          url: bookmarksTable.url,
-          sortOrder: bookmarksTable.sortOrder,
-        })
-        .from(bookmarksTable)
-        .orderBy(asc(bookmarksTable.sortOrder))
+      const rows = await db.query.bookmarks.findMany({
+        with: {
+          bookmarkKeywords: {
+            with: {
+              keyword: true,
+            },
+          },
+        },
+        orderBy: (bookmarks, { asc }) => [asc(bookmarks.sortOrder)],
+      })
 
       const bookmarks = rows.map((row) => ({
-        id: BookmarkIdSchema.parse(String(row.id)),
+        id: BookmarkIdSchema.parse(String(row.bookmarkId)),
         title: row.title,
         url: row.url,
         sortOrder: row.sortOrder,
+        keywords: row.bookmarkKeywords.map((bk) => ({
+          id: KeywordIdSchema.parse(String(bk.keyword.keywordId)),
+          name: bk.keyword.keywordName,
+        })),
       }))
 
       const result = bookmarksResponseSchema.parse({ bookmarks })
@@ -70,6 +76,7 @@ const bookmarksRoute = new Hono()
             title: row.title,
             url: row.url,
             sortOrder: row.sortOrder,
+            keywords: [],
           },
         },
         HTTP_STATUS.CREATED,
@@ -159,13 +166,31 @@ const bookmarksRoute = new Hono()
           )
         }
 
+        // 最新のキーワード情報を含めて再取得
+        const updatedRow = await db.query.bookmarks.findFirst({
+          where: eq(bookmarksTable.bookmarkId, bookmarkId),
+          with: {
+            bookmarkKeywords: {
+              with: {
+                keyword: true,
+              },
+            },
+          },
+        })
+
+        if (!updatedRow) throw new Error(LOG_MESSAGES.FETCH_BOOKMARKS_FAILED)
+
         return c.json({
           success: true,
           data: {
-            id: BookmarkIdSchema.parse(String(row.id)),
-            title: row.title,
-            url: row.url,
-            sortOrder: row.sortOrder,
+            id: BookmarkIdSchema.parse(String(updatedRow.bookmarkId)),
+            title: updatedRow.title,
+            url: updatedRow.url,
+            sortOrder: updatedRow.sortOrder,
+            keywords: updatedRow.bookmarkKeywords.map((bk) => ({
+              id: KeywordIdSchema.parse(String(bk.keyword.keywordId)),
+              name: bk.keyword.keywordName,
+            })),
           },
         })
       } catch (error) {

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -8,6 +8,18 @@ export const BookmarkIdSchema = z
   .brand<'BookmarkId'>()
 export type BookmarkId = z.infer<typeof BookmarkIdSchema>
 
+export const KeywordIdSchema = z
+  .string()
+  .regex(/^[1-9]\d*$/)
+  .brand<'KeywordId'>()
+export type KeywordId = z.infer<typeof KeywordIdSchema>
+
+export const keywordSchema = z.object({
+  id: KeywordIdSchema,
+  name: z.string(),
+})
+export type Keyword = z.infer<typeof keywordSchema>
+
 export const bookmarkSchema = z.object({
   id: BookmarkIdSchema,
   title: z.string(),
@@ -18,6 +30,7 @@ export const bookmarkSchema = z.object({
       message: VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
     }),
   sortOrder: z.number(),
+  keywords: z.array(keywordSchema),
 })
 
 export type Bookmark = z.infer<typeof bookmarkSchema>

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -7,6 +7,7 @@ export const MOCK_BOOKMARK_1: Bookmark = {
   title: `${MOCK_BOOKMARK_TITLE_PREFIX} 1`,
   url: 'https://example.com/1',
   sortOrder: 0,
+  keywords: [],
 }
 
 export const MOCK_BOOKMARK_2: Bookmark = {
@@ -14,6 +15,7 @@ export const MOCK_BOOKMARK_2: Bookmark = {
   title: `${MOCK_BOOKMARK_TITLE_PREFIX} 2`,
   url: 'https://example.com/2',
   sortOrder: 1,
+  keywords: [],
 }
 
 export const MOCK_BOOKMARKS = [MOCK_BOOKMARK_1, MOCK_BOOKMARK_2]


### PR DESCRIPTION
### 概要
`GET /api/bookmarks` のレスポンスを拡張し、各ブックマークに関連付けられているキーワードの一覧を返却するように修正しました。

### 変更内容
- **スキーマ更新**: `shared/schemas/bookmark.ts`
  - `bookmarkSchema` に `keywords: { id, name }[]` を追加。
- **API 実装拡張**: `server/routes/bookmarks.ts`
  - `GET /`: Drizzle ORM の `with` 句を使用して、`bookmark_keywords` および `keywords` テーブルを結合して一括取得。
  - `POST` / `PATCH`: 更新・作成後のレスポンスにも `keywords` 情報を含めるように修正。
- **フィクスチャ更新**: `shared/test/fixtures.ts`
  - 新しいスキーマに合わせて `MOCK_BOOKMARK_1`, `MOCK_BOOKMARK_2` に `keywords: []` を追加。
- **テストの修正・検証**:
  - `server/routes/bookmarks.test.ts` にキーワード取得の検証テストを追加。
  - 実装方式の変更（`db.select` から `db.query`）により影響を受けたエラーハンドリングテストを修正。
- **ドキュメント更新**: `README.md`
  - API 仕様セクションのレスポンス例を最新化。

### 背景・目的
フロントエンドにおいて、ブックマークに関連付けられたタグを表示し、フィルタリングを可能にするためのデータ基盤を構築しました。

Closes #200