### PR TITLE
[Backend] キーワード関連のスキーマ定義 (Step 1-B-1)

### DIFF
--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -1,24 +1,22 @@
 import { z } from 'zod'
 import { isHttpUrl } from '../utils/url'
 import { VALIDATION_MESSAGES } from '../constants'
+import {
+  keywordSchema,
+} from './keyword'
+
+export {
+  KeywordIdSchema,
+  keywordSchema,
+  type KeywordId,
+  type Keyword,
+} from './keyword'
 
 export const BookmarkIdSchema = z
   .string()
   .regex(/^[1-9]\d*$/)
   .brand<'BookmarkId'>()
 export type BookmarkId = z.infer<typeof BookmarkIdSchema>
-
-export const KeywordIdSchema = z
-  .string()
-  .regex(/^[1-9]\d*$/)
-  .brand<'KeywordId'>()
-export type KeywordId = z.infer<typeof KeywordIdSchema>
-
-export const keywordSchema = z.object({
-  id: KeywordIdSchema,
-  name: z.string(),
-})
-export type Keyword = z.infer<typeof keywordSchema>
 
 export const bookmarkSchema = z.object({
   id: BookmarkIdSchema,

--- a/shared/schemas/keyword.test.ts
+++ b/shared/schemas/keyword.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import {
+  KeywordIdSchema,
+  keywordSchema,
+  keywordWithCountSchema,
+  keywordsResponseSchema,
+} from './keyword'
+
+describe('Keyword Schemas', () => {
+  describe('KeywordIdSchema', () => {
+    it('正の整数文字列を受け入れること', () => {
+      expect(KeywordIdSchema.parse('1')).toBe('1')
+      expect(KeywordIdSchema.parse('123')).toBe('123')
+    })
+
+    it('0や負の数、非数値を拒否すること', () => {
+      expect(() => KeywordIdSchema.parse('0')).toThrow()
+      expect(() => KeywordIdSchema.parse('-1')).toThrow()
+      expect(() => KeywordIdSchema.parse('abc')).toThrow()
+    })
+  })
+
+  describe('keywordSchema', () => {
+    it('正しいキーワードオブジェクトを受け入れること', () => {
+      const validKeyword = { id: '1', name: 'Test' }
+      expect(keywordSchema.parse(validKeyword)).toEqual(validKeyword)
+    })
+
+    it('不正なデータを拒否すること', () => {
+      expect(() => keywordSchema.parse({ id: 'invalid', name: 'Test' })).toThrow()
+      expect(() => keywordSchema.parse({ id: '1' })).toThrow() // name missing
+    })
+  })
+
+  describe('keywordWithCountSchema', () => {
+    it('bookmarkCount を含むオブジェクトを受け入れること', () => {
+      const validData = { id: '1', name: 'Test', bookmarkCount: 5 }
+      expect(keywordWithCountSchema.parse(validData)).toEqual(validData)
+    })
+
+    it('bookmarkCount が欠落している場合に拒否すること', () => {
+      expect(() =>
+        keywordWithCountSchema.parse({ id: '1', name: 'Test' }),
+      ).toThrow()
+    })
+  })
+
+  describe('keywordsResponseSchema', () => {
+    it('キーワードリストを含むレスポンスを受け入れること', () => {
+      const validResponse = {
+        keywords: [
+          { id: '1', name: 'Tag1', bookmarkCount: 10 },
+          { id: '2', name: 'Tag2', bookmarkCount: 0 },
+        ],
+      }
+      expect(keywordsResponseSchema.parse(validResponse)).toEqual(validResponse)
+    })
+  })
+})

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+export const KeywordIdSchema = z
+  .string()
+  .regex(/^[1-9]\d*$/)
+  .brand<'KeywordId'>()
+export type KeywordId = z.infer<typeof KeywordIdSchema>
+
+export const keywordSchema = z.object({
+  id: KeywordIdSchema,
+  name: z.string(),
+})
+export type Keyword = z.infer<typeof keywordSchema>
+
+export const keywordWithCountSchema = keywordSchema.extend({
+  bookmarkCount: z.number(),
+})
+export type KeywordWithCount = z.infer<typeof keywordWithCountSchema>
+
+export const keywordsResponseSchema = z.object({
+  keywords: z.array(keywordWithCountSchema),
+})
+export type KeywordsResponse = z.infer<typeof keywordsResponseSchema>


### PR DESCRIPTION
### 概要
キーワード機能で使用するデータ構造（スキーマ）を定義・整理しました。

### 変更内容
- **新ファイル作成**: `shared/schemas/keyword.ts`
  - `KeywordIdSchema`, `keywordSchema` を定義。
  - 一覧取得 API 用の `keywordsResponseSchema` を新規追加。
- **リファクタリング**: `shared/schemas/bookmark.ts`
  - キーワード関連の定義を新ファイルからのインポート（re-export）に変更し、依存関係を整理。
- **テスト追加**: `shared/schemas/keyword.test.ts`
  - 定義したスキーマが期待通りにパース・検証を行うことを確認するユニットテストを追加。

### 背景・目的
キーワード一覧取得 API (`GET /api/keywords`) や今後の管理機能の実装に向けた、データ構造の基盤整備です。

Closes #205