### PR TITLE
chore(deps): 依存関係の一括アップデートと脆弱性の解消

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,11 @@ updates:
     labels:
       - 'type:chore'
     ignore:
-      - dependency-name: 'eslint'
+      - dependency-name: 'eslint*'
         update-types: ['version-update:semver-major']
-      - dependency-name: '@eslint/js'
+      - dependency-name: '@eslint*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript-eslint'
         update-types: ['version-update:semver-major']
     commit-message:
       prefix: 'chore(deps)'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
         patterns:
           - '*'
     labels:
-      - 'dependencies'
+      - 'type:chore'
+    ignore:
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@eslint/js'
+        update-types: ['version-update:semver-major']
     commit-message:
       prefix: 'chore(deps)'


### PR DESCRIPTION
### 概要
Dependabot が提案していた複数のプルリクエストを一つにまとめ、依存関係を一括で最新化しました。

### 変更内容
- `npm update` を実行し、主要なパッケージをアップデート。
- 対象 Dependabot PR: #148, #154, #198, #199, #211
- 主要更新内容:
  - `rollup`: 4.57.1 -> 4.59.0
  - `minimatch`: 3.1.2 -> 3.1.5
  - `hono`: 4.12.3 -> 4.12.5
  - `@hono/node-server`: 1.19.8 -> 1.19.11
- `.github/dependabot.yml` の修正:
  - ESLint v10 へのメジャーアップデートを一時的に除外（プラグイン対応待ち）。
  - ラベルを `type:chore` に更新。

### 検証内容
- `npm run lint`: パス
- `npm run type-check`: パス
- `npm run test`: 全 279 件パス

この PR のマージにより、個別の Dependabot PR は不要となります。