### PR TITLE
[Backend] キーワード一覧取得 API の新規実装 (Step 1-B-2)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -4,6 +4,7 @@ import { cors } from 'hono/cors'
 import { ERROR_MESSAGES, HTTP_STATUS, LOG_MESSAGES } from '@shared/constants'
 
 import bookmarksRoute from './routes/bookmarks'
+import keywordsRoute from './routes/keywords'
 import { API_ERROR_CODES } from './utils/error'
 
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
@@ -66,7 +67,10 @@ app.notFound((c) => {
 })
 
 // APIルートの定義
-export const api = app.basePath('/api').route('/bookmarks', bookmarksRoute)
+export const api = app
+  .basePath('/api')
+  .route('/bookmarks', bookmarksRoute)
+  .route('/keywords', keywordsRoute)
 
 export type AppType = typeof api
 

--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { API_PATHS, HTTP_STATUS } from '@shared/constants'
+import { VALID_URLS } from '@shared/test/fixtures'
+import app from '../app'
+import { sqlite, initializeDatabase, resetDatabase } from '../db'
+import { type KeywordWithCount } from '@shared/schemas/keyword'
+
+describe(`GET ${API_PATHS.KEYWORDS}`, () => {
+  beforeEach(() => {
+    initializeDatabase()
+    resetDatabase()
+  })
+
+  const seed = () => {
+    // ブックマーク作成
+    const b1 = sqlite
+      .prepare(
+        'INSERT INTO bookmarks (title, url) VALUES (?, ?) RETURNING bookmark_id',
+      )
+      .get('B1', VALID_URLS.HTTP) as { bookmark_id: number }
+    const b2 = sqlite
+      .prepare(
+        'INSERT INTO bookmarks (title, url) VALUES (?, ?) RETURNING bookmark_id',
+      )
+      .get('B2', VALID_URLS.HTTPS) as { bookmark_id: number }
+
+    // キーワード作成
+    const k1 = sqlite
+      .prepare(
+        'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
+      )
+      .get('Tag1') as { keyword_id: number }
+    const k2 = sqlite
+      .prepare(
+        'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
+      )
+      .get('Tag2') as { keyword_id: number }
+    sqlite.prepare('INSERT INTO keywords (keyword_name) VALUES (?)').run('Tag3') // 使われないキーワード
+
+    // 紐付け (Tag1: 2件, Tag2: 1件, Tag3: 0件)
+    const insertRel = sqlite.prepare(
+      'INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (?, ?)',
+    )
+    insertRel.run(b1.bookmark_id, k1.keyword_id)
+    insertRel.run(b2.bookmark_id, k1.keyword_id)
+    insertRel.run(b2.bookmark_id, k2.keyword_id)
+  }
+
+  it('登録済みのキーワードとブックマーク数を返すこと', async () => {
+    seed()
+    const res = await app.request(API_PATHS.KEYWORDS)
+    expect(res.status).toBe(HTTP_STATUS.OK)
+
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.data.keywords).toHaveLength(3)
+
+    // Tag1: 2 bookmarks
+    const tag1 = body.data.keywords.find(
+      (k: KeywordWithCount) => k.name === 'Tag1',
+    )
+    expect(tag1).toBeDefined()
+    expect((tag1 as KeywordWithCount).bookmarkCount).toBe(2)
+
+    // Tag2: 1 bookmark
+    const tag2 = body.data.keywords.find(
+      (k: KeywordWithCount) => k.name === 'Tag2',
+    )
+    expect(tag2).toBeDefined()
+    expect((tag2 as KeywordWithCount).bookmarkCount).toBe(1)
+
+    // Tag3: 0 bookmarks
+    const tag3 = body.data.keywords.find(
+      (k: KeywordWithCount) => k.name === 'Tag3',
+    )
+    expect(tag3).toBeDefined()
+    expect((tag3 as KeywordWithCount).bookmarkCount).toBe(0)
+  })
+
+  it('キーワードが存在しない場合は空リストを返すこと', async () => {
+    const res = await app.request(API_PATHS.KEYWORDS)
+    expect(res.status).toBe(HTTP_STATUS.OK)
+    const body = await res.json()
+    expect(body.data.keywords).toEqual([])
+  })
+})

--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { API_PATHS, HTTP_STATUS } from '@shared/constants'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { API_PATHS, HTTP_STATUS, LOG_MESSAGES } from '@shared/constants'
 import { VALID_URLS } from '@shared/test/fixtures'
 import app from '../app'
 import { sqlite, initializeDatabase, resetDatabase } from '../db'
@@ -64,5 +64,27 @@ describe(`GET ${API_PATHS.KEYWORDS}`, () => {
     expect(res.status).toBe(HTTP_STATUS.OK)
     const body = await res.json()
     expect(body.data.keywords).toEqual([])
+  })
+
+  describe('Database Error Handling', () => {
+    it('データベースエラー時に 500 を返し、適切なログを出力すること', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const dbError = new Error('Database error')
+
+      // API 実行中にエラーを発生させる
+      vi.spyOn(sqlite, 'prepare').mockImplementation(() => {
+        throw dbError
+      })
+
+      const res = await app.request(API_PATHS.KEYWORDS)
+      expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+
+      const body = await res.json()
+      expect(body.success).toBe(false)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        LOG_MESSAGES.FETCH_KEYWORDS_FAILED,
+        dbError,
+      )
+    })
   })
 })

--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -11,29 +11,27 @@ describe(`GET ${API_PATHS.KEYWORDS}`, () => {
   })
 
   const seed = () => {
+    const createBookmark = (title: string, url: string) =>
+      sqlite
+        .prepare(
+          'INSERT INTO bookmarks (title, url) VALUES (?, ?) RETURNING bookmark_id',
+        )
+        .get(title, url) as { bookmark_id: number }
+
+    const createKeywordWithId = (name: string) =>
+      sqlite
+        .prepare(
+          'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
+        )
+        .get(name) as { keyword_id: number }
+
     // ブックマーク作成
-    const b1 = sqlite
-      .prepare(
-        'INSERT INTO bookmarks (title, url) VALUES (?, ?) RETURNING bookmark_id',
-      )
-      .get('B1', VALID_URLS.HTTP) as { bookmark_id: number }
-    const b2 = sqlite
-      .prepare(
-        'INSERT INTO bookmarks (title, url) VALUES (?, ?) RETURNING bookmark_id',
-      )
-      .get('B2', VALID_URLS.HTTPS) as { bookmark_id: number }
+    const b1 = createBookmark('B1', VALID_URLS.HTTP)
+    const b2 = createBookmark('B2', VALID_URLS.HTTPS)
 
     // キーワード作成
-    const k1 = sqlite
-      .prepare(
-        'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
-      )
-      .get('Tag1') as { keyword_id: number }
-    const k2 = sqlite
-      .prepare(
-        'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
-      )
-      .get('Tag2') as { keyword_id: number }
+    const k1 = createKeywordWithId('Tag1')
+    const k2 = createKeywordWithId('Tag2')
     sqlite.prepare('INSERT INTO keywords (keyword_name) VALUES (?)').run('Tag3') // 使われないキーワード
 
     // 紐付け (Tag1: 2件, Tag2: 1件, Tag3: 0件)

--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -3,7 +3,6 @@ import { API_PATHS, HTTP_STATUS } from '@shared/constants'
 import { VALID_URLS } from '@shared/test/fixtures'
 import app from '../app'
 import { sqlite, initializeDatabase, resetDatabase } from '../db'
-import { type KeywordWithCount } from '@shared/schemas/keyword'
 
 describe(`GET ${API_PATHS.KEYWORDS}`, () => {
   beforeEach(() => {
@@ -53,28 +52,13 @@ describe(`GET ${API_PATHS.KEYWORDS}`, () => {
 
     const body = await res.json()
     expect(body.success).toBe(true)
-    expect(body.data.keywords).toHaveLength(3)
 
-    // Tag1: 2 bookmarks
-    const tag1 = body.data.keywords.find(
-      (k: KeywordWithCount) => k.name === 'Tag1',
-    )
-    expect(tag1).toBeDefined()
-    expect((tag1 as KeywordWithCount).bookmarkCount).toBe(2)
-
-    // Tag2: 1 bookmark
-    const tag2 = body.data.keywords.find(
-      (k: KeywordWithCount) => k.name === 'Tag2',
-    )
-    expect(tag2).toBeDefined()
-    expect((tag2 as KeywordWithCount).bookmarkCount).toBe(1)
-
-    // Tag3: 0 bookmarks
-    const tag3 = body.data.keywords.find(
-      (k: KeywordWithCount) => k.name === 'Tag3',
-    )
-    expect(tag3).toBeDefined()
-    expect((tag3 as KeywordWithCount).bookmarkCount).toBe(0)
+    const { keywords } = body.data
+    expect(keywords).toEqual([
+      { id: expect.any(String), name: 'Tag1', bookmarkCount: 2 },
+      { id: expect.any(String), name: 'Tag2', bookmarkCount: 1 },
+      { id: expect.any(String), name: 'Tag3', bookmarkCount: 0 },
+    ])
   })
 
   it('キーワードが存在しない場合は空リストを返すこと', async () => {

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -1,0 +1,46 @@
+import { Hono } from 'hono'
+import { sql } from 'drizzle-orm'
+import { db } from '../db'
+import { keywords as keywordsTable, bookmarkKeywords } from '../db/schema'
+import {
+  keywordsResponseSchema,
+  KeywordIdSchema,
+} from '@shared/schemas/keyword'
+import { LOG_MESSAGES } from '@shared/constants'
+
+const keywordsRoute = new Hono().get('/', async (c) => {
+  try {
+    // 全キーワードを取得し、各キーワードに紐付くブックマーク数をカウントする
+    // LEFT JOIN を使用して、ブックマークが 0 件のキーワードも取得する
+    const rows = await db
+      .select({
+        id: keywordsTable.keywordId,
+        name: keywordsTable.keywordName,
+        bookmarkCount: sql<number>`count(${bookmarkKeywords.bookmarkId})`,
+      })
+      .from(keywordsTable)
+      .leftJoin(
+        bookmarkKeywords,
+        sql`${keywordsTable.keywordId} = ${bookmarkKeywords.keywordId}`,
+      )
+      .groupBy(keywordsTable.keywordId)
+      .orderBy(keywordsTable.keywordName)
+
+    const keywords = rows.map((row) => ({
+      id: KeywordIdSchema.parse(String(row.id)),
+      name: row.name,
+      bookmarkCount: Number(row.bookmarkCount),
+    }))
+
+    const result = keywordsResponseSchema.parse({ keywords })
+    return c.json({
+      success: true,
+      data: result,
+    })
+  } catch (error) {
+    console.error(LOG_MESSAGES.FETCH_BOOKMARKS_FAILED, error) // TODO: 適切なメッセージ定数があれば差し替え
+    throw error
+  }
+})
+
+export default keywordsRoute

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -38,7 +38,7 @@ const keywordsRoute = new Hono().get('/', async (c) => {
       data: result,
     })
   } catch (error) {
-    console.error(LOG_MESSAGES.FETCH_BOOKMARKS_FAILED, error) // TODO: 適切なメッセージ定数があれば差し替え
+    console.error(LOG_MESSAGES.FETCH_KEYWORDS_FAILED, error)
     throw error
   }
 })

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono'
-import { sql } from 'drizzle-orm'
+import { eq, count } from 'drizzle-orm'
 import { db } from '../db'
 import { keywords as keywordsTable, bookmarkKeywords } from '../db/schema'
 import {
@@ -16,20 +16,20 @@ const keywordsRoute = new Hono().get('/', async (c) => {
       .select({
         id: keywordsTable.keywordId,
         name: keywordsTable.keywordName,
-        bookmarkCount: sql<number>`count(${bookmarkKeywords.bookmarkId})`,
+        bookmarkCount: count(bookmarkKeywords.bookmarkId),
       })
       .from(keywordsTable)
       .leftJoin(
         bookmarkKeywords,
-        sql`${keywordsTable.keywordId} = ${bookmarkKeywords.keywordId}`,
+        eq(keywordsTable.keywordId, bookmarkKeywords.keywordId),
       )
-      .groupBy(keywordsTable.keywordId)
+      .groupBy(keywordsTable.keywordId, keywordsTable.keywordName)
       .orderBy(keywordsTable.keywordName)
 
     const keywords = rows.map((row) => ({
       id: KeywordIdSchema.parse(String(row.id)),
       name: row.name,
-      bookmarkCount: Number(row.bookmarkCount),
+      bookmarkCount: row.bookmarkCount,
     }))
 
     const result = keywordsResponseSchema.parse({ keywords })

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -301,6 +301,7 @@ export const LOG_MESSAGES = {
   UPDATED_VERSION: (version: string) =>
     `[sync-version] Updated manifest.json version to ${version}`,
   BLOCKED_NON_HTTP_URL: (url: string) => `Blocked opening non-HTTP URL: ${url}`,
+  FETCH_KEYWORDS_FAILED: 'Failed to fetch keywords:',
 } as const
 
 /**

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -225,6 +225,7 @@ export const HTML_ATTRIBUTES = {
  */
 export const API_PATHS = {
   BOOKMARKS: '/api/bookmarks',
+  KEYWORDS: '/api/keywords',
 } as const
 
 export const HTTP_STATUS = {


### PR DESCRIPTION
### 概要
全キーワードの一覧を取得するエンドポイント `GET /api/keywords` を新規実装しました。

### 変更内容
- **ルート登録**: `server/app.ts`
  - `keywordsRoute` を `/api/keywords` として登録。
- **API 実装**: `server/routes/keywords.ts`
  - `keywords` テーブルから全件取得。
  - `LEFT JOIN` と `count` を使用して、各キーワードに紐付くブックマーク数を集計。
- **定数追加**: `shared/constants.ts`
  - `API_PATHS.KEYWORDS` を追加。
- **テスト追加**: `server/routes/keywords.test.ts`
  - 正常なキーワード取得およびブックマーク件数の集計を検証する統合テストを追加。

### 背景・目的
フロントエンドのサイドバーでのキーワード一覧表示や、フィルタリング機能のための基盤データを提供します。

Closes #201