### PR TITLE
[Refactor] サーバー側テストのシードデータ投入ロジックの共通化

### DIFF
--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -11,6 +11,7 @@ import { VALID_URLS } from '@shared/test/fixtures'
 import app from '../app'
 import { db, initializeDatabase, resetDatabase, sqlite } from '../db'
 import { API_ERROR_CODES } from '../utils/error'
+import { createBookmark, createKeyword, attachKeyword } from '../test/seedUtils'
 
 describe('Bookmarks API', () => {
   beforeEach(() => {
@@ -23,31 +24,17 @@ describe('Bookmarks API', () => {
   const SEED_DATA_2 = { title: 'Google', url: VALID_URLS.GOOGLE }
 
   const seed = () => {
-    const insertBookmarkStmt = sqlite.prepare(
-      'INSERT INTO bookmarks (title, url, sort_order) VALUES (?, ?, ?)',
-    )
-    insertBookmarkStmt.run(SEED_DATA_1.title, SEED_DATA_1.url, 0)
-    insertBookmarkStmt.run(SEED_DATA_2.title, SEED_DATA_2.url, 1)
+    createBookmark(SEED_DATA_1.title, SEED_DATA_1.url, 0)
+    createBookmark(SEED_DATA_2.title, SEED_DATA_2.url, 1)
   }
 
   const seedWithKeywords = () => {
-    const b1 = sqlite
-      .prepare(
-        'INSERT INTO bookmarks (title, url, sort_order) VALUES (?, ?, ?) RETURNING bookmark_id',
-      )
-      .get(SEED_DATA_1.title, SEED_DATA_1.url, 0) as { bookmark_id: number }
+    const b1 = createBookmark(SEED_DATA_1.title, SEED_DATA_1.url, 0)
+    const k1 = createKeyword('Tag1')
+    const k2 = createKeyword('Tag2')
 
-    const insertKeywordStmt = sqlite.prepare(
-      'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
-    )
-    const k1 = insertKeywordStmt.get('Tag1') as { keyword_id: number }
-    const k2 = insertKeywordStmt.get('Tag2') as { keyword_id: number }
-
-    const insertRelationStmt = sqlite.prepare(
-      'INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (?, ?)',
-    )
-    insertRelationStmt.run(b1.bookmark_id, k1.keyword_id)
-    insertRelationStmt.run(b1.bookmark_id, k2.keyword_id)
+    attachKeyword(b1.bookmark_id, k1.keyword_id)
+    attachKeyword(b1.bookmark_id, k2.keyword_id)
   }
 
   describe(`GET ${API_PATHS.BOOKMARKS}`, () => {

--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -3,6 +3,7 @@ import { API_PATHS, HTTP_STATUS, LOG_MESSAGES } from '@shared/constants'
 import { VALID_URLS } from '@shared/test/fixtures'
 import app from '../app'
 import { sqlite, initializeDatabase, resetDatabase } from '../db'
+import { createBookmark, createKeyword, attachKeyword } from '../test/seedUtils'
 
 describe(`GET ${API_PATHS.KEYWORDS}`, () => {
   beforeEach(() => {
@@ -11,36 +12,19 @@ describe(`GET ${API_PATHS.KEYWORDS}`, () => {
   })
 
   const seed = () => {
-    const createBookmark = (title: string, url: string) =>
-      sqlite
-        .prepare(
-          'INSERT INTO bookmarks (title, url) VALUES (?, ?) RETURNING bookmark_id',
-        )
-        .get(title, url) as { bookmark_id: number }
-
-    const createKeywordWithId = (name: string) =>
-      sqlite
-        .prepare(
-          'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
-        )
-        .get(name) as { keyword_id: number }
-
     // ブックマーク作成
     const b1 = createBookmark('B1', VALID_URLS.HTTP)
     const b2 = createBookmark('B2', VALID_URLS.HTTPS)
 
     // キーワード作成
-    const k1 = createKeywordWithId('Tag1')
-    const k2 = createKeywordWithId('Tag2')
+    const k1 = createKeyword('Tag1')
+    const k2 = createKeyword('Tag2')
     sqlite.prepare('INSERT INTO keywords (keyword_name) VALUES (?)').run('Tag3') // 使われないキーワード
 
     // 紐付け (Tag1: 2件, Tag2: 1件, Tag3: 0件)
-    const insertRel = sqlite.prepare(
-      'INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (?, ?)',
-    )
-    insertRel.run(b1.bookmark_id, k1.keyword_id)
-    insertRel.run(b2.bookmark_id, k1.keyword_id)
-    insertRel.run(b2.bookmark_id, k2.keyword_id)
+    attachKeyword(b1.bookmark_id, k1.keyword_id)
+    attachKeyword(b2.bookmark_id, k1.keyword_id)
+    attachKeyword(b2.bookmark_id, k2.keyword_id)
   }
 
   it('登録済みのキーワードとブックマーク数を返すこと', async () => {

--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -19,7 +19,7 @@ describe(`GET ${API_PATHS.KEYWORDS}`, () => {
     // キーワード作成
     const k1 = createKeyword('Tag1')
     const k2 = createKeyword('Tag2')
-    sqlite.prepare('INSERT INTO keywords (keyword_name) VALUES (?)').run('Tag3') // 使われないキーワード
+    createKeyword('Tag3') // 使われないキーワード
 
     // 紐付け (Tag1: 2件, Tag2: 1件, Tag3: 0件)
     attachKeyword(b1.bookmark_id, k1.keyword_id)

--- a/server/test/seedUtils.ts
+++ b/server/test/seedUtils.ts
@@ -1,18 +1,24 @@
 import { z } from 'zod'
 import { sqlite } from '../db'
+import type { Statement } from 'better-sqlite3'
 
 const BookmarkIdResultSchema = z.object({ bookmark_id: z.number() })
 const KeywordIdResultSchema = z.object({ keyword_id: z.number() })
+
+let insertBookmarkStmt: Statement | undefined
+let insertKeywordStmt: Statement | undefined
+let attachKeywordStmt: Statement | undefined
 
 /**
  * テスト用のブックマークを作成する
  */
 export const createBookmark = (title: string, url: string, sortOrder = 0) => {
-  const row = sqlite
-    .prepare(
+  if (!insertBookmarkStmt) {
+    insertBookmarkStmt = sqlite.prepare(
       'INSERT INTO bookmarks (title, url, sort_order) VALUES (?, ?, ?) RETURNING bookmark_id',
     )
-    .get(title, url, sortOrder)
+  }
+  const row = insertBookmarkStmt.get(title, url, sortOrder)
   return BookmarkIdResultSchema.parse(row)
 }
 
@@ -20,11 +26,12 @@ export const createBookmark = (title: string, url: string, sortOrder = 0) => {
  * テスト用のキーワードを作成する
  */
 export const createKeyword = (name: string) => {
-  const row = sqlite
-    .prepare(
+  if (!insertKeywordStmt) {
+    insertKeywordStmt = sqlite.prepare(
       'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
     )
-    .get(name)
+  }
+  const row = insertKeywordStmt.get(name)
   return KeywordIdResultSchema.parse(row)
 }
 
@@ -32,9 +39,10 @@ export const createKeyword = (name: string) => {
  * ブックマークとキーワードを紐付ける
  */
 export const attachKeyword = (bookmarkId: number, keywordId: number) => {
-  return sqlite
-    .prepare(
+  if (!attachKeywordStmt) {
+    attachKeywordStmt = sqlite.prepare(
       'INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (?, ?)',
     )
-    .run(bookmarkId, keywordId)
+  }
+  return attachKeywordStmt.run(bookmarkId, keywordId)
 }

--- a/server/test/seedUtils.ts
+++ b/server/test/seedUtils.ts
@@ -1,25 +1,31 @@
+import { z } from 'zod'
 import { sqlite } from '../db'
+
+const BookmarkIdResultSchema = z.object({ bookmark_id: z.number() })
+const KeywordIdResultSchema = z.object({ keyword_id: z.number() })
 
 /**
  * テスト用のブックマークを作成する
  */
 export const createBookmark = (title: string, url: string, sortOrder = 0) => {
-  return sqlite
+  const row = sqlite
     .prepare(
       'INSERT INTO bookmarks (title, url, sort_order) VALUES (?, ?, ?) RETURNING bookmark_id',
     )
-    .get(title, url, sortOrder) as { bookmark_id: number }
+    .get(title, url, sortOrder)
+  return BookmarkIdResultSchema.parse(row)
 }
 
 /**
  * テスト用のキーワードを作成する
  */
 export const createKeyword = (name: string) => {
-  return sqlite
+  const row = sqlite
     .prepare(
       'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
     )
-    .get(name) as { keyword_id: number }
+    .get(name)
+  return KeywordIdResultSchema.parse(row)
 }
 
 /**

--- a/server/test/seedUtils.ts
+++ b/server/test/seedUtils.ts
@@ -1,0 +1,34 @@
+import { sqlite } from '../db'
+
+/**
+ * テスト用のブックマークを作成する
+ */
+export const createBookmark = (title: string, url: string, sortOrder = 0) => {
+  return sqlite
+    .prepare(
+      'INSERT INTO bookmarks (title, url, sort_order) VALUES (?, ?, ?) RETURNING bookmark_id',
+    )
+    .get(title, url, sortOrder) as { bookmark_id: number }
+}
+
+/**
+ * テスト用のキーワードを作成する
+ */
+export const createKeyword = (name: string) => {
+  return sqlite
+    .prepare(
+      'INSERT INTO keywords (keyword_name) VALUES (?) RETURNING keyword_id',
+    )
+    .get(name) as { keyword_id: number }
+}
+
+/**
+ * ブックマークとキーワードを紐付ける
+ */
+export const attachKeyword = (bookmarkId: number, keywordId: number) => {
+  return sqlite
+    .prepare(
+      'INSERT INTO bookmark_keywords (bookmark_id, keyword_id) VALUES (?, ?)',
+    )
+    .run(bookmarkId, keywordId)
+}


### PR DESCRIPTION
### 概要
`bookmarks.test.ts` や `keywords.test.ts` で重複していたテストデータのセットアップロジックを、共通のユーティリティとして抽出・再利用できるようにリファクタリングしました。

### 変更内容
- **新ファイルの作成**: `server/test/seedUtils.ts`
  - `createBookmark`, `createKeyword`, `attachKeyword` を定義。
- **既存テストの修正**:
  - `server/routes/keywords.test.ts` および `server/routes/bookmarks.test.ts` からローカルのデータ作成ヘルパーを削除し、共通ユーティリティを使用するように書き換え。

### 背景・目的
テストコードの DRY 原則を適用し、今後のキーワード機能拡張に伴うテストデータの投入を容易にすることを目的としています。

Closes #216