### PR TITLE
[Refactor] POST ハンドラでの toBookmarkDto 利用とヘルパーの汎用化

### DIFF
--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -26,7 +26,7 @@ interface BookmarkQueryResult {
   title: string
   url: string
   sortOrder: number
-  bookmarkKeywords: {
+  bookmarkKeywords?: {
     keyword: {
       keywordId: number
       keywordName: string
@@ -42,10 +42,11 @@ const toBookmarkDto = (row: BookmarkQueryResult): Bookmark => ({
   title: row.title,
   url: row.url,
   sortOrder: row.sortOrder,
-  keywords: row.bookmarkKeywords.map((bk) => ({
-    id: KeywordIdSchema.parse(String(bk.keyword.keywordId)),
-    name: bk.keyword.keywordName,
-  })),
+  keywords:
+    row.bookmarkKeywords?.map((bk) => ({
+      id: KeywordIdSchema.parse(String(bk.keyword.keywordId)),
+      name: bk.keyword.keywordName,
+    })) ?? [],
 })
 
 const bookmarksRoute = new Hono()
@@ -82,7 +83,7 @@ const bookmarksRoute = new Hono()
         .insert(bookmarksTable)
         .values({ title, url })
         .returning({
-          id: bookmarksTable.bookmarkId,
+          bookmarkId: bookmarksTable.bookmarkId,
           title: bookmarksTable.title,
           url: bookmarksTable.url,
           sortOrder: bookmarksTable.sortOrder,
@@ -93,13 +94,7 @@ const bookmarksRoute = new Hono()
       return c.json(
         {
           success: true,
-          data: {
-            id: BookmarkIdSchema.parse(String(row.id)),
-            title: row.title,
-            url: row.url,
-            sortOrder: row.sortOrder,
-            keywords: [],
-          },
+          data: toBookmarkDto(row),
         },
         HTTP_STATUS.CREATED,
       )
@@ -168,12 +163,7 @@ const bookmarksRoute = new Hono()
           .update(bookmarksTable)
           .set(updates)
           .where(eq(bookmarksTable.bookmarkId, bookmarkId))
-          .returning({
-            id: bookmarksTable.bookmarkId,
-            title: bookmarksTable.title,
-            url: bookmarksTable.url,
-            sortOrder: bookmarksTable.sortOrder,
-          })
+          .returning()
 
         if (!row) {
           return c.json(


### PR DESCRIPTION
### 概要
`POST /api/bookmarks` ハンドラにおけるレスポンス生成ロジックを、既存の `toBookmarkDto` ヘルパー関数を利用するように統合しました。

### 変更内容
- **`toBookmarkDto` の汎用化**:
  - 引数の型定義において `bookmarkKeywords` をオプショナルに変更。
  - プロパティが存在しない場合は空配列 `[]` を返すように堅牢化。
- **`POST /api/bookmarks` の修正**:
  - 手動でのオブジェクト生成を止め、`toBookmarkDto` を経由するように変更。
- **`PATCH /api/bookmarks/:id` の最適化**:
  - `returning()` の引数を省略（全カラム取得）し、再取得ロジックとの整合性を維持。

### 背景・目的
API レスポンスの生成ロジックを一箇所に集約することで、今後のキーワード機能拡張に伴う変更漏れを防ぎ、保守性を向上させるためです。

Closes #204