### PR TITLE
feat(frontend): react-router-dom の導入とメイン一覧画面 (/) のルート定義

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "hono": "^4.12.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-router-dom": "^7.13.1",
         "zod": "^4.3.5"
       },
       "devDependencies": {
@@ -3529,7 +3530,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6290,6 +6290,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
+      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.1.tgz",
+      "integrity": "sha512-UJnV3Rxc5TgUPJt2KJpo1Jpy0OKQr0AjgbZzBFjaPJcFOb2Y8jA5H3LT8HUJAiRLlWrEXWHbF1Z4SCZaQjWDHw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -6507,6 +6545,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "hono": "^4.12.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-router-dom": "^7.13.1",
     "zod": "^4.3.5"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,19 @@
+import { Routes, Route } from 'react-router-dom'
 import './App.css'
-import { BookmarkList } from './components/BookmarkList'
-import { BookmarkDetail } from './components/BookmarkDetail'
 import { SettingsPanel } from './components/SettingsPanel'
 import { useApp } from './hooks/useApp'
 import { FIELD_LABELS } from '@shared/constants'
+import { HomePage } from './pages/HomePage'
 
 function App() {
+  const appState = useApp()
   const {
-    bookmarks,
-    selectedBookmark,
-    selectedId,
-    isLoading,
-    error,
     showSettings,
     currentApiUrl,
-    handleRowClick,
-    handleDoubleClick,
-    handleUpdate,
-    handleDelete,
-    handleOpen,
-    handleClose,
-    handleReorder,
     handleSaveSettings,
     toggleSettings,
     closeSettings,
-  } = useApp()
+  } = appState
 
   return (
     <div className="flex flex-col h-full w-full bg-white overflow-hidden">
@@ -67,36 +56,9 @@ function App() {
         />
       )}
 
-      <main className="flex-1 flex justify-center overflow-hidden">
-        <div className="w-full max-w-2xl flex flex-col h-full shadow-xl">
-          <div className="flex-1 overflow-y-auto pt-4 pb-4 px-4">
-            <BookmarkList
-              bookmarks={bookmarks}
-              isLoading={isLoading}
-              error={error}
-              selectedId={selectedId}
-              onRowClick={handleRowClick}
-              onDoubleClick={handleDoubleClick}
-              onClose={handleClose}
-              onReorder={handleReorder}
-            />
-          </div>
-        </div>
-      </main>
-
-      {selectedBookmark && (
-        <footer className="w-full flex justify-center border-t border-gray-200 shadow-[0_-4px_20px_-2px_rgba(0,0,0,0.1)] z-10">
-          <div className="w-full max-w-2xl">
-            <BookmarkDetail
-              bookmark={selectedBookmark}
-              onUpdate={handleUpdate}
-              onDelete={handleDelete}
-              onOpen={handleOpen}
-              onClose={handleClose}
-            />
-          </div>
-        </footer>
-      )}
+      <Routes>
+        <Route path="/" element={<HomePage appState={appState} />} />
+      </Routes>
     </div>
   )
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import './index.css'
 import App from './App.tsx'
@@ -9,10 +10,12 @@ const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ApiProvider>
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
-    </ApiProvider>
+    <BrowserRouter>
+      <ApiProvider>
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
+      </ApiProvider>
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,59 @@
+import { BookmarkList } from '../components/BookmarkList'
+import { BookmarkDetail } from '../components/BookmarkDetail'
+import { useApp } from '../hooks/useApp'
+
+interface HomePageProps {
+  appState: ReturnType<typeof useApp>
+}
+
+export function HomePage({ appState }: HomePageProps) {
+  const {
+    bookmarks,
+    selectedBookmark,
+    selectedId,
+    isLoading,
+    error,
+    handleRowClick,
+    handleDoubleClick,
+    handleUpdate,
+    handleDelete,
+    handleOpen,
+    handleClose,
+    handleReorder,
+  } = appState
+
+  return (
+    <>
+      <main className="flex-1 flex justify-center overflow-hidden">
+        <div className="w-full max-w-2xl flex flex-col h-full shadow-xl">
+          <div className="flex-1 overflow-y-auto pt-4 pb-4 px-4">
+            <BookmarkList
+              bookmarks={bookmarks}
+              isLoading={isLoading}
+              error={error}
+              selectedId={selectedId}
+              onRowClick={handleRowClick}
+              onDoubleClick={handleDoubleClick}
+              onClose={handleClose}
+              onReorder={handleReorder}
+            />
+          </div>
+        </div>
+      </main>
+
+      {selectedBookmark && (
+        <footer className="w-full flex justify-center border-t border-gray-200 shadow-[0_-4px_20px_-2px_rgba(0,0,0,0.1)] z-10">
+          <div className="w-full max-w-2xl">
+            <BookmarkDetail
+              bookmark={selectedBookmark}
+              onUpdate={handleUpdate}
+              onDelete={handleDelete}
+              onOpen={handleOpen}
+              onClose={handleClose}
+            />
+          </div>
+        </footer>
+      )}
+    </>
+  )
+}

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -2,6 +2,7 @@ import { useMemo, type ReactNode, type ReactElement } from 'react'
 import { render, renderHook } from '@testing-library/react'
 import type { RenderOptions, RenderHookOptions } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
 import { ApiProvider } from '../contexts/ApiContext'
 
 /**
@@ -23,22 +24,24 @@ export const createTestQueryClient = () =>
 /**
  * すべての Provider で包むラッパーコンポーネント
  */
-export const AllTheProviders = ({ 
-  children, 
-  initialUrl 
-}: { 
-  children: ReactNode, 
-  initialUrl?: string 
+export const AllTheProviders = ({
+  children,
+  initialUrl,
+}: {
+  children: ReactNode
+  initialUrl?: string
 }) => {
   // QueryClient をメモ化して再生成を防ぐ
   const queryClient = useMemo(() => createTestQueryClient(), [])
-  
+
   return (
-    <ApiProvider initialUrl={initialUrl}>
-      <QueryClientProvider client={queryClient}>
-        {children}
-      </QueryClientProvider>
-    </ApiProvider>
+    <MemoryRouter initialEntries={['/']}>
+      <ApiProvider initialUrl={initialUrl}>
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      </ApiProvider>
+    </MemoryRouter>
   )
 }
 
@@ -47,7 +50,7 @@ export const AllTheProviders = ({
  */
 const customRender = (
   ui: ReactElement,
-  options?: RenderOptions & { initialUrl?: string }
+  options?: RenderOptions & { initialUrl?: string },
 ) => {
   const { wrapper: Wrapper, initialUrl, ...rest } = options || {}
 
@@ -64,7 +67,7 @@ const customRender = (
  */
 const customRenderHook = <Result, Props>(
   hookRender: (initialProps: Props) => Result,
-  options?: RenderHookOptions<Props> & { initialUrl?: string }
+  options?: RenderHookOptions<Props> & { initialUrl?: string },
 ) => {
   const { wrapper: Wrapper, initialUrl, ...rest } = options || {}
 


### PR DESCRIPTION
### 概要
`react-router-dom` を導入し、アプリケーション全体のルーティング基盤を構築しました。現在のブックマーク一覧表示機能をルートパス (`/`) に割り当て、既存の動作を維持したままページ遷移の準備を整えました。

### 変更内容
- **ライブラリ導入**: `react-router-dom` をインストール。
- **基盤設定**: `src/main.tsx` に `BrowserRouter` を追加。
- **ページ分離**: 既存の `App.tsx` からブックマーク一覧表示ロジックを `src/pages/HomePage.tsx` へ分離。
- **ルート定義**: `App.tsx` で `Routes`/`Route` を定義し、`/` パスに `HomePage` を配置。
- **テスト対応**: `src/test/utils.tsx` を `MemoryRouter` でラップし、既存の統合テストがパスするように修正。

### 検証結果
- `npm run type-check`: パス
- `npm run test`: 全ての統合テストが正常にパス

Closes #219