### PR TITLE
refactor(frontend): ダブルクリックによるブックマーク起動機能の廃止

### DIFF
--- a/src/components/BookmarkItem.test.tsx
+++ b/src/components/BookmarkItem.test.tsx
@@ -49,10 +49,13 @@ describe('BookmarkItem', () => {
   })
 
   describe('キーボード操作', () => {
-    it('Enter キーで onOpen が呼ばれること', async () => {
+    it('Enter キーで onOpen が呼ばれること (isSelected が true の場合)', async () => {
       const user = userEvent.setup()
       const onOpen = vi.fn()
-      render(<BookmarkItem {...defaultProps} onOpen={onOpen} />, { wrapper })
+      render(
+        <BookmarkItem {...defaultProps} isSelected={true} onOpen={onOpen} />,
+        { wrapper },
+      )
 
       const item = screen.getByRole(ARIA_ROLES.BUTTON, {
         name: new RegExp(MOCK_BOOKMARK_1.title),
@@ -60,6 +63,22 @@ describe('BookmarkItem', () => {
       item.focus()
       await user.keyboard('{Enter}')
       expect(onOpen).toHaveBeenCalled()
+    })
+
+    it('isSelected が false の場合、Enter キーで onOpen が呼ばれないこと', async () => {
+      const user = userEvent.setup()
+      const onOpen = vi.fn()
+      render(
+        <BookmarkItem {...defaultProps} isSelected={false} onOpen={onOpen} />,
+        { wrapper },
+      )
+
+      const item = screen.getByRole(ARIA_ROLES.BUTTON, {
+        name: new RegExp(MOCK_BOOKMARK_1.title),
+      })
+      item.focus()
+      await user.keyboard('{Enter}')
+      expect(onOpen).not.toHaveBeenCalled()
     })
 
     it('スペース キーで onRowClick が呼ばれること', async () => {

--- a/src/components/BookmarkItem.test.tsx
+++ b/src/components/BookmarkItem.test.tsx
@@ -14,9 +14,9 @@ describe('BookmarkItem', () => {
   const defaultProps = {
     bookmark: MOCK_BOOKMARK_1,
     isSelected: false,
-    isFocusable: false,
+    isFocusable: true,
     onRowClick: vi.fn(),
-    onDoubleClick: vi.fn(),
+    onOpen: vi.fn(),
     onClose: vi.fn(),
   }
 
@@ -48,38 +48,18 @@ describe('BookmarkItem', () => {
     expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
   })
 
-  it('ダブルクリック時に onDoubleClick が呼ばれること', async () => {
-    const user = userEvent.setup()
-    const onDoubleClick = vi.fn()
-    render(<BookmarkItem {...defaultProps} onDoubleClick={onDoubleClick} />, {
-      wrapper,
-    })
-
-    await user.dblClick(screen.getByText(MOCK_BOOKMARK_1.title))
-    expect(onDoubleClick).toHaveBeenCalledWith(
-      MOCK_BOOKMARK_1.id,
-      MOCK_BOOKMARK_1.url,
-    )
-  })
-
   describe('キーボード操作', () => {
-    it('Enter キーで onDoubleClick が呼ばれること', async () => {
+    it('Enter キーで onOpen が呼ばれること', async () => {
       const user = userEvent.setup()
-      const onDoubleClick = vi.fn()
-      render(
-        <BookmarkItem {...defaultProps} onDoubleClick={onDoubleClick} />,
-        { wrapper },
-      )
+      const onOpen = vi.fn()
+      render(<BookmarkItem {...defaultProps} onOpen={onOpen} />, { wrapper })
 
       const item = screen.getByRole(ARIA_ROLES.BUTTON, {
         name: new RegExp(MOCK_BOOKMARK_1.title),
       })
       item.focus()
       await user.keyboard('{Enter}')
-      expect(onDoubleClick).toHaveBeenCalledWith(
-        MOCK_BOOKMARK_1.id,
-        MOCK_BOOKMARK_1.url,
-      )
+      expect(onOpen).toHaveBeenCalled()
     })
 
     it('スペース キーで onRowClick が呼ばれること', async () => {
@@ -113,13 +93,13 @@ describe('BookmarkItem', () => {
     it('その他のキー（aなど）では何も呼ばれないこと', async () => {
       const user = userEvent.setup()
       const onRowClick = vi.fn()
-      const onDoubleClick = vi.fn()
+      const onOpen = vi.fn()
       const onClose = vi.fn()
       render(
         <BookmarkItem
           {...defaultProps}
           onRowClick={onRowClick}
-          onDoubleClick={onDoubleClick}
+          onOpen={onOpen}
           onClose={onClose}
         />,
         { wrapper },
@@ -131,7 +111,7 @@ describe('BookmarkItem', () => {
       item.focus()
       await user.keyboard('a')
       expect(onRowClick).not.toHaveBeenCalled()
-      expect(onDoubleClick).not.toHaveBeenCalled()
+      expect(onOpen).not.toHaveBeenCalled()
       expect(onClose).not.toHaveBeenCalled()
     })
   })

--- a/src/components/BookmarkItem.tsx
+++ b/src/components/BookmarkItem.tsx
@@ -58,7 +58,7 @@ export const BookmarkItem = memo(
         {...{ [ARIA_ATTRIBUTES.SELECTED]: isSelected }}
         onClick={() => onRowClick(bookmark.id)}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') {
+          if (e.key === 'Enter' && isSelected) {
             onOpen()
           } else if (e.key === ' ') {
             e.preventDefault()

--- a/src/components/BookmarkItem.tsx
+++ b/src/components/BookmarkItem.tsx
@@ -9,7 +9,7 @@ interface BookmarkItemProps {
   isSelected: boolean
   isFocusable: boolean
   onRowClick: (id: BookmarkId) => void
-  onDoubleClick: (id: BookmarkId, url: string) => void
+  onOpen: () => void
   onClose: () => void
 }
 
@@ -19,7 +19,7 @@ export const BookmarkItem = memo(
     isSelected,
     isFocusable,
     onRowClick,
-    onDoubleClick,
+    onOpen,
     onClose,
   }: BookmarkItemProps) => {
     const {
@@ -36,14 +36,14 @@ export const BookmarkItem = memo(
       transition,
       opacity: isDragging ? 0.5 : 1,
       zIndex: isDragging ? 50 : undefined,
-      position: isDragging ? 'relative' as const : undefined,
+      position: isDragging ? ('relative' as const) : undefined,
     }
 
     // テーブルの行のような見た目を div で再現
     const itemClassName = `flex items-center transition-colors cursor-pointer hover:bg-blue-200 bg-blue-100 text-sm text-left text-gray-900 select-none group border-b border-blue-700 ${
       isDragging ? 'shadow-lg' : ''
     }`
-    
+
     const contentClassName = `flex-1 px-2 py-1 truncate ${
       isSelected ? 'font-bold' : ''
     }`
@@ -57,10 +57,9 @@ export const BookmarkItem = memo(
         {...{ [HTML_ATTRIBUTES.ROLE]: ARIA_ROLES.BUTTON }}
         {...{ [ARIA_ATTRIBUTES.SELECTED]: isSelected }}
         onClick={() => onRowClick(bookmark.id)}
-        onDoubleClick={() => onDoubleClick(bookmark.id, bookmark.url)}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
-            onDoubleClick(bookmark.id, bookmark.url)
+            onOpen()
           } else if (e.key === ' ') {
             e.preventDefault()
             onRowClick(bookmark.id)
@@ -91,7 +90,7 @@ export const BookmarkItem = memo(
             />
           </svg>
         </div>
-        
+
         {/* ブックマークタイトル */}
         <div className={contentClassName}>{bookmark.title}</div>
       </div>

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -176,16 +176,23 @@ describe('BookmarkList', () => {
   it('行にフォーカスして Enter キーを押した際に onOpen が呼び出されること', async () => {
     const user = userEvent.setup()
     const onOpen = vi.fn()
-    render(<BookmarkList {...defaultProps} onOpen={onOpen} />)
+    // MOCK_BOOKMARK_2 を選択状態にしてレンダリング
+    render(
+      <BookmarkList
+        {...defaultProps}
+        onOpen={onOpen}
+        selectedId={MOCK_BOOKMARK_2.id}
+      />,
+    )
 
     const items = screen.getAllByRole(ARIA_ROLES.BUTTON, {
       name: new RegExp(MOCK_BOOKMARK_TITLE_PREFIX),
     })
 
-    expect(items[0]).toHaveAttribute(HTML_ATTRIBUTES.TAB_INDEX, '0')
-    expect(items[1]).toHaveAttribute(HTML_ATTRIBUTES.TAB_INDEX, '-1')
+    // 選択されている items[1] (MOCK_BOOKMARK_2) にフォーカスして Enter
+    items[1]!.focus()
+    await user.keyboard('{Enter}')
 
-    await user.type(items[1]!, '{enter}')
     expect(onOpen).toHaveBeenCalled()
   })
 

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -68,7 +68,7 @@ describe('BookmarkList', () => {
     error: null,
     selectedId: null,
     onRowClick: vi.fn(),
-    onDoubleClick: vi.fn(),
+    onOpen: vi.fn(),
     onClose: vi.fn(),
     onReorder: vi.fn(),
   }
@@ -173,22 +173,10 @@ describe('BookmarkList', () => {
     )
   })
 
-  it('行をダブルクリックした際に onDoubleClick が呼び出されること', async () => {
+  it('行にフォーカスして Enter キーを押した際に onOpen が呼び出されること', async () => {
     const user = userEvent.setup()
-    const onDoubleClick = vi.fn()
-    render(<BookmarkList {...defaultProps} onDoubleClick={onDoubleClick} />)
-
-    await user.dblClick(screen.getByText(MOCK_BOOKMARK_1.title))
-    expect(onDoubleClick).toHaveBeenCalledWith(
-      MOCK_BOOKMARK_1.id,
-      MOCK_BOOKMARK_1.url,
-    )
-  })
-
-  it('行にフォーカスして Enter キーを押した際に onDoubleClick が呼び出されること', async () => {
-    const user = userEvent.setup()
-    const onDoubleClick = vi.fn()
-    render(<BookmarkList {...defaultProps} onDoubleClick={onDoubleClick} />)
+    const onOpen = vi.fn()
+    render(<BookmarkList {...defaultProps} onOpen={onOpen} />)
 
     const items = screen.getAllByRole(ARIA_ROLES.BUTTON, {
       name: new RegExp(MOCK_BOOKMARK_TITLE_PREFIX),
@@ -198,10 +186,7 @@ describe('BookmarkList', () => {
     expect(items[1]).toHaveAttribute(HTML_ATTRIBUTES.TAB_INDEX, '-1')
 
     await user.type(items[1]!, '{enter}')
-    expect(onDoubleClick).toHaveBeenCalledWith(
-      MOCK_BOOKMARK_2.id,
-      MOCK_BOOKMARK_2.url,
-    )
+    expect(onOpen).toHaveBeenCalled()
   })
 
   it('行にフォーカスして スペース キーを押した際に onRowClick が呼び出されること', async () => {

--- a/src/components/BookmarkList.tsx
+++ b/src/components/BookmarkList.tsx
@@ -29,7 +29,7 @@ export type BookmarkProps = {
   error: null | string | Error
   selectedId: BookmarkId | null
   onRowClick: (id: BookmarkId) => void
-  onDoubleClick: (id: BookmarkId, url: string) => void
+  onOpen: () => void
   onClose: () => void
   onReorder: (activeId: BookmarkId, overId: BookmarkId) => void
 }
@@ -40,7 +40,7 @@ export const BookmarkList = ({
   error,
   selectedId,
   onRowClick,
-  onDoubleClick,
+  onOpen,
   onClose,
   onReorder,
 }: BookmarkProps) => {
@@ -119,7 +119,7 @@ export const BookmarkList = ({
                   (selectedId === null && index === 0)
                 }
                 onRowClick={onRowClick}
-                onDoubleClick={onDoubleClick}
+                onOpen={onOpen}
                 onClose={onClose}
               />
             ))}

--- a/src/hooks/useApp.test.tsx
+++ b/src/hooks/useApp.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useApp } from './useApp'
-import { TEST_MESSAGES, HTML_ATTRIBUTES } from '@shared/constants'
+import { TEST_MESSAGES } from '@shared/constants'
 import { http, HttpResponse } from 'msw'
 import { server } from '../test/setup'
 import { renderHook, waitFor, act } from '../test/utils'
@@ -90,25 +90,6 @@ describe('useApp Hook (Integration)', () => {
 
       expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
       expect(result.current.selectedBookmark).toEqual(MOCK_BOOKMARK_1)
-    })
-
-    it('ダブルクリックで URL が開かれること (Commands との連動)', async () => {
-      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
-      const { result } = await renderAppHook()
-
-      act(() => {
-        result.current.handleDoubleClick(
-          MOCK_BOOKMARK_1.id,
-          MOCK_BOOKMARK_1.url,
-        )
-      })
-
-      expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
-      expect(openSpy).toHaveBeenCalledWith(
-        MOCK_BOOKMARK_1.url,
-        HTML_ATTRIBUTES.TARGET_BLANK,
-        HTML_ATTRIBUTES.REL_NOOPENER_NOREFERRER,
-      )
     })
 
     it('削除操作後に選択が解除されること (Commands と ListState の連動)', async () => {

--- a/src/hooks/useApp.ts
+++ b/src/hooks/useApp.ts
@@ -1,6 +1,4 @@
-import {
-  useBookmarks,
-} from './useBookmarks'
+import { useBookmarks } from './useBookmarks'
 import { useSettings } from './useSettings'
 import { useBookmarkListState } from './useBookmarkListState'
 import { useBookmarkCommands } from './useBookmarkCommands'
@@ -16,11 +14,7 @@ export const useApp = () => {
   } = useSettings()
 
   // 2. 一覧の状態管理
-  const {
-    selectedId,
-    setSelectedId,
-    handleRowClick,
-  } = useBookmarkListState()
+  const { selectedId, setSelectedId, handleRowClick } = useBookmarkListState()
 
   // 3. データの取得
   const { data, isLoading, error } = useBookmarks()
@@ -28,14 +22,8 @@ export const useApp = () => {
   const selectedBookmark = bookmarks.find((b) => b.id === selectedId)
 
   // 4. 操作（コマンド）ロジック
-  const {
-    handleUpdate,
-    handleDelete,
-    handleOpen,
-    handleClose,
-    handleDoubleClick,
-    handleReorder,
-  } = useBookmarkCommands(selectedBookmark, setSelectedId)
+  const { handleUpdate, handleDelete, handleOpen, handleClose, handleReorder } =
+    useBookmarkCommands(selectedBookmark, setSelectedId)
 
   return {
     bookmarks,
@@ -46,7 +34,6 @@ export const useApp = () => {
     showSettings,
     currentApiUrl,
     handleRowClick,
-    handleDoubleClick,
     handleUpdate,
     handleDelete,
     handleOpen,

--- a/src/hooks/useBookmarkCommands.test.ts
+++ b/src/hooks/useBookmarkCommands.test.ts
@@ -43,22 +43,6 @@ describe('useBookmarkCommands Hook', () => {
     })
   })
 
-  it('handleDoubleClick で ID が選択され、URL が開かれること', async () => {
-    const openUrlSpy = vi
-      .spyOn(urlUtils, 'openUrlInNewTab')
-      .mockImplementation(() => {})
-    const { result } = renderHook(() =>
-      useBookmarkCommands(undefined, mockSetSelectedId),
-    )
-
-    act(() => {
-      result.current.handleDoubleClick(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_1.url)
-    })
-
-    expect(mockSetSelectedId).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
-    expect(openUrlSpy).toHaveBeenCalledWith(MOCK_BOOKMARK_1.url)
-  })
-
   it('handleUpdate が正しくミューテーションを呼び出すこと', async () => {
     const { result } = renderHook(() =>
       useBookmarkCommands(MOCK_BOOKMARK_1, mockSetSelectedId),

--- a/src/hooks/useBookmarkCommands.ts
+++ b/src/hooks/useBookmarkCommands.ts
@@ -1,11 +1,6 @@
 import { useCallback } from 'react'
-import {
-  useUpdateBookmark,
-  useDeleteBookmark,
-} from './useBookmarks'
-import {
-  UI_MESSAGES,
-} from '@shared/constants'
+import { useUpdateBookmark, useDeleteBookmark } from './useBookmarks'
+import { UI_MESSAGES } from '@shared/constants'
 import { useBookmarkReorder } from './useBookmarkReorder'
 import { openUrlInNewTab } from '@shared/utils/url'
 import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
@@ -15,16 +10,11 @@ import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
  */
 export const useBookmarkCommands = (
   selectedBookmark: Bookmark | undefined,
-  setSelectedId: (id: BookmarkId | null) => void
+  setSelectedId: (id: BookmarkId | null) => void,
 ) => {
   const updateMutation = useUpdateBookmark()
   const deleteMutation = useDeleteBookmark()
   const { handleReorder } = useBookmarkReorder()
-
-  const handleDoubleClick = useCallback((id: BookmarkId, url: string) => {
-    setSelectedId(id)
-    openUrlInNewTab(url)
-  }, [setSelectedId])
 
   const handleUpdate = useCallback(
     async (title: string, url: string) => {
@@ -60,7 +50,6 @@ export const useBookmarkCommands = (
     handleDelete,
     handleOpen,
     handleClose,
-    handleDoubleClick,
     handleReorder,
   }
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -14,7 +14,6 @@ export function HomePage({ appState }: HomePageProps) {
     isLoading,
     error,
     handleRowClick,
-    handleDoubleClick,
     handleUpdate,
     handleDelete,
     handleOpen,
@@ -33,7 +32,7 @@ export function HomePage({ appState }: HomePageProps) {
               error={error}
               selectedId={selectedId}
               onRowClick={handleRowClick}
-              onDoubleClick={handleDoubleClick}
+              onOpen={handleOpen}
               onClose={handleClose}
               onReorder={handleReorder}
             />


### PR DESCRIPTION
### 概要
将来的なページ遷移（`/bookmark/:id`）の導入に向けた準備として、操作体系を整理し、ダブルクリックによるブックマーク起動機能を廃止しました。

### 変更内容
- **ロジック変更**: `handleDoubleClick` を削除し、ダブルクリックイベントへの反応を廃止。
- **インターフェース整理**:
  - `BookmarkList` および `BookmarkItem` の `onDoubleClick` prop を `onOpen` へリネーム。
  - JSX 内の `onDoubleClick` ハンドラを削除。
- **キーボード操作**: 選択状態での `Enter` キー押下による起動機能は `onOpen` として維持。
- **テストの適正化**:
  - 廃止されたダブルクリックのテストケースを削除。
  - `Enter` キーによる起動（`onOpen`）の検証を継続・強化。
  - 既存のドラッグ＆ドロップやその他の統合テストが完全に維持されていることを確認（全278件パス）。

### 背景・目的
ブラウザの仕様上、ダブルクリック時には必ずシングルクリックが先行して発生します。今後シングルクリックに詳細画面への遷移を割り当てる際、意図しない「遷移と起動の同時発生」を防ぎ、シンプルで予測可能な UI を提供するためです。

Closes #227