### PR TITLE
refactor(test): テストユーティリティにおけるパス抽出の堅牢化

### DIFF
--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -34,8 +34,20 @@ export const AllTheProviders = ({
   // QueryClient をメモ化して再生成を防ぐ
   const queryClient = useMemo(() => createTestQueryClient(), [])
 
+  // MemoryRouter 用にパス部分のみを抽出 (フルURLが渡された場合への対策)
+  const initialPath = useMemo(() => {
+    if (!initialUrl) return '/'
+    try {
+      const url = new URL(initialUrl)
+      return `${url.pathname}${url.search}${url.hash}`
+    } catch {
+      // フルURLでない場合は、'/foo/bar' のようなパスと見なしてそのまま返す
+      return initialUrl
+    }
+  }, [initialUrl])
+
   return (
-    <MemoryRouter initialEntries={['/']}>
+    <MemoryRouter initialEntries={[initialPath]}>
       <ApiProvider initialUrl={initialUrl}>
         <QueryClientProvider client={queryClient}>
           {children}


### PR DESCRIPTION
### 概要
`src/test/utils.tsx` 内の `MemoryRouter` 設定を修正し、`initialUrl` としてフル URL（http://...）が渡された場合でも適切にパス名部分を抽出して処理できるようにしました。

### 変更内容
- **パス抽出ロジックの追加**: `new URL()` を活用し、`initialUrl` から `pathname` を抽出する処理を実装。
- **MemoryRouter 設定の更新**: 抽出したパス名を `initialEntries` に設定するように修正。
- **ApiProvider との共存**: `ApiProvider` には引き続きフル URL を渡し、`MemoryRouter` にはパス名のみを渡すことで、両者の要求を満たす構造に変更。

### 背景・目的
PR #219 でルーティングを導入したことにより、`MemoryRouter` が相対パスのみを期待するようになりました。既存の統合テストがフル URL を `initialUrl` に渡していたため、エラーが発生していましたが、本修正により既存テストの互換性を維持しつつ、将来のルーティングテストにも対応可能になりました。

### 検証結果
- `npm run test`: `src/App.test.tsx` を含む既存テストが全てパス。

Closes #230