### PR TITLE
feat(frontend): ブックマーク編集画面 (/bookmark/:id) のルート定義

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { SettingsPanel } from './components/SettingsPanel'
 import { useApp } from './hooks/useApp'
 import { FIELD_LABELS } from '@shared/constants'
 import { HomePage } from './pages/HomePage'
+import { BookmarkPage } from './pages/BookmarkPage'
 
 function App() {
   const appState = useApp()
@@ -58,6 +59,7 @@ function App() {
 
       <Routes>
         <Route path="/" element={<HomePage appState={appState} />} />
+        <Route path="/bookmark/:id" element={<BookmarkPage />} />
       </Routes>
     </div>
   )

--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { Routes, Route } from 'react-router-dom'
+import { render, screen } from '../test/utils'
+import { BookmarkPage } from './BookmarkPage'
+
+describe('BookmarkPage', () => {
+  it('URL パラメータから取得した ID が表示されること', () => {
+    const testId = '123'
+    render(
+      <Routes>
+        <Route path="/bookmark/:id" element={<BookmarkPage />} />
+      </Routes>,
+      { initialUrl: `/bookmark/${testId}` },
+    )
+
+    expect(screen.getByText(`Bookmark ID: ${testId}`)).toBeInTheDocument()
+    expect(screen.getByText('Bookmark Detail')).toBeInTheDocument()
+  })
+
+  it('戻るリンクが表示されていること', () => {
+    render(<BookmarkPage />)
+    const link = screen.getByRole('link', { name: /Back to List/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/')
+  })
+})

--- a/src/pages/BookmarkPage.tsx
+++ b/src/pages/BookmarkPage.tsx
@@ -1,0 +1,22 @@
+import { useParams, Link } from 'react-router-dom'
+
+export function BookmarkPage() {
+  const { id } = useParams<{ id: string }>()
+
+  return (
+    <div className="p-4">
+      <div className="mb-4">
+        <Link to="/" className="text-blue-600 hover:underline">
+          &larr; Back to List
+        </Link>
+      </div>
+      <h1 className="text-xl font-bold mb-2">Bookmark Detail</h1>
+      <p className="text-gray-600">Bookmark ID: {id}</p>
+      <div className="mt-8 p-4 bg-yellow-50 border border-yellow-200 rounded-md">
+        <p className="text-sm text-yellow-700">
+          Note: This is a placeholder for the bookmark editing screen.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
### 概要
特定のブックマークを表示・編集するためのルーティング定義を追加し、その器となるプレースホルダページを実装しました。

### 変更内容
- **新ページの作成**: `src/pages/BookmarkPage.tsx`
  - `useParams` を使用して URL から `id` を取得し表示。
- **ルート定義の追加**: `src/App.tsx`
  - `/bookmark/:id` パスに `BookmarkPage` を割り当て。
- **テストの追加**: `src/pages/BookmarkPage.test.tsx`
  - URL パラメータが正しくコンポーネントに伝わることを検証。

### 背景・目的
キーワード管理機能（設計書 Step 2-2）に基づき、各ブックマークに対して固有の URL を割り当てることで、詳細表示の永続化と共有を可能にします。

### 備考
Issue #230 で強化されたテスト基盤（MemoryRouter の initialUrl 対応）により、URL パラメータを伴うコンポーネントのテストが正常に動作することを確認済みです。

Closes #220