### PR TITLE
feat(frontend): キーワード詳細画面 (/keyword/:id) のルート定義

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { useApp } from './hooks/useApp'
 import { FIELD_LABELS } from '@shared/constants'
 import { HomePage } from './pages/HomePage'
 import { BookmarkPage } from './pages/BookmarkPage'
+import { KeywordPage } from './pages/KeywordPage'
 
 function App() {
   const appState = useApp()
@@ -60,6 +61,7 @@ function App() {
       <Routes>
         <Route path="/" element={<HomePage appState={appState} />} />
         <Route path="/bookmark/:id" element={<BookmarkPage />} />
+        <Route path="/keyword/:id" element={<KeywordPage />} />
       </Routes>
     </div>
   )

--- a/src/pages/KeywordPage.test.tsx
+++ b/src/pages/KeywordPage.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { Routes, Route } from 'react-router-dom'
+import { render, screen } from '../test/utils'
+import { KeywordPage } from './KeywordPage'
+
+describe('KeywordPage', () => {
+  it('URL パラメータから取得したキーワード ID が表示されること', () => {
+    const testId = 'abc'
+    render(
+      <Routes>
+        <Route path="/keyword/:id" element={<KeywordPage />} />
+      </Routes>,
+      { initialUrl: `/keyword/${testId}` },
+    )
+
+    expect(screen.getByText(`Keyword ID: ${testId}`)).toBeInTheDocument()
+    expect(screen.getByText('Keyword Detail')).toBeInTheDocument()
+  })
+
+  it('戻るリンクが表示されていること', () => {
+    render(<KeywordPage />)
+    const link = screen.getByRole('link', { name: /Back to List/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/')
+  })
+})

--- a/src/pages/KeywordPage.tsx
+++ b/src/pages/KeywordPage.tsx
@@ -1,0 +1,22 @@
+import { useParams, Link } from 'react-router-dom'
+
+export function KeywordPage() {
+  const { id } = useParams<{ id: string }>()
+
+  return (
+    <div className="p-4">
+      <div className="mb-4">
+        <Link to="/" className="text-blue-600 hover:underline">
+          &larr; Back to List
+        </Link>
+      </div>
+      <h1 className="text-xl font-bold mb-2">Keyword Detail</h1>
+      <p className="text-gray-600">Keyword ID: {id}</p>
+      <div className="mt-8 p-4 bg-blue-50 border border-blue-200 rounded-md">
+        <p className="text-sm text-blue-700">
+          Note: This is a placeholder for the keyword filtered list screen.
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
### 概要
キーワードごとの一覧を表示するためのルーティング定義を追加し、その器となるプレースホルダページを実装しました。

### 変更内容
- **新ページの作成**: `src/pages/KeywordPage.tsx`
  - `useParams` を使用して URL から `id` を取得し表示。
- **ルート定義の追加**: `src/App.tsx`
  - `/keyword/:id` パスに `KeywordPage` を割り当て。
- **テストの追加**: `src/pages/KeywordPage.test.tsx`
  - URL パラメータが正しくコンポーネントに伝わることを検証。

### 背景・目的
キーワード管理機能（設計書 Step 2-3）に基づき、キーワードを起点としたブックマークの絞り込み表示を URL で管理可能にします。

### 備考
これで Step 2（ルーティング基盤の作成）の全 3 ルート（ `/`, `/bookmark/:id`, `/keyword/:id` ）の定義が完了しました。

Closes #221