### PR TITLE
feat(frontend): ブックマーク一覧のクリックイベントと URL 遷移の統合

### DIFF
--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -17,6 +17,11 @@ export const FIELD_LABELS = {
   OPTIONS_TITLE: '拡張機能の設定',
   POPUP_TITLE: 'ページをブックマーク',
   SETTING_TITLE: '設定',
+  BOOKMARK_DETAIL_TITLE: 'Bookmark Detail',
+  KEYWORD_DETAIL_TITLE: 'Keyword Detail',
+  BOOKMARK_ID_PREFIX: 'Bookmark ID:',
+  KEYWORD_ID_PREFIX: 'Keyword ID:',
+  BACK_TO_LIST: 'Back to List',
 } as const
 
 export const PLACEHOLDERS = {
@@ -226,6 +231,17 @@ export const HTML_ATTRIBUTES = {
 export const API_PATHS = {
   BOOKMARKS: '/api/bookmarks',
   KEYWORDS: '/api/keywords',
+} as const
+
+/**
+ * フロントエンドのパス関連の定数
+ */
+export const APP_PATHS = {
+  HOME: '/',
+  BOOKMARK_DETAIL: (id: string | number) => `/bookmark/${id}`,
+  BOOKMARK_DETAIL_PATTERN: '/bookmark/:id',
+  KEYWORD_DETAIL: (id: string | number) => `/keyword/${id}`,
+  KEYWORD_DETAIL_PATTERN: '/keyword/:id',
 } as const
 
 export const HTTP_STATUS = {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -16,7 +16,6 @@ import userEvent from '@testing-library/user-event'
 import App from './App'
 import { server } from './test/setup'
 
-import type { UpdateBookmarkRequest } from '@shared/schemas/bookmark'
 import type { DragEndEvent } from '@dnd-kit/core'
 
 // DndContext をモック化
@@ -62,15 +61,18 @@ describe('App Integration', () => {
   beforeEach(() => {
     vi.stubGlobal('open', vi.fn())
     localStorage.clear()
-    
+
     // 基本的なハンドラをあらかじめ登録しておく (未ハンドルのリクエスト警告を防止)
     server.use(
       http.get(`${DEFAULT_API_URL}${API_PATHS.BOOKMARKS}`, () => {
-        return HttpResponse.json({ success: true, data: { bookmarks: [MOCK_BOOKMARK_1, MOCK_BOOKMARK_2] } })
+        return HttpResponse.json({
+          success: true,
+          data: { bookmarks: [MOCK_BOOKMARK_1, MOCK_BOOKMARK_2] },
+        })
       }),
       http.put(`${DEFAULT_API_URL}${API_PATHS.BOOKMARKS}/reorder`, () => {
         return HttpResponse.json({ success: true, data: null })
-      })
+      }),
     )
   })
 
@@ -120,18 +122,7 @@ describe('App Integration', () => {
     expect(await screen.findByRole(ARIA_ROLES.ALERT)).toBeInTheDocument()
   })
 
-  it('詳細パネルからブックマークを更新できること', async () => {
-    let patchCalled = false
-    server.use(
-      http.patch(`${DEFAULT_API_URL}${API_PATHS.BOOKMARKS}/:id`, async ({ request }) => {
-        patchCalled = true
-        const body = (await request.json()) as UpdateBookmarkRequest
-        return HttpResponse.json({
-          success: true,
-          data: { ...MOCK_BOOKMARK_1, ...body },
-        })
-      }),
-    )
+  it('行をクリックすると詳細ページへ遷移し、正しい ID が表示されること', async () => {
     const { user } = setup()
 
     const item = await screen.findByRole(ARIA_ROLES.BUTTON, {
@@ -139,61 +130,67 @@ describe('App Integration', () => {
     })
     await user.click(item)
 
-    const titleInput = await screen.findByDisplayValue(MOCK_BOOKMARK_1.title)
-    await user.clear(titleInput)
-    await user.type(titleInput, 'Updated by Panel')
+    // 遷移後のプレースホルダ画面の内容を検証
+    expect(
+      await screen.findByText(FIELD_LABELS.BOOKMARK_DETAIL_TITLE),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        new RegExp(`${FIELD_LABELS.BOOKMARK_ID_PREFIX} ${MOCK_BOOKMARK_1.id}`),
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i')),
+    ).toBeInTheDocument()
+  })
 
-    await user.click(screen.getByText(FIELD_LABELS.BUTTON_UPDATE))
-    expect(patchCalled).toBe(true)
+  it('詳細ページから一覧ページへ戻れること', async () => {
+    const { user } = setup()
+
+    const item = await screen.findByRole(ARIA_ROLES.BUTTON, {
+      name: new RegExp(MOCK_BOOKMARK_1.title),
+    })
+    await user.click(item)
+
+    const backLink = await screen.findByText(
+      new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i'),
+    )
+    await user.click(backLink)
+
+    // 一覧画面に戻ったことを検証
+    expect(await screen.findByText(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
   })
 
   it('ドラッグ＆ドロップ操作によって並び替え API が呼ばれること', async () => {
     let putCalled = false
     server.use(
-      http.put(`${DEFAULT_API_URL}${API_PATHS.BOOKMARKS}/reorder`, async ({ request }) => {
-        putCalled = true
-        const body = await request.json()
-        expect(body).toEqual({ ids: [MOCK_BOOKMARK_2.id, MOCK_BOOKMARK_1.id] })
-        return HttpResponse.json({ success: true, data: null })
-      }),
+      http.put(
+        `${DEFAULT_API_URL}${API_PATHS.BOOKMARKS}/reorder`,
+        async ({ request }) => {
+          putCalled = true
+          const body = await request.json()
+          expect(body).toEqual({
+            ids: [MOCK_BOOKMARK_2.id, MOCK_BOOKMARK_1.id],
+          })
+          return HttpResponse.json({ success: true, data: null })
+        },
+      ),
     )
-    
+
     setup()
 
     await screen.findByRole(ARIA_ROLES.LIST)
-    
+
     const dndContext = screen.getByTestId('mock-dnd-context')
     await userEvent.click(dndContext)
 
     expect(putCalled).toBe(true)
   })
 
-  it('詳細パネルからブックマークを削除できること', async () => {
-    let deleteCalled = false
-    vi.spyOn(window, 'confirm').mockReturnValue(true)
-    server.use(
-      http.delete(`${DEFAULT_API_URL}${API_PATHS.BOOKMARKS}/:id`, () => {
-        deleteCalled = true
-        return new HttpResponse(null, { status: HTTP_STATUS.NO_CONTENT })
-      }),
-    )
-    const { user } = setup()
-
-    const item = await screen.findByRole(ARIA_ROLES.BUTTON, {
-      name: new RegExp(MOCK_BOOKMARK_1.title),
-    })
-    await user.click(item)
-
-    await user.click(screen.getByText(FIELD_LABELS.BUTTON_DELETE))
-
-    expect(deleteCalled).toBe(true)
-    expect(screen.queryByDisplayValue(MOCK_BOOKMARK_1.title)).not.toBeInTheDocument()
-  })
-
   it('API URL 設定を変更すると、新しい URL に対してリクエストが行われること', async () => {
     let newUrlRequested = false
     const NEW_BASE_URL = 'http://localhost:4000'
-    
+
     // 新しい URL へのリクエストを監視
     server.use(
       http.get(`${NEW_BASE_URL}${API_PATHS.BOOKMARKS}`, () => {
@@ -206,7 +203,7 @@ describe('App Integration', () => {
     )
 
     const { user } = setup()
-    
+
     // 設定パネルを開く
     const settingsButton = await screen.findByTitle(FIELD_LABELS.SETTING_TITLE)
     await user.click(settingsButton)
@@ -215,14 +212,17 @@ describe('App Integration', () => {
     const urlInput = await screen.findByLabelText(FIELD_LABELS.URL)
     await user.clear(urlInput)
     await user.type(urlInput, NEW_BASE_URL)
-    
+
     // 保存ボタンをクリック
     await user.click(screen.getByText(FIELD_LABELS.BUTTON_SAVE_AND_APPLY))
 
     // 新しい URL に対してリクエストが行われ、データが更新されることを確認
-    await waitFor(() => {
-      expect(newUrlRequested).toBe(true)
-    }, { timeout: 2000 })
+    await waitFor(
+      () => {
+        expect(newUrlRequested).toBe(true)
+      },
+      { timeout: 2000 },
+    )
     expect(await screen.findByText(MOCK_BOOKMARK_2.title)).toBeInTheDocument()
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { Routes, Route } from 'react-router-dom'
 import './App.css'
 import { SettingsPanel } from './components/SettingsPanel'
 import { useApp } from './hooks/useApp'
-import { FIELD_LABELS } from '@shared/constants'
+import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
 import { HomePage } from './pages/HomePage'
 import { BookmarkPage } from './pages/BookmarkPage'
 import { KeywordPage } from './pages/KeywordPage'
@@ -59,9 +59,18 @@ function App() {
       )}
 
       <Routes>
-        <Route path="/" element={<HomePage appState={appState} />} />
-        <Route path="/bookmark/:id" element={<BookmarkPage />} />
-        <Route path="/keyword/:id" element={<KeywordPage />} />
+        <Route
+          path={APP_PATHS.HOME}
+          element={<HomePage appState={appState} />}
+        />
+        <Route
+          path={APP_PATHS.BOOKMARK_DETAIL_PATTERN}
+          element={<BookmarkPage />}
+        />
+        <Route
+          path={APP_PATHS.KEYWORD_DETAIL_PATTERN}
+          element={<KeywordPage />}
+        />
       </Routes>
     </div>
   )

--- a/src/hooks/useBookmarkListState.test.ts
+++ b/src/hooks/useBookmarkListState.test.ts
@@ -2,7 +2,18 @@ import { act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useBookmarkListState } from './useBookmarkListState'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
+import { APP_PATHS } from '@shared/constants'
 import { renderHook } from '../test/utils'
+
+// useNavigate のモック
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
 
 describe('useBookmarkListState Hook', () => {
   beforeEach(() => {
@@ -14,7 +25,7 @@ describe('useBookmarkListState Hook', () => {
     expect(result.current.selectedId).toBeNull()
   })
 
-  it('handleRowClick で selectedId が更新されること', () => {
+  it('handleRowClick で selectedId が更新され、navigate が呼ばれること', () => {
     const { result } = renderHook(() => useBookmarkListState())
 
     act(() => {
@@ -22,6 +33,9 @@ describe('useBookmarkListState Hook', () => {
     })
 
     expect(result.current.selectedId).toBe(MOCK_BOOKMARK_1.id)
+    expect(mockNavigate).toHaveBeenCalledWith(
+      APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
+    )
   })
 
   it('setSelectedId を直接呼んで更新できること', () => {

--- a/src/hooks/useBookmarkListState.ts
+++ b/src/hooks/useBookmarkListState.ts
@@ -1,4 +1,6 @@
 import { useState, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { APP_PATHS } from '@shared/constants'
 import type { BookmarkId } from '@shared/schemas/bookmark'
 
 /**
@@ -7,10 +9,15 @@ import type { BookmarkId } from '@shared/schemas/bookmark'
  */
 export const useBookmarkListState = () => {
   const [selectedId, setSelectedId] = useState<BookmarkId | null>(null)
+  const navigate = useNavigate()
 
-  const handleRowClick = useCallback((id: BookmarkId) => {
-    setSelectedId(id)
-  }, [])
+  const handleRowClick = useCallback(
+    (id: BookmarkId) => {
+      setSelectedId(id)
+      navigate(APP_PATHS.BOOKMARK_DETAIL(id))
+    },
+    [navigate],
+  )
 
   return {
     selectedId,

--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -2,25 +2,37 @@ import { describe, it, expect } from 'vitest'
 import { Routes, Route } from 'react-router-dom'
 import { render, screen } from '../test/utils'
 import { BookmarkPage } from './BookmarkPage'
+import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
 
 describe('BookmarkPage', () => {
   it('URL パラメータから取得した ID が表示されること', () => {
     const testId = '123'
     render(
       <Routes>
-        <Route path="/bookmark/:id" element={<BookmarkPage />} />
+        <Route
+          path={APP_PATHS.BOOKMARK_DETAIL_PATTERN}
+          element={<BookmarkPage />}
+        />
       </Routes>,
-      { initialUrl: `/bookmark/${testId}` },
+      { initialUrl: APP_PATHS.BOOKMARK_DETAIL(testId) },
     )
 
-    expect(screen.getByText(`Bookmark ID: ${testId}`)).toBeInTheDocument()
-    expect(screen.getByText('Bookmark Detail')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        new RegExp(`${FIELD_LABELS.BOOKMARK_ID_PREFIX} ${testId}`),
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(FIELD_LABELS.BOOKMARK_DETAIL_TITLE),
+    ).toBeInTheDocument()
   })
 
   it('戻るリンクが表示されていること', () => {
     render(<BookmarkPage />)
-    const link = screen.getByRole('link', { name: /Back to List/i })
+    const link = screen.getByRole('link', {
+      name: new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i'),
+    })
     expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', '/')
+    expect(link).toHaveAttribute('href', APP_PATHS.HOME)
   })
 })

--- a/src/pages/BookmarkPage.tsx
+++ b/src/pages/BookmarkPage.tsx
@@ -1,4 +1,5 @@
 import { useParams, Link } from 'react-router-dom'
+import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
 
 export function BookmarkPage() {
   const { id } = useParams<{ id: string }>()
@@ -6,12 +7,16 @@ export function BookmarkPage() {
   return (
     <div className="p-4">
       <div className="mb-4">
-        <Link to="/" className="text-blue-600 hover:underline">
-          &larr; Back to List
+        <Link to={APP_PATHS.HOME} className="text-blue-600 hover:underline">
+          &larr; {FIELD_LABELS.BACK_TO_LIST}
         </Link>
       </div>
-      <h1 className="text-xl font-bold mb-2">Bookmark Detail</h1>
-      <p className="text-gray-600">Bookmark ID: {id}</p>
+      <h1 className="text-xl font-bold mb-2">
+        {FIELD_LABELS.BOOKMARK_DETAIL_TITLE}
+      </h1>
+      <p className="text-gray-600">
+        {FIELD_LABELS.BOOKMARK_ID_PREFIX} {id}
+      </p>
       <div className="mt-8 p-4 bg-yellow-50 border border-yellow-200 rounded-md">
         <p className="text-sm text-yellow-700">
           Note: This is a placeholder for the bookmark editing screen.

--- a/src/pages/KeywordPage.test.tsx
+++ b/src/pages/KeywordPage.test.tsx
@@ -2,25 +2,37 @@ import { describe, it, expect } from 'vitest'
 import { Routes, Route } from 'react-router-dom'
 import { render, screen } from '../test/utils'
 import { KeywordPage } from './KeywordPage'
+import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
 
 describe('KeywordPage', () => {
   it('URL パラメータから取得したキーワード ID が表示されること', () => {
     const testId = 'abc'
     render(
       <Routes>
-        <Route path="/keyword/:id" element={<KeywordPage />} />
+        <Route
+          path={APP_PATHS.KEYWORD_DETAIL_PATTERN}
+          element={<KeywordPage />}
+        />
       </Routes>,
-      { initialUrl: `/keyword/${testId}` },
+      { initialUrl: APP_PATHS.KEYWORD_DETAIL(testId) },
     )
 
-    expect(screen.getByText(`Keyword ID: ${testId}`)).toBeInTheDocument()
-    expect(screen.getByText('Keyword Detail')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        new RegExp(`${FIELD_LABELS.KEYWORD_ID_PREFIX} ${testId}`),
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(FIELD_LABELS.KEYWORD_DETAIL_TITLE),
+    ).toBeInTheDocument()
   })
 
   it('戻るリンクが表示されていること', () => {
     render(<KeywordPage />)
-    const link = screen.getByRole('link', { name: /Back to List/i })
+    const link = screen.getByRole('link', {
+      name: new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i'),
+    })
     expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', '/')
+    expect(link).toHaveAttribute('href', APP_PATHS.HOME)
   })
 })

--- a/src/pages/KeywordPage.tsx
+++ b/src/pages/KeywordPage.tsx
@@ -1,4 +1,5 @@
 import { useParams, Link } from 'react-router-dom'
+import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
 
 export function KeywordPage() {
   const { id } = useParams<{ id: string }>()
@@ -6,12 +7,16 @@ export function KeywordPage() {
   return (
     <div className="p-4">
       <div className="mb-4">
-        <Link to="/" className="text-blue-600 hover:underline">
-          &larr; Back to List
+        <Link to={APP_PATHS.HOME} className="text-blue-600 hover:underline">
+          &larr; {FIELD_LABELS.BACK_TO_LIST}
         </Link>
       </div>
-      <h1 className="text-xl font-bold mb-2">Keyword Detail</h1>
-      <p className="text-gray-600">Keyword ID: {id}</p>
+      <h1 className="text-xl font-bold mb-2">
+        {FIELD_LABELS.KEYWORD_DETAIL_TITLE}
+      </h1>
+      <p className="text-gray-600">
+        {FIELD_LABELS.KEYWORD_ID_PREFIX} {id}
+      </p>
       <div className="mt-8 p-4 bg-blue-50 border border-blue-200 rounded-md">
         <p className="text-sm text-blue-700">
           Note: This is a placeholder for the keyword filtered list screen.


### PR DESCRIPTION
### 概要
ブックマーク一覧画面でアイテムをクリックした際、URL を `/bookmark/:id` へ遷移させることで、現在の選択状態を URL と同期させました。

### 変更内容
- **ロジック修正**: `src/hooks/useBookmarkListState.ts`
  - `useNavigate` を導入。
  - `handleRowClick` 内で `navigate` を実行。
- **テスト修正**:
  - `src/hooks/useBookmarkListState.test.ts`: `navigate` の呼び出しを検証するテストを追加。
  - `src/App.test.tsx`: クリック後の検証対象を、詳細パネルから詳細ページ（プレースホルダ）の表示内容へ更新。既存の DND テスト等を維持。

### 背景・目的
設計書 Step 2 に基づき、URL による状態管理を導入します。これにより、特定のブックマークを表示した状態の URL 共有や、ブラウザの戻る/進むボタンでの操作が可能になります。

### 次のステップ
Step 4 (#223) にて、現在プレースホルダとなっている詳細ページの実装（編集・削除機能の統合）を行います。

Closes #229