### PR TITLE
feat(frontend): ブックマーク詳細プレースホルダでの Enter キー起動の実装

### DIFF
--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -1,12 +1,34 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Routes, Route } from 'react-router-dom'
-import { render, screen } from '../test/utils'
+import { render, screen, fireEvent } from '../test/utils'
 import { BookmarkPage } from './BookmarkPage'
 import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
+import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
+import { http, HttpResponse } from 'msw'
+import { server } from '../test/setup'
+import * as urlUtils from '@shared/utils/url'
+
+// openUrlInNewTab をモック
+vi.mock('@shared/utils/url', () => ({
+  openUrlInNewTab: vi.fn(),
+}))
 
 describe('BookmarkPage', () => {
-  it('URL パラメータから取得した ID が表示されること', () => {
-    const testId = '123'
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // MSW のデフォルト動作: ブックマークデータを返す
+    server.use(
+      http.get('*/api/bookmarks', () => {
+        return HttpResponse.json({
+          success: true,
+          data: { bookmarks: [MOCK_BOOKMARK_1] },
+        })
+      }),
+    )
+  })
+
+  it('URL パラメータから取得した ID が表示されること', async () => {
+    const testId = MOCK_BOOKMARK_1.id
     render(
       <Routes>
         <Route
@@ -18,13 +40,88 @@ describe('BookmarkPage', () => {
     )
 
     expect(
-      screen.getByText(
+      await screen.findByText(
         new RegExp(`${FIELD_LABELS.BOOKMARK_ID_PREFIX} ${testId}`),
       ),
     ).toBeInTheDocument()
     expect(
       screen.getByText(FIELD_LABELS.BOOKMARK_DETAIL_TITLE),
     ).toBeInTheDocument()
+  })
+
+  it('データが取得できればブックマーク情報が表示されること', async () => {
+    render(
+      <Routes>
+        <Route
+          path={APP_PATHS.BOOKMARK_DETAIL_PATTERN}
+          element={<BookmarkPage />}
+        />
+      </Routes>,
+      { initialUrl: APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id) },
+    )
+
+    expect(await screen.findByText(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
+    expect(screen.getByText(MOCK_BOOKMARK_1.url)).toBeInTheDocument()
+  })
+
+  describe('Keyboard interaction (Enter key shortcut)', () => {
+    it('Enter キーを押した際に openUrlInNewTab が呼ばれること', async () => {
+      render(
+        <Routes>
+          <Route
+            path={APP_PATHS.BOOKMARK_DETAIL_PATTERN}
+            element={<BookmarkPage />}
+          />
+        </Routes>,
+        { initialUrl: APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id) },
+      )
+
+      await screen.findByText(MOCK_BOOKMARK_1.title)
+      fireEvent.keyDown(window, { key: 'Enter' })
+
+      expect(urlUtils.openUrlInNewTab).toHaveBeenCalledWith(MOCK_BOOKMARK_1.url)
+    })
+
+    it('データがロードされていない状態で Enter キーを押しても何も起きないこと', async () => {
+      // データのロードをわざと遅延させる、または空にする設定
+      server.use(
+        http.get('*/api/bookmarks', () => {
+          return HttpResponse.json({ success: true, data: { bookmarks: [] } })
+        }),
+      )
+
+      render(
+        <Routes>
+          <Route
+            path={APP_PATHS.BOOKMARK_DETAIL_PATTERN}
+            element={<BookmarkPage />}
+          />
+        </Routes>,
+        { initialUrl: APP_PATHS.BOOKMARK_DETAIL('non-existent-id') },
+      )
+
+      // 少し待つがブックマークは表示されない
+      fireEvent.keyDown(window, { key: 'Enter' })
+
+      expect(urlUtils.openUrlInNewTab).not.toHaveBeenCalled()
+    })
+
+    it('Enter 以外のキーを押しても何も起きないこと', async () => {
+      render(
+        <Routes>
+          <Route
+            path={APP_PATHS.BOOKMARK_DETAIL_PATTERN}
+            element={<BookmarkPage />}
+          />
+        </Routes>,
+        { initialUrl: APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id) },
+      )
+
+      await screen.findByText(MOCK_BOOKMARK_1.title)
+      fireEvent.keyDown(window, { key: 'a' })
+
+      expect(urlUtils.openUrlInNewTab).not.toHaveBeenCalled()
+    })
   })
 
   it('戻るリンクが表示されていること', () => {

--- a/src/pages/BookmarkPage.tsx
+++ b/src/pages/BookmarkPage.tsx
@@ -1,8 +1,25 @@
+import { useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
+import { useBookmarks } from '../hooks/useBookmarks'
+import { openUrlInNewTab } from '@shared/utils/url'
 
 export function BookmarkPage() {
   const { id } = useParams<{ id: string }>()
+  const { data } = useBookmarks()
+
+  const bookmark = data?.bookmarks.find((b) => b.id === id)
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Enter' && bookmark) {
+        openUrlInNewTab(bookmark.url)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [bookmark])
 
   return (
     <div className="p-4">
@@ -17,6 +34,15 @@ export function BookmarkPage() {
       <p className="text-gray-600">
         {FIELD_LABELS.BOOKMARK_ID_PREFIX} {id}
       </p>
+      {bookmark && (
+        <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-md">
+          <p className="font-semibold">{bookmark.title}</p>
+          <p className="text-sm text-gray-500 truncate">{bookmark.url}</p>
+          <p className="mt-2 text-xs text-blue-600 font-medium animate-pulse">
+            Press Enter to open this link
+          </p>
+        </div>
+      )}
       <div className="mt-8 p-4 bg-yellow-50 border border-yellow-200 rounded-md">
         <p className="text-sm text-yellow-700">
           Note: This is a placeholder for the bookmark editing screen.


### PR DESCRIPTION
### 概要
現在プレースホルダとなっている `/bookmark/:id` の画面において、Enter キーを押すことで該当するブックマークを即座に開けるショートカット機能を実装しました。

### 変更内容
- **データ取得の統合**: `useBookmarks` フックを使用し、URL の `id` パラメータに対応するタイトルと URL を表示。
- **ショートカット機能**: 画面表示中に `Enter` キーを押すと、そのブックマークを別タブで開く（`openUrlInNewTab`）ロジックを追加。
- **テストの拡充**: データの表示確認に加え、正常系の `Enter` キー起動、および「データ未ロード時」や「Enter 以外のキー」に対するネガティブテストを追加。

### 背景・目的
一覧から詳細ページへの遷移導線を導入したことにより、ブックマークを開くアクションが 1 ステップ増えていました。詳細画面の正式な実装（Step 4）を待たずに利便性を確保し、開発中の確認作業を効率化することを目的としています。

Closes #235