### PR TITLE
feat(frontend): ブックマーク詳細・編集画面（基本機能）の実装 (Step 4-1)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -135,9 +135,7 @@ describe('App Integration', () => {
       await screen.findByText(FIELD_LABELS.BOOKMARK_DETAIL_TITLE),
     ).toBeInTheDocument()
     expect(
-      screen.getByText(
-        new RegExp(`${FIELD_LABELS.BOOKMARK_ID_PREFIX} ${MOCK_BOOKMARK_1.id}`),
-      ),
+      screen.getByText(new RegExp(`${MOCK_BOOKMARK_1.id}`)),
     ).toBeInTheDocument()
     expect(
       screen.getByText(new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i')),

--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -1,22 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { Routes, Route } from 'react-router-dom'
-import { render, screen, fireEvent } from '../test/utils'
+import { render, screen, fireEvent, waitFor } from '../test/utils'
 import { BookmarkPage } from './BookmarkPage'
-import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
+import { FIELD_LABELS, APP_PATHS, HTTP_STATUS } from '@shared/constants'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 import { http, HttpResponse } from 'msw'
 import { server } from '../test/setup'
 import * as urlUtils from '@shared/utils/url'
 
-// openUrlInNewTab をモック
-vi.mock('@shared/utils/url', () => ({
-  openUrlInNewTab: vi.fn(),
-}))
+// openUrlInNewTab をモック (他の関数は実体を使用)
+vi.mock('@shared/utils/url', async () => {
+  const actual = await vi.importActual<typeof urlUtils>('@shared/utils/url')
+  return {
+    ...actual,
+    openUrlInNewTab: vi.fn(),
+  }
+})
 
 describe('BookmarkPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // MSW のデフォルト動作: ブックマークデータを返す
+    // デフォルトのモック設定
     server.use(
       http.get('*/api/bookmarks', () => {
         return HttpResponse.json({
@@ -27,92 +31,116 @@ describe('BookmarkPage', () => {
     )
   })
 
-  // 共通のレンダリングヘルパー（警告防止用のダミールートを含む）
   const renderWithRoutes = (ui: React.ReactElement, initialUrl: string) => {
     return render(
       <Routes>
         <Route path={APP_PATHS.HOME} element={<div>Home</div>} />
         <Route path={APP_PATHS.BOOKMARK_DETAIL_PATTERN} element={ui} />
       </Routes>,
-      { initialUrl }
+      { initialUrl },
     )
   }
 
-  it('URL パラメータから取得した ID が表示されること', async () => {
-    const testId = MOCK_BOOKMARK_1.id
-    renderWithRoutes(<BookmarkPage />, APP_PATHS.BOOKMARK_DETAIL(testId))
-    
-    expect(await screen.findByText(new RegExp(`${FIELD_LABELS.BOOKMARK_ID_PREFIX} ${testId}`))).toBeInTheDocument()
-    expect(screen.getByText(FIELD_LABELS.BOOKMARK_DETAIL_TITLE)).toBeInTheDocument()
+  it('ブックマーク情報がフォームに初期表示されること', async () => {
+    renderWithRoutes(
+      <BookmarkPage />,
+      APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
+    )
+
+    const titleInput = await screen.findByLabelText(FIELD_LABELS.TITLE)
+    const urlInput = screen.getByLabelText(FIELD_LABELS.URL)
+
+    expect(titleInput).toHaveValue(MOCK_BOOKMARK_1.title)
+    expect(urlInput).toHaveValue(MOCK_BOOKMARK_1.url)
   })
 
-  it('データが取得できればブックマーク情報が表示されること', async () => {
-    renderWithRoutes(<BookmarkPage />, APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id))
-    
-    expect(await screen.findByText(MOCK_BOOKMARK_1.title)).toBeInTheDocument()
-    expect(screen.getByText(MOCK_BOOKMARK_1.url)).toBeInTheDocument()
+  it('更新ボタンクリックで update API が呼ばれ、一覧へ戻ること', async () => {
+    let patchCalled = false
+    server.use(
+      http.patch('*/api/bookmarks/:id', async ({ request }) => {
+        patchCalled = true
+        const body = await request.json()
+        expect(body).toMatchObject({ title: 'Updated Title' })
+        return HttpResponse.json({ success: true, data: MOCK_BOOKMARK_1 })
+      }),
+    )
+
+    renderWithRoutes(
+      <BookmarkPage />,
+      APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
+    )
+
+    const titleInput = await screen.findByLabelText(FIELD_LABELS.TITLE)
+    fireEvent.change(titleInput, { target: { value: 'Updated Title' } })
+
+    const updateButton = screen.getByText(FIELD_LABELS.BUTTON_UPDATE)
+    fireEvent.click(updateButton)
+
+    await waitFor(() => expect(patchCalled).toBe(true))
+    expect(await screen.findByText('Home')).toBeInTheDocument()
+  })
+
+  it('削除ボタンクリックで confirm の後に delete API が呼ばれ、一覧へ戻ること', async () => {
+    let deleteCalled = false
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    server.use(
+      http.delete('*/api/bookmarks/:id', () => {
+        deleteCalled = true
+        return new HttpResponse(null, { status: HTTP_STATUS.NO_CONTENT })
+      }),
+    )
+
+    renderWithRoutes(
+      <BookmarkPage />,
+      APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
+    )
+
+    const deleteButton = await screen.findByText(FIELD_LABELS.BUTTON_DELETE)
+    fireEvent.click(deleteButton)
+
+    await waitFor(() => expect(deleteCalled).toBe(true))
+    expect(await screen.findByText('Home')).toBeInTheDocument()
+  })
+
+  it('開くボタンクリックで openUrlInNewTab が呼ばれること', async () => {
+    renderWithRoutes(
+      <BookmarkPage />,
+      APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
+    )
+
+    const openButton = await screen.findByText(FIELD_LABELS.BUTTON_OPEN)
+    fireEvent.click(openButton)
+
+    expect(urlUtils.openUrlInNewTab).toHaveBeenCalledWith(MOCK_BOOKMARK_1.url)
+  })
+
+  it('存在しない ID の場合はエラーメッセージが表示されること', async () => {
+    renderWithRoutes(<BookmarkPage />, APP_PATHS.BOOKMARK_DETAIL('999'))
+
+    expect(await screen.findByText(/Bookmark not found/i)).toBeInTheDocument()
   })
 
   describe('Keyboard interaction', () => {
-    it('Enter キーを押した際に openUrlInNewTab が呼ばれること', async () => {
-      renderWithRoutes(<BookmarkPage />, APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id))
-      
-      await screen.findByText(MOCK_BOOKMARK_1.title)
-      fireEvent.keyDown(window, { key: 'Enter' })
+    it('Enter キーでブックマークが開かれること', async () => {
+      renderWithRoutes(
+        <BookmarkPage />,
+        APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
+      )
+      await screen.findByLabelText(FIELD_LABELS.TITLE)
 
+      fireEvent.keyDown(window, { key: 'Enter' })
       expect(urlUtils.openUrlInNewTab).toHaveBeenCalledWith(MOCK_BOOKMARK_1.url)
     })
 
-    it('Escape キーを押した際に onBack が呼ばれること', async () => {
-      const onBack = vi.fn()
-      renderWithRoutes(<BookmarkPage onBack={onBack} />, APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id))
-      
-      fireEvent.keyDown(window, { key: 'Escape' })
-
-      expect(onBack).toHaveBeenCalled()
-    })
-
-    it('データがロードされていない状態で Enter キーを押しても何も起きないこと', async () => {
-      // データのロードを空にする設定
-      server.use(
-        http.get('*/api/bookmarks', () => {
-          return HttpResponse.json({ success: true, data: { bookmarks: [] } })
-        }),
+    it('Escape キーで一覧に戻ること', async () => {
+      renderWithRoutes(
+        <BookmarkPage />,
+        APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
       )
+      await screen.findByLabelText(FIELD_LABELS.TITLE)
 
-      renderWithRoutes(<BookmarkPage />, APP_PATHS.BOOKMARK_DETAIL('non-existent-id'))
-      
-      fireEvent.keyDown(window, { key: 'Enter' })
-
-      expect(urlUtils.openUrlInNewTab).not.toHaveBeenCalled()
+      fireEvent.keyDown(window, { key: 'Escape' })
+      expect(await screen.findByText('Home')).toBeInTheDocument()
     })
-
-    it('Enter/Escape 以外のキーを押しても何も起きないこと', async () => {
-      const onBack = vi.fn()
-      renderWithRoutes(<BookmarkPage onBack={onBack} />, APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id))
-      
-      await screen.findByText(MOCK_BOOKMARK_1.title)
-      fireEvent.keyDown(window, { key: 'a' })
-
-      expect(urlUtils.openUrlInNewTab).not.toHaveBeenCalled()
-      expect(onBack).not.toHaveBeenCalled()
-    })
-  })
-
-  it('戻るリンクが表示されていること', () => {
-    renderWithRoutes(<BookmarkPage />, APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id))
-    const link = screen.getByRole('link', { name: new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i') })
-    expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', APP_PATHS.HOME)
-  })
-
-  it('戻るリンクをクリックした際に onBack が呼ばれること', async () => {
-    const onBack = vi.fn()
-    renderWithRoutes(<BookmarkPage onBack={onBack} />, APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id))
-    
-    const link = screen.getByRole('link', { name: new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i') })
-    fireEvent.click(link)
-    
-    expect(onBack).toHaveBeenCalled()
   })
 })

--- a/src/pages/BookmarkPage.tsx
+++ b/src/pages/BookmarkPage.tsx
@@ -1,8 +1,20 @@
-import { useEffect } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
-import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
-import { useBookmarks } from '../hooks/useBookmarks'
+import {
+  FIELD_LABELS,
+  APP_PATHS,
+  PLACEHOLDERS,
+  UI_MESSAGES,
+} from '@shared/constants'
+import {
+  useBookmarks,
+  useUpdateBookmark,
+  useDeleteBookmark,
+} from '../hooks/useBookmarks'
 import { openUrlInNewTab } from '@shared/utils/url'
+import { Button } from '@shared/ui/Button'
+import { InputField } from '@shared/ui/InputField'
+import { BookmarkIdSchema } from '@shared/schemas/bookmark'
 
 interface BookmarkPageProps {
   onBack?: () => void
@@ -10,55 +22,170 @@ interface BookmarkPageProps {
 
 export function BookmarkPage({ onBack }: BookmarkPageProps) {
   const { id } = useParams<{ id: string }>()
-  const navigate = useNavigate()
-  const { data } = useBookmarks()
 
+  // データ取得
+  const { data, isLoading } = useBookmarks()
   const bookmark = data?.bookmarks.find((b) => b.id === id)
+
+  if (isLoading) {
+    return (
+      <div className="p-4">
+        {FIELD_LABELS.BOOKMARK_DETAIL_TITLE} - Loading...
+      </div>
+    )
+  }
+
+  if (!bookmark) {
+    return (
+      <div className="p-4">
+        <p className="text-red-600 mb-4">Bookmark not found (ID: {id})</p>
+        <Link to={APP_PATHS.HOME} className="text-blue-600 hover:underline">
+          &larr; {FIELD_LABELS.BACK_TO_LIST}
+        </Link>
+      </div>
+    )
+  }
+
+  // データが確定した後にフォームを表示
+  return <BookmarkEditForm bookmark={bookmark} onBack={onBack} id={id!} />
+}
+
+/**
+ * 実際の編集フォーム
+ */
+function BookmarkEditForm({
+  bookmark,
+  onBack,
+  id,
+}: {
+  bookmark: import('@shared/schemas/bookmark').Bookmark
+  onBack?: () => void
+  id: string
+}) {
+  const navigate = useNavigate()
+  const [editTitle, setEditTitle] = useState(bookmark.title)
+  const [editUrl, setEditUrl] = useState(bookmark.url)
+
+  const updateMutation = useUpdateBookmark()
+  const deleteMutation = useDeleteBookmark()
+
+  const handleBack = useCallback(() => {
+    onBack?.()
+    navigate(APP_PATHS.HOME)
+  }, [onBack, navigate])
+
+  const handleUpdate = useCallback(async () => {
+    try {
+      const parsedId = BookmarkIdSchema.parse(id)
+      await updateMutation.mutateAsync({
+        id: parsedId,
+        updates: { title: editTitle, url: editUrl },
+      })
+      handleBack()
+    } catch (e) {
+      console.error('Invalid bookmark ID:', e)
+    }
+  }, [id, editTitle, editUrl, updateMutation, handleBack])
+
+  const handleDelete = useCallback(async () => {
+    try {
+      const parsedId = BookmarkIdSchema.parse(id)
+      if (window.confirm(UI_MESSAGES.DELETE_CONFIRM)) {
+        await deleteMutation.mutateAsync(parsedId)
+        handleBack()
+      }
+    } catch (e) {
+      console.error('Invalid bookmark ID:', e)
+    }
+  }, [id, deleteMutation, handleBack])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Enter' && bookmark) {
-        openUrlInNewTab(bookmark.url)
-      } else if (e.key === 'Escape') {
-        onBack?.()
-        navigate(APP_PATHS.HOME)
+      if (e.key === 'Escape') {
+        handleBack()
+      } else if (e.key === 'Enter') {
+        if (e.metaKey || e.ctrlKey) {
+          handleUpdate()
+        } else {
+          openUrlInNewTab(editUrl)
+        }
       }
     }
-
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [bookmark, onBack, navigate])
+  }, [handleBack, handleUpdate, editUrl])
 
   return (
-    <div className="p-4">
-      <div className="mb-4">
+    <div className="p-4 max-w-2xl mx-auto">
+      <div className="mb-6">
         <Link
           to={APP_PATHS.HOME}
-          className="text-blue-600 hover:underline"
-          onClick={() => onBack?.()}
+          className="text-blue-600 hover:underline flex items-center"
+          onClick={(e) => {
+            e.preventDefault()
+            handleBack()
+          }}
         >
           &larr; {FIELD_LABELS.BACK_TO_LIST}
         </Link>
       </div>
-      <h1 className="text-xl font-bold mb-2">
+
+      <h1 className="text-2xl font-bold mb-6">
         {FIELD_LABELS.BOOKMARK_DETAIL_TITLE}
       </h1>
-      <p className="text-gray-600">
+
+      <p className="text-gray-600 mb-4">
         {FIELD_LABELS.BOOKMARK_ID_PREFIX} {id}
       </p>
-      {bookmark && (
-        <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-md">
-          <p className="font-semibold">{bookmark.title}</p>
-          <p className="text-sm text-gray-500 truncate">{bookmark.url}</p>
-          <p className="mt-2 text-xs text-blue-600 font-medium animate-pulse">
-            Press Enter to open this link, or ESC to go back
-          </p>
+
+      <div className="bg-white p-4 border border-gray-200 rounded-lg shadow-sm">
+        <div className="grid grid-cols-[1fr_auto] gap-4 items-stretch">
+          {/* 左側: テキストボックスを2段で配置 */}
+          <div className="grid grid-rows-2 gap-4">
+            <InputField
+              id="detail-title"
+              label={FIELD_LABELS.TITLE}
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+              placeholder={PLACEHOLDERS.TITLE}
+            />
+            <InputField
+              id="detail-url"
+              label={FIELD_LABELS.URL}
+              value={editUrl}
+              onChange={(e) => setEditUrl(e.target.value)}
+              placeholder={PLACEHOLDERS.URL}
+              className="font-mono"
+            />
+          </div>
+
+          {/* 右側: ボタンを縦に配置 */}
+          <div className="grid grid-rows-4 gap-0.5 min-w-24">
+            <Button
+              variant="primary"
+              onClick={handleUpdate}
+              disabled={updateMutation.isPending}
+            >
+              {updateMutation.isPending ? '...' : FIELD_LABELS.BUTTON_UPDATE}
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => openUrlInNewTab(editUrl)}
+            >
+              {FIELD_LABELS.BUTTON_OPEN}
+            </Button>
+            <Button
+              variant="danger"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? '...' : FIELD_LABELS.BUTTON_DELETE}
+            </Button>
+            <Button variant="secondary" onClick={handleBack}>
+              {FIELD_LABELS.BUTTON_CLOSE}
+            </Button>
+          </div>
         </div>
-      )}
-      <div className="mt-8 p-4 bg-yellow-50 border border-yellow-200 rounded-md">
-        <p className="text-sm text-yellow-700">
-          Note: This is a placeholder for the bookmark editing screen.
-        </p>
       </div>
     </div>
   )


### PR DESCRIPTION
### 概要
詳細ページ（`/bookmark/:id`）において、ブックマークの基本情報（タイトル、URL）の編集、および削除を行える機能を実装しました。これにより、プレースホルダを廃止し、実用的な詳細画面へと刷新しました。

### 変更内容
- **UI 刷新**: `BookmarkPage.tsx` をプレースホルダから、`BookmarkDetail.tsx` (旧フッター) の操作感を踏襲した編集フォームへ変更。
- **データ連携**: `useBookmarks` フックを使用し、URL パラメータの `id` に基づいて該当データを取得。
- **アクション実装**: 
  - `useUpdateBookmark`: タイトル・URL の更新。
  - `useDeleteBookmark`: ブックマークの削除。
  - 実行成功後は自動的に一覧画面 (`/`) へ遷移。
- **操作性向上**: 
  - `Enter`: ブックマークを別タブで開く。
  - `Ctrl+Enter` / `Cmd+Enter`: 更新を保存。
  - `Escape`: 一覧に戻る（選択解除）。
- **テスト拡充**:
  - `BookmarkPage.test.tsx`: 全アクション（更新・削除・起動・遷移）の検証テストを追加。
  - `App.test.tsx`: ページ遷移後の ID 表示検証を最新 UI に合わせて調整。

### 背景・目的
設計書 Step 4 に基づき、ルーティング導入後の「プレースホルダのみの状態」を解消し、アプリケーションの基本機能を独立したページで完結できるようにしました。

### 次のステップ
Step 4-2 (#239) にて、本画面内へのキーワード紐付け管理機能（追加・削除）を実装します。

Closes #223