### PR TITLE
refactor(frontend): ブックマーク詳細画面의 UI 整理と不要な項目の削除

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -122,7 +122,7 @@ describe('App Integration', () => {
     expect(await screen.findByRole(ARIA_ROLES.ALERT)).toBeInTheDocument()
   })
 
-  it('行をクリックすると詳細ページへ遷移し、正しい ID が表示されること', async () => {
+  it('行をクリックすると詳細ページへ遷移すること', async () => {
     const { user } = setup()
 
     const item = await screen.findByRole(ARIA_ROLES.BUTTON, {
@@ -130,16 +130,9 @@ describe('App Integration', () => {
     })
     await user.click(item)
 
-    // 遷移後のプレースホルダ画面の内容を検証
-    expect(
-      await screen.findByText(FIELD_LABELS.BOOKMARK_DETAIL_TITLE),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText(new RegExp(`${MOCK_BOOKMARK_1.id}`)),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText(new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i')),
-    ).toBeInTheDocument()
+    // 遷移後の詳細画面（編集フォーム）の存在を検証
+    expect(await screen.findByLabelText(FIELD_LABELS.TITLE)).toBeInTheDocument()
+    expect(screen.getByLabelText(FIELD_LABELS.URL)).toBeInTheDocument()
   })
 
   it('詳細ページから一覧ページへ戻れること', async () => {
@@ -150,10 +143,8 @@ describe('App Integration', () => {
     })
     await user.click(item)
 
-    const backLink = await screen.findByText(
-      new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i'),
-    )
-    await user.click(backLink)
+    const closeButton = await screen.findByText(FIELD_LABELS.BUTTON_CLOSE)
+    await user.click(closeButton)
 
     // 一覧画面に戻ったことを検証
     expect(await screen.findByText(MOCK_BOOKMARK_1.title)).toBeInTheDocument()

--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -143,4 +143,17 @@ describe('BookmarkPage', () => {
       expect(await screen.findByText('Home')).toBeInTheDocument()
     })
   })
+
+  it('閉じるボタンをクリックした際に onBack が呼ばれること', async () => {
+    const onBack = vi.fn()
+    renderWithRoutes(
+      <BookmarkPage onBack={onBack} />,
+      APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
+    )
+
+    const closeButton = await screen.findByText(FIELD_LABELS.BUTTON_CLOSE)
+    fireEvent.click(closeButton)
+
+    expect(onBack).toHaveBeenCalled()
+  })
 })

--- a/src/pages/BookmarkPage.tsx
+++ b/src/pages/BookmarkPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
-import { useParams, Link, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
 import {
   FIELD_LABELS,
   APP_PATHS,
@@ -22,26 +22,28 @@ interface BookmarkPageProps {
 
 export function BookmarkPage({ onBack }: BookmarkPageProps) {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
 
   // データ取得
   const { data, isLoading } = useBookmarks()
   const bookmark = data?.bookmarks.find((b) => b.id === id)
 
+  const handleNotFoundBack = useCallback(() => {
+    onBack?.()
+    navigate(APP_PATHS.HOME)
+  }, [onBack, navigate])
+
   if (isLoading) {
-    return (
-      <div className="p-4">
-        {FIELD_LABELS.BOOKMARK_DETAIL_TITLE} - Loading...
-      </div>
-    )
+    return <div className="p-4">Loading...</div>
   }
 
   if (!bookmark) {
     return (
       <div className="p-4">
         <p className="text-red-600 mb-4">Bookmark not found (ID: {id})</p>
-        <Link to={APP_PATHS.HOME} className="text-blue-600 hover:underline">
-          &larr; {FIELD_LABELS.BACK_TO_LIST}
-        </Link>
+        <Button variant="secondary" onClick={handleNotFoundBack}>
+          {FIELD_LABELS.BUTTON_CLOSE}
+        </Button>
       </div>
     )
   }
@@ -117,27 +119,6 @@ function BookmarkEditForm({
 
   return (
     <div className="p-4 max-w-2xl mx-auto">
-      <div className="mb-6">
-        <Link
-          to={APP_PATHS.HOME}
-          className="text-blue-600 hover:underline flex items-center"
-          onClick={(e) => {
-            e.preventDefault()
-            handleBack()
-          }}
-        >
-          &larr; {FIELD_LABELS.BACK_TO_LIST}
-        </Link>
-      </div>
-
-      <h1 className="text-2xl font-bold mb-6">
-        {FIELD_LABELS.BOOKMARK_DETAIL_TITLE}
-      </h1>
-
-      <p className="text-gray-600 mb-4">
-        {FIELD_LABELS.BOOKMARK_ID_PREFIX} {id}
-      </p>
-
       <div className="bg-white p-4 border border-gray-200 rounded-lg shadow-sm">
         <div className="grid grid-cols-[1fr_auto] gap-4 items-stretch">
           {/* 左側: テキストボックスを2段で配置 */}


### PR DESCRIPTION
### 概要
詳細画面（`/bookmark/:id`）の UI を簡素化するため、冗長な情報や重複するナビゲーションを削除し、あわせて関連するテストコードを更新しました。

### 変更内容
- **UI コンポーネント (`BookmarkPage.tsx`)**:
  - 「Bookmark Detail」タイトルを削除。
  - 「← Back to List」リンクを削除（閉じるボタンと機能重複のため）。
  - 「Bookmark ID」の表示を削除（内部情報のため）。
- **統合テスト (`App.test.tsx`)**:
  - 詳細画面への遷移確認を、ID 表示のチェックから「タイトル入力欄（label: タイトル）の存在確認」に変更。
  - 戻る操作の検証を、リンククリックから「閉じる」ボタンのクリックに変更。
- **ユニットテスト (`BookmarkPage.test.tsx`)**:
  - 削除した要素の検証を廃止し、閉じるボタンの動作検証を強化。

### 背景・目的
今後のキーワード管理機能の追加に備え、画面上の余白を確保し、ユーザーにとってノイズとなる情報を排除して操作性を向上させるためです。

Closes #247