### PR TITLE
feat(backend): キーワード作成 API (POST /api/keywords) の実装

### DIFF
--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -10,6 +10,7 @@ import { VALID_URLS } from '@shared/test/fixtures'
 
 import app from '../app'
 import { db, initializeDatabase, resetDatabase, sqlite } from '../db'
+import { API_ERROR_CODES } from '../utils/error'
 import { attachKeyword, createBookmark, createKeyword } from '../test/seedUtils'
 
 describe(`GET ${API_PATHS.KEYWORDS}`, () => {
@@ -120,7 +121,17 @@ describe(`POST ${API_PATHS.KEYWORDS}`, () => {
     expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
   })
 
-  it('既に存在する名前の場合は 409 Conflict を返すこと', async () => {
+  it('名前が50文字を超える場合は 400 Bad Request を返すこと', async () => {
+    const res = await app.request(API_PATHS.KEYWORDS, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'a'.repeat(51) }),
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
+  })
+
+  it('既に存在する名前の場合は 409 Conflict を返し、エラーオブジェクトを含むこと', async () => {
     const DUPLICATE_KEYWORD = 'Duplicate'
     createKeyword(DUPLICATE_KEYWORD)
 
@@ -133,7 +144,8 @@ describe(`POST ${API_PATHS.KEYWORDS}`, () => {
     expect(res.status).toBe(HTTP_STATUS.CONFLICT)
     const body = await res.json()
     expect(body.success).toBe(false)
-    expect(body.message).toBe(ERROR_MESSAGES.DUPLICATE_KEYWORD)
+    expect(body.error.message).toBe(ERROR_MESSAGES.DUPLICATE_KEYWORD)
+    expect(body.error.code).toBe(API_ERROR_CODES.CONFLICT)
   })
 
   describe('Error Handling', () => {
@@ -160,7 +172,7 @@ describe(`POST ${API_PATHS.KEYWORDS}`, () => {
       expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
       expect(consoleSpy).toHaveBeenCalledWith(
         LOG_MESSAGES.CREATE_KEYWORD_FAILED,
-        expect.any(Error),
+        new Error(ERROR_MESSAGES.KEYWORD_INSERT_RETURN_VALUE_MISSING),
       )
     })
 

--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -1,9 +1,16 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { API_PATHS, HTTP_STATUS, LOG_MESSAGES } from '@shared/constants'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  API_PATHS,
+  ERROR_MESSAGES,
+  HTTP_STATUS,
+  LOG_MESSAGES,
+} from '@shared/constants'
 import { VALID_URLS } from '@shared/test/fixtures'
+
 import app from '../app'
-import { sqlite, initializeDatabase, resetDatabase } from '../db'
-import { createBookmark, createKeyword, attachKeyword } from '../test/seedUtils'
+import { db, initializeDatabase, resetDatabase, sqlite } from '../db'
+import { attachKeyword, createBookmark, createKeyword } from '../test/seedUtils'
 
 describe(`GET ${API_PATHS.KEYWORDS}`, () => {
   beforeEach(() => {
@@ -67,6 +74,113 @@ describe(`GET ${API_PATHS.KEYWORDS}`, () => {
       expect(body.success).toBe(false)
       expect(consoleSpy).toHaveBeenCalledWith(
         LOG_MESSAGES.FETCH_KEYWORDS_FAILED,
+        dbError,
+      )
+    })
+  })
+})
+
+describe(`POST ${API_PATHS.KEYWORDS}`, () => {
+  beforeEach(() => {
+    initializeDatabase()
+    resetDatabase()
+  })
+
+  it('新しいキーワードを正常に作成できること', async () => {
+    const NEW_TAG = 'NewTag'
+    const res = await app.request(API_PATHS.KEYWORDS, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: NEW_TAG }),
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.CREATED)
+    const body = await res.json()
+    expect(body.success).toBe(true)
+    expect(body.data.keyword).toEqual({
+      id: expect.any(String),
+      name: NEW_TAG,
+    })
+
+    // 実際に保存されているか確認
+    const getRes = await app.request(API_PATHS.KEYWORDS)
+    const getBody = await getRes.json()
+    expect(getBody.data.keywords).toContainEqual(
+      expect.objectContaining({ name: NEW_TAG }),
+    )
+  })
+
+  it('名前が空の場合は 400 Bad Request を返すこと', async () => {
+    const res = await app.request(API_PATHS.KEYWORDS, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: '' }),
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.BAD_REQUEST)
+  })
+
+  it('既に存在する名前の場合は 409 Conflict を返すこと', async () => {
+    const DUPLICATE_KEYWORD = 'Duplicate'
+    createKeyword(DUPLICATE_KEYWORD)
+
+    const res = await app.request(API_PATHS.KEYWORDS, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: DUPLICATE_KEYWORD }),
+    })
+
+    expect(res.status).toBe(HTTP_STATUS.CONFLICT)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+    expect(body.message).toBe(ERROR_MESSAGES.DUPLICATE_KEYWORD)
+  })
+
+  describe('Error Handling', () => {
+    it('キーワードの作成結果が取得できなかった場合に 500 を返すこと', async () => {
+      const NEW_TAG = 'FailureTag'
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      // db.insert()...get() が undefined を返すようにモックして if (!result) を通す
+      vi.spyOn(db, 'insert').mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockReturnValue({
+            get: vi.fn().mockReturnValue(undefined),
+          }),
+        }),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any)
+
+      const res = await app.request(API_PATHS.KEYWORDS, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: NEW_TAG }),
+      })
+
+      expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        LOG_MESSAGES.CREATE_KEYWORD_FAILED,
+        expect.any(Error),
+      )
+    })
+
+    it('作成失敗（例外発生）時に 500 を返し、ログを出力すること', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const dbError = new Error('Insert failed')
+
+      vi.spyOn(sqlite, 'prepare').mockImplementation(() => {
+        throw dbError
+      })
+
+      const res = await app.request(API_PATHS.KEYWORDS, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'ErrorTag' }),
+      })
+
+      expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        LOG_MESSAGES.CREATE_KEYWORD_FAILED,
         dbError,
       )
     })

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -12,6 +12,7 @@ import {
 
 import { db } from '../db'
 import { bookmarkKeywords, keywords as keywordsTable } from '../db/schema'
+import { API_ERROR_CODES } from '../utils/error'
 
 const keywordsRoute = new Hono()
   .get('/', async (c) => {
@@ -63,7 +64,10 @@ const keywordsRoute = new Hono()
         return c.json(
           {
             success: false,
-            message: ERROR_MESSAGES.DUPLICATE_KEYWORD,
+            error: {
+              message: ERROR_MESSAGES.DUPLICATE_KEYWORD,
+              code: API_ERROR_CODES.CONFLICT,
+            },
           },
           HTTP_STATUS.CONFLICT,
         )
@@ -77,7 +81,7 @@ const keywordsRoute = new Hono()
         .get()
 
       if (!result) {
-        throw new Error(ERROR_MESSAGES.CREATE_KEYWORD_FAILED)
+        throw new Error(ERROR_MESSAGES.KEYWORD_INSERT_RETURN_VALUE_MISSING)
       }
 
       const keyword = {

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -1,46 +1,101 @@
+import { count, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
-import { eq, count } from 'drizzle-orm'
-import { db } from '../db'
-import { keywords as keywordsTable, bookmarkKeywords } from '../db/schema'
+
+import { zValidator } from '@hono/zod-validator'
+import { ERROR_MESSAGES, HTTP_STATUS, LOG_MESSAGES } from '@shared/constants'
 import {
-  keywordsResponseSchema,
+  createKeywordRequestSchema,
   KeywordIdSchema,
+  keywordResponseSchema,
+  keywordsResponseSchema,
 } from '@shared/schemas/keyword'
-import { LOG_MESSAGES } from '@shared/constants'
 
-const keywordsRoute = new Hono().get('/', async (c) => {
-  try {
-    // 全キーワードを取得し、各キーワードに紐付くブックマーク数をカウントする
-    // LEFT JOIN を使用して、ブックマークが 0 件のキーワードも取得する
-    const rows = await db
-      .select({
-        id: keywordsTable.keywordId,
-        name: keywordsTable.keywordName,
-        bookmarkCount: count(bookmarkKeywords.bookmarkId),
+import { db } from '../db'
+import { bookmarkKeywords, keywords as keywordsTable } from '../db/schema'
+
+const keywordsRoute = new Hono()
+  .get('/', async (c) => {
+    try {
+      // 全キーワードを取得し、各キーワードに紐付くブックマーク数をカウントする
+      // LEFT JOIN を使用して、ブックマークが 0 件のキーワードも取得する
+      const rows = await db
+        .select({
+          id: keywordsTable.keywordId,
+          name: keywordsTable.keywordName,
+          bookmarkCount: count(bookmarkKeywords.bookmarkId),
+        })
+        .from(keywordsTable)
+        .leftJoin(
+          bookmarkKeywords,
+          eq(keywordsTable.keywordId, bookmarkKeywords.keywordId),
+        )
+        .groupBy(keywordsTable.keywordId, keywordsTable.keywordName)
+        .orderBy(keywordsTable.keywordName)
+
+      const keywords = rows.map((row) => ({
+        id: KeywordIdSchema.parse(String(row.id)),
+        name: row.name,
+        bookmarkCount: row.bookmarkCount,
+      }))
+
+      const result = keywordsResponseSchema.parse({ keywords })
+      return c.json({
+        success: true,
+        data: result,
       })
-      .from(keywordsTable)
-      .leftJoin(
-        bookmarkKeywords,
-        eq(keywordsTable.keywordId, bookmarkKeywords.keywordId),
+    } catch (error) {
+      console.error(LOG_MESSAGES.FETCH_KEYWORDS_FAILED, error)
+      throw error
+    }
+  })
+  .post('/', zValidator('json', createKeywordRequestSchema), async (c) => {
+    const { name } = c.req.valid('json')
+
+    try {
+      // 重複チェック
+      const existing = await db
+        .select()
+        .from(keywordsTable)
+        .where(eq(keywordsTable.keywordName, name))
+        .get()
+
+      if (existing) {
+        return c.json(
+          {
+            success: false,
+            message: ERROR_MESSAGES.DUPLICATE_KEYWORD,
+          },
+          HTTP_STATUS.CONFLICT,
+        )
+      }
+
+      // 新規作成
+      const result = await db
+        .insert(keywordsTable)
+        .values({ keywordName: name })
+        .returning()
+        .get()
+
+      if (!result) {
+        throw new Error(ERROR_MESSAGES.CREATE_KEYWORD_FAILED)
+      }
+
+      const keyword = {
+        id: KeywordIdSchema.parse(String(result.keywordId)),
+        name: result.keywordName,
+      }
+
+      return c.json(
+        {
+          success: true,
+          data: keywordResponseSchema.parse({ keyword }),
+        },
+        HTTP_STATUS.CREATED,
       )
-      .groupBy(keywordsTable.keywordId, keywordsTable.keywordName)
-      .orderBy(keywordsTable.keywordName)
-
-    const keywords = rows.map((row) => ({
-      id: KeywordIdSchema.parse(String(row.id)),
-      name: row.name,
-      bookmarkCount: row.bookmarkCount,
-    }))
-
-    const result = keywordsResponseSchema.parse({ keywords })
-    return c.json({
-      success: true,
-      data: result,
-    })
-  } catch (error) {
-    console.error(LOG_MESSAGES.FETCH_KEYWORDS_FAILED, error)
-    throw error
-  }
-})
+    } catch (error) {
+      console.error(LOG_MESSAGES.CREATE_KEYWORD_FAILED, error)
+      throw error
+    }
+  })
 
 export default keywordsRoute

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -100,6 +100,8 @@ export const COMMON_MESSAGES = {
 export const ERROR_MESSAGES = {
   INTERNAL_SERVER_ERROR: 'サーバー内部エラーが発生しました',
   DUPLICATE_URL: 'この URL は既に登録されています',
+  DUPLICATE_KEYWORD: 'このキーワードは既に登録されています',
+  CREATE_KEYWORD_FAILED: 'キーワードの作成に失敗しました',
   BOOKMARK_NOT_FOUND: '指定されたブックマークが見つかりませんでした',
   NOT_FOUND: 'リソースが見つかりませんでした',
   INVALID_URL: '有効な URL 形式ではありません',
@@ -318,6 +320,7 @@ export const LOG_MESSAGES = {
     `[sync-version] Updated manifest.json version to ${version}`,
   BLOCKED_NON_HTTP_URL: (url: string) => `Blocked opening non-HTTP URL: ${url}`,
   FETCH_KEYWORDS_FAILED: 'Failed to fetch keywords:',
+  CREATE_KEYWORD_FAILED: 'Failed to create keyword:',
 } as const
 
 /**
@@ -335,6 +338,7 @@ export const TEST_MESSAGES = {
 export const VALIDATION_MESSAGES = {
   TITLE_REQUIRED: 'タイトルは必須です',
   TITLE_MIN_LENGTH: 'タイトルは1文字以上である必要があります',
+  KEYWORD_MIN_LENGTH: 'キーワード名は1文字以上である必要があります',
   URL_INVALID_PROTOCOL: 'URL は http:// または https:// で始まる必要があります',
   URL_INVALID_FORMAT: '有効な URL形式である必要があります',
   UPDATE_MIN_FIELDS:

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -102,6 +102,8 @@ export const ERROR_MESSAGES = {
   DUPLICATE_URL: 'この URL は既に登録されています',
   DUPLICATE_KEYWORD: 'このキーワードは既に登録されています',
   CREATE_KEYWORD_FAILED: 'キーワードの作成に失敗しました',
+  KEYWORD_INSERT_RETURN_VALUE_MISSING:
+    'キーワードの挿入に成功しましたが、返り値の取得に失敗しました',
   BOOKMARK_NOT_FOUND: '指定されたブックマークが見つかりませんでした',
   NOT_FOUND: 'リソースが見つかりませんでした',
   INVALID_URL: '有効な URL 形式ではありません',
@@ -339,6 +341,7 @@ export const VALIDATION_MESSAGES = {
   TITLE_REQUIRED: 'タイトルは必須です',
   TITLE_MIN_LENGTH: 'タイトルは1文字以上である必要があります',
   KEYWORD_MIN_LENGTH: 'キーワード名は1文字以上である必要があります',
+  KEYWORD_MAX_LENGTH: 'キーワード名は50文字以内で入力してください',
   URL_INVALID_PROTOCOL: 'URL は http:// または https:// で始まる必要があります',
   URL_INVALID_FORMAT: '有効な URL形式である必要があります',
   UPDATE_MIN_FIELDS:

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { VALIDATION_MESSAGES } from '@shared/constants'
 
 export const KeywordIdSchema = z
   .string()
@@ -21,3 +22,19 @@ export const keywordsResponseSchema = z.object({
   keywords: z.array(keywordWithCountSchema),
 })
 export type KeywordsResponse = z.infer<typeof keywordsResponseSchema>
+
+/**
+ * キーワード作成リクエストのバリデーションスキーマ
+ */
+export const createKeywordRequestSchema = z.object({
+  name: z.string().min(1, VALIDATION_MESSAGES.KEYWORD_MIN_LENGTH),
+})
+export type CreateKeywordRequest = z.infer<typeof createKeywordRequestSchema>
+
+/**
+ * 単一キーワードのレスポンススキーマ
+ */
+export const keywordResponseSchema = z.object({
+  keyword: keywordSchema,
+})
+export type KeywordResponse = z.infer<typeof keywordResponseSchema>

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -27,7 +27,10 @@ export type KeywordsResponse = z.infer<typeof keywordsResponseSchema>
  * キーワード作成リクエストのバリデーションスキーマ
  */
 export const createKeywordRequestSchema = z.object({
-  name: z.string().min(1, VALIDATION_MESSAGES.KEYWORD_MIN_LENGTH),
+  name: z
+    .string()
+    .min(1, VALIDATION_MESSAGES.KEYWORD_MIN_LENGTH)
+    .max(50, VALIDATION_MESSAGES.KEYWORD_MAX_LENGTH),
 })
 export type CreateKeywordRequest = z.infer<typeof createKeywordRequestSchema>
 


### PR DESCRIPTION
### 概要
新しいキーワードを登録するための API `POST /api/keywords` を実装しました。

### 変更内容
- **API 実装**: `server/routes/keywords.ts` に POST ハンドラを追加。
  - 名前の一意性チェック（409 Conflict）を実装。
  - 共通定数 (`shared/constants.ts`) によるメッセージ管理を導入。
- **スキーマ更新**: `shared/schemas/keyword.ts` に作成リクエスト用スキーマを追加。
- **テスト強化**: `server/routes/keywords.test.ts` を拡充。
  - 正常系・異常系（重複、バリデーションエラー、DBエラー）を網羅。
  - **対象ファイルの行カバレッジ 100%** を達成。

### 背景・目的
フロントエンドからキーワードを新規作成できるようにするための、基本的なバックエンド機能を提供します。

### 次のステップ
Issue #252 にて、特定のブックマークにキーワードを紐付ける機能を実装します。

Closes #251