### PR TITLE
feat(backend): ブックマークへのキーワード紐付け API (POST) の実装

### DIFF
--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -263,6 +263,75 @@ describe('Bookmarks API', () => {
     })
   })
 
+  describe(`POST ${API_PATHS.BOOKMARKS}/:id/keywords`, () => {
+    it('キーワードをブックマークに紐付けられること', async () => {
+      const b1 = createBookmark('B1', VALID_URLS.HTTP)
+      const k1 = createKeyword('Tag1')
+
+      const res = await app.request(
+        `${API_PATHS.BOOKMARKS}/${b1.bookmark_id}/keywords`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ keywordId: String(k1.keyword_id) }),
+        },
+      )
+
+      expect(res.status).toBe(HTTP_STATUS.CREATED)
+      const body = await res.json()
+      expect(body.success).toBe(true)
+
+      // ブックマーク一覧で紐付けを確認
+      const getRes = await app.request(API_PATHS.BOOKMARKS)
+      const getBody = await getRes.json()
+      expect(getBody.data.bookmarks[0].keywords).toContainEqual(
+        expect.objectContaining({ name: 'Tag1' }),
+      )
+    })
+
+    it('存在しないブックマークへの紐付け時に 404 を返すこと', async () => {
+      const k1 = createKeyword('Tag1')
+      const res = await app.request(`${API_PATHS.BOOKMARKS}/999/keywords`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ keywordId: String(k1.keyword_id) }),
+      })
+      expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
+    })
+
+    it('存在しないキーワードの紐付け時に 404 を返すこと', async () => {
+      const b1 = createBookmark('B1', VALID_URLS.HTTP)
+      const res = await app.request(
+        `${API_PATHS.BOOKMARKS}/${b1.bookmark_id}/keywords`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ keywordId: '999' }),
+        },
+      )
+      expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
+    })
+
+    it('既に紐付いているキーワードを再度紐付けようとした場合に 409 を返すこと', async () => {
+      const b1 = createBookmark('B1', VALID_URLS.HTTP)
+      const k1 = createKeyword('Tag1')
+      attachKeyword(b1.bookmark_id, k1.keyword_id)
+
+      const res = await app.request(
+        `${API_PATHS.BOOKMARKS}/${b1.bookmark_id}/keywords`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ keywordId: String(k1.keyword_id) }),
+        },
+      )
+
+      expect(res.status).toBe(HTTP_STATUS.CONFLICT)
+      const body = await res.json()
+      expect(body.error.message).toBe(ERROR_MESSAGES.DUPLICATE_KEYWORD)
+    })
+  })
+
   describe('Database Error Handling (500)', () => {
     const dbError = new Error('Database connection failed')
 
@@ -345,6 +414,32 @@ describe('Bookmarks API', () => {
       expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
       expect(consoleSpy).toHaveBeenCalledWith(
         LOG_MESSAGES.REORDER_FAILED_CONSOLE,
+        dbError,
+      )
+    })
+
+    it('POST (keywords): データベースエラー時に 500 を返し、適切なログを出力すること', async () => {
+      const b1 = createBookmark('B1', VALID_URLS.HTTP)
+      const k1 = createKeyword('Tag1')
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      // 最初の select (bookmark/keyword存在確認) は通し、insert でエラーを発生させる
+      vi.spyOn(db, 'insert').mockImplementation(() => {
+        throw dbError
+      })
+
+      const res = await app.request(
+        `${API_PATHS.BOOKMARKS}/${b1.bookmark_id}/keywords`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ keywordId: String(k1.keyword_id) }),
+        },
+      )
+
+      expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        LOG_MESSAGES.ATTACH_KEYWORD_FAILED,
         dbError,
       )
     })

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -310,6 +310,8 @@ describe('Bookmarks API', () => {
         },
       )
       expect(res.status).toBe(HTTP_STATUS.NOT_FOUND)
+      const body = await res.json()
+      expect(body.error.message).toBe(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
     })
 
     it('既に紐付いているキーワードを再度紐付けようとした場合に 409 を返すこと', async () => {
@@ -425,6 +427,33 @@ describe('Bookmarks API', () => {
 
       // 最初の select (bookmark/keyword存在確認) は通し、insert でエラーを発生させる
       vi.spyOn(db, 'insert').mockImplementation(() => {
+        throw dbError
+      })
+
+      const res = await app.request(
+        `${API_PATHS.BOOKMARKS}/${b1.bookmark_id}/keywords`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ keywordId: String(k1.keyword_id) }),
+        },
+      )
+
+      expect(res.status).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      expect(consoleSpy).toHaveBeenCalledWith(
+        LOG_MESSAGES.ATTACH_KEYWORD_FAILED,
+        dbError,
+      )
+    })
+
+    it('POST (keywords): 存在確認のDBエラー時に 500 を返すこと', async () => {
+      const b1 = createBookmark('B1', VALID_URLS.HTTP)
+      const k1 = createKeyword('Tag1')
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const dbError = new Error('DB select failed')
+
+      // select でエラーを発生させる
+      vi.spyOn(db, 'select').mockImplementation(() => {
         throw dbError
       })
 

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -13,9 +13,14 @@ import {
   reorderBookmarksSchema,
   type Bookmark,
 } from '@shared/schemas/bookmark'
+import { attachKeywordRequestSchema } from '@shared/schemas/keyword'
 
 import { db } from '../db'
-import { bookmarks as bookmarksTable } from '../db/schema'
+import {
+  bookmarks as bookmarksTable,
+  bookmarkKeywords as bookmarkKeywordsTable,
+  keywords as keywordsTable,
+} from '../db/schema'
 import { isUniqueConstraintError, API_ERROR_CODES } from '../utils/error'
 
 /**
@@ -247,5 +252,79 @@ const bookmarksRoute = new Hono()
       throw error
     }
   })
+  .post(
+    '/:id/keywords',
+    zValidator('param', z.object({ id: z.string().regex(/^[1-9]\d*$/) })),
+    zValidator('json', attachKeywordRequestSchema),
+    async (c) => {
+      const { id } = c.req.valid('param')
+      const { keywordId } = c.req.valid('json')
+      const bookmarkIdNum = parseInt(id, 10)
+      const keywordIdNum = parseInt(keywordId, 10)
+
+      try {
+        // 1. ブックマークの存在確認
+        const bookmark = await db
+          .select()
+          .from(bookmarksTable)
+          .where(eq(bookmarksTable.bookmarkId, bookmarkIdNum))
+          .get()
+        if (!bookmark) {
+          return c.json(
+            {
+              success: false,
+              error: {
+                message: ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+                code: API_ERROR_CODES.NOT_FOUND,
+              },
+            },
+            HTTP_STATUS.NOT_FOUND,
+          )
+        }
+
+        // 2. キーワードの存在確認
+        const keyword = await db
+          .select()
+          .from(keywordsTable)
+          .where(eq(keywordsTable.keywordId, keywordIdNum))
+          .get()
+        if (!keyword) {
+          return c.json(
+            {
+              success: false,
+              error: {
+                message: ERROR_MESSAGES.NOT_FOUND,
+                code: API_ERROR_CODES.NOT_FOUND,
+              },
+            },
+            HTTP_STATUS.NOT_FOUND,
+          )
+        }
+
+        // 3. 紐付け (中間テーブルへの挿入)
+        await db.insert(bookmarkKeywordsTable).values({
+          bookmarkId: bookmarkIdNum,
+          keywordId: keywordIdNum,
+        })
+
+        return c.json({ success: true, data: null }, HTTP_STATUS.CREATED)
+      } catch (error) {
+        if (isUniqueConstraintError(error)) {
+          return c.json(
+            {
+              success: false,
+              error: {
+                message: ERROR_MESSAGES.DUPLICATE_KEYWORD,
+                code: API_ERROR_CODES.CONFLICT,
+              },
+            },
+            HTTP_STATUS.CONFLICT,
+          )
+        }
+        console.error(LOG_MESSAGES.ATTACH_KEYWORD_FAILED, error)
+        throw error
+      }
+    },
+  )
 
 export default bookmarksRoute

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -263,12 +263,20 @@ const bookmarksRoute = new Hono()
       const keywordIdNum = parseInt(keywordId, 10)
 
       try {
-        // 1. ブックマークの存在確認
-        const bookmark = await db
-          .select()
-          .from(bookmarksTable)
-          .where(eq(bookmarksTable.bookmarkId, bookmarkIdNum))
-          .get()
+        // 1. ブックマークとキーワードの存在を並行して確認
+        const [bookmark, keyword] = await Promise.all([
+          db
+            .select({ id: bookmarksTable.bookmarkId })
+            .from(bookmarksTable)
+            .where(eq(bookmarksTable.bookmarkId, bookmarkIdNum))
+            .get(),
+          db
+            .select({ id: keywordsTable.keywordId })
+            .from(keywordsTable)
+            .where(eq(keywordsTable.keywordId, keywordIdNum))
+            .get(),
+        ])
+
         if (!bookmark) {
           return c.json(
             {
@@ -282,18 +290,12 @@ const bookmarksRoute = new Hono()
           )
         }
 
-        // 2. キーワードの存在確認
-        const keyword = await db
-          .select()
-          .from(keywordsTable)
-          .where(eq(keywordsTable.keywordId, keywordIdNum))
-          .get()
         if (!keyword) {
           return c.json(
             {
               success: false,
               error: {
-                message: ERROR_MESSAGES.NOT_FOUND,
+                message: ERROR_MESSAGES.KEYWORD_NOT_FOUND,
                 code: API_ERROR_CODES.NOT_FOUND,
               },
             },
@@ -301,7 +303,7 @@ const bookmarksRoute = new Hono()
           )
         }
 
-        // 3. 紐付け (中間テーブルへの挿入)
+        // 2. 紐付け (中間テーブルへの挿入)
         await db.insert(bookmarkKeywordsTable).values({
           bookmarkId: bookmarkIdNum,
           keywordId: keywordIdNum,

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -323,6 +323,7 @@ export const LOG_MESSAGES = {
   BLOCKED_NON_HTTP_URL: (url: string) => `Blocked opening non-HTTP URL: ${url}`,
   FETCH_KEYWORDS_FAILED: 'Failed to fetch keywords:',
   CREATE_KEYWORD_FAILED: 'Failed to create keyword:',
+  ATTACH_KEYWORD_FAILED: 'Failed to attach keyword:',
 } as const
 
 /**

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -104,6 +104,7 @@ export const ERROR_MESSAGES = {
   CREATE_KEYWORD_FAILED: 'キーワードの作成に失敗しました',
   KEYWORD_INSERT_RETURN_VALUE_MISSING:
     'キーワードの挿入に成功しましたが、返り値の取得に失敗しました',
+  KEYWORD_NOT_FOUND: '指定されたキーワードが見つかりませんでした',
   BOOKMARK_NOT_FOUND: '指定されたブックマークが見つかりませんでした',
   NOT_FOUND: 'リソースが見つかりませんでした',
   INVALID_URL: '有効な URL 形式ではありません',

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -41,3 +41,11 @@ export const keywordResponseSchema = z.object({
   keyword: keywordSchema,
 })
 export type KeywordResponse = z.infer<typeof keywordResponseSchema>
+
+/**
+ * キーワード紐付けリクエストのバリデーションスキーマ
+ */
+export const attachKeywordRequestSchema = z.object({
+  keywordId: KeywordIdSchema,
+})
+export type AttachKeywordRequest = z.infer<typeof attachKeywordRequestSchema>


### PR DESCRIPTION
### 概要
特定のブックマークにキーワードを紐付けるための API `POST /api/bookmarks/:id/keywords` を実装しました。

### 変更内容
- **スキーマ追加**: `shared/schemas/keyword.ts` に `attachKeywordRequestSchema` を追加。
- **エンドポイント実装**: `server/routes/bookmarks.ts` に POST ハンドラを追加。
  - ブックマークおよびキーワードの存在チェックを実装。
  - 重複紐付け時の 409 Conflict エラーを実装。
  - `LOG_MESSAGES.ATTACH_KEYWORD_FAILED` 定数による一貫したログ出力を導入。
- **テスト追加**: `server/routes/bookmarks.test.ts` に正常系、異常系（存在しない ID、重複、DBエラー）のテストを追加し、動作を検証。

### 背景・目的
詳細画面から既存のキーワードをブックマークに紐付けられるようにし、キーワードによる管理機能の基盤を強化します。

### 次のステップ
Issue #253 にて、キーワード自体の削除 API を実装します。

Closes #252