### PR TITLE
feat(dx): package.json と manifest.json のバージョン同期を自動化 (#258)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+npm run version-check
 npx lint-staged

--- a/extension/sync-version.ts
+++ b/extension/sync-version.ts
@@ -14,8 +14,9 @@ const manifestJsonPath = path.resolve(
  * package.json と manifest.json のバージョンを同期するスクリプト
  * 成功した場合は true、変更が不要な場合は false を返す。
  * エラーが発生した場合は例外を投げる。
+ * @param checkOnly true の場合、不一致がある場合にエラーを投げ、ファイルへの書き込みを行わない。
  */
-export function syncVersion(): boolean {
+export function syncVersion(checkOnly = false): boolean {
   // 1. ファイルの存在確認 (防御的チェック)
   if (!fs.existsSync(packageJsonPath)) {
     throw new Error(
@@ -38,13 +39,13 @@ export function syncVersion(): boolean {
     )
   }
 
-  // 3. バージョンの同期
+  // 3. バージョンの同期/チェック
   if (manifest.version !== packageJson.version) {
+    if (checkOnly) {
+      throw new Error(LOG_MESSAGES.VERSION_MISMATCH_ERROR)
+    }
     manifest.version = packageJson.version
-    fs.writeFileSync(
-      manifestJsonPath,
-      JSON.stringify(manifest, null, 2) + '\n',
-    )
+    fs.writeFileSync(manifestJsonPath, JSON.stringify(manifest, null, 2) + '\n')
     console.log(LOG_MESSAGES.UPDATED_VERSION(packageJson.version))
     return true
   }
@@ -53,10 +54,13 @@ export function syncVersion(): boolean {
 }
 
 // 直接実行された場合のみ実行 (CLI としての挙動)
-const isMain = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+const isMain =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
 if (isMain) {
+  const checkOnly = process.argv.includes('--check')
   try {
-    syncVersion()
+    syncVersion(checkOnly)
   } catch (error) {
     console.error(error instanceof Error ? error.message : error)
     process.exit(1)

--- a/package.json
+++ b/package.json
@@ -21,8 +21,11 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
-    "extension:dev": "tsx extension/sync-version.ts && vite --config extension/vite.config.ts",
-    "extension:build": "tsx extension/sync-version.ts && tsc -p extension/tsconfig.json && vite build --config extension/vite.config.ts",
+    "version-sync": "tsx extension/sync-version.ts",
+    "version-check": "tsx extension/sync-version.ts --check",
+    "version": "npm run version-sync && git add extension/public/manifest.json",
+    "extension:dev": "npm run version-sync && vite --config extension/vite.config.ts",
+    "extension:build": "npm run version-sync && tsc -p extension/tsconfig.json && vite build --config extension/vite.config.ts",
     "type-check:extension": "tsc -p extension/tsconfig.json --noEmit",
     "prepare": "husky"
   },

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -323,6 +323,8 @@ export const LOG_MESSAGES = {
     'Blocked message from unauthorized extension:',
   UNAUTHORIZED_ORIGIN_MESSAGE: 'Blocked unauthorized message from origin:',
   VERSION_SYNC_ERROR: '[sync-version] Error syncing versions:',
+  VERSION_MISMATCH_ERROR:
+    '[sync-version] package.json and manifest.json versions do not match. Run "npm run version-sync" to fix.',
   UPDATED_VERSION: (version: string) =>
     `[sync-version] Updated manifest.json version to ${version}`,
   BLOCKED_NON_HTTP_URL: (url: string) => `Blocked opening non-HTTP URL: ${url}`,


### PR DESCRIPTION
Issue #258 の対応として、ブラウザ拡張機能の `manifest.json` と `package.json` のバージョン不一致を防ぐための仕組みを導入しました。

### 変更内容
- **検証モードの導入**: `extension/sync-version.ts` に `--check` 引数を追加し、不一致を検出してエラーを出す機能を追加。
- **Git Hook (Husky) への組み込み**: `pre-commit` 時、および `npm version` 時に自動的にチェックまたは同期を行うように設定。
- **スクリプトの整理**: `package.json` に `version-sync`, `version-check`, `version` スクリプトを追加。

これにより、バージョンの不一致があるままコミットされるのを防ぎつつ、開発者が明示的にバージョンを上げた際の同期作業を自動化しています。

### 動作確認
- バージョンが一致している場合に `npm run version-check` がパスすることを確認済み。
- バージョン不一致時に `npm run version-check` が失敗し、`npm run version-sync` で解消されることを確認済み。