### PR TITLE
refactor: ブックマーク詳細画面のキーワード追加と表示ブロックの分離 (#263)

### DIFF
--- a/src/pages/BookmarkPage.tsx
+++ b/src/pages/BookmarkPage.tsx
@@ -104,29 +104,8 @@ export function BookmarkPage({ onBack }: BookmarkPageProps) {
         </div>
       </div>
 
-      {/* 2. キーワード追加・表示ブロック (暫定) */}
-      <div className="bg-gray-50 p-4 border border-gray-200 rounded-lg shadow-sm space-y-4">
-        <h3 className="sr-only">{FIELD_LABELS.KEYWORDS_SECTION_TITLE}</h3>
-
-        {/* キーワード一覧 */}
-        <div className="flex flex-wrap gap-2">
-          {bookmark.keywords.length > 0 ? (
-            bookmark.keywords.map((kw) => (
-              <span
-                key={kw.id}
-                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200"
-              >
-                {kw.name}
-              </span>
-            ))
-          ) : (
-            <span className="text-sm text-gray-400 italic">
-              {FIELD_LABELS.NO_KEYWORDS_ATTACHED}
-            </span>
-          )}
-        </div>
-
-        {/* キーワード追加フォーム */}
+      {/* 2. キーワード追加ブロック */}
+      <div className="bg-gray-50 p-4 border border-gray-200 rounded-lg shadow-sm">
         <div className="flex gap-2 items-end">
           <div className="flex-1">
             <InputField
@@ -147,6 +126,27 @@ export function BookmarkPage({ onBack }: BookmarkPageProps) {
               {isAddingKeyword ? '...' : FIELD_LABELS.BUTTON_ADD}
             </Button>
           </div>
+        </div>
+      </div>
+
+      {/* 3. 割当済みキーワードブロック */}
+      <div className="bg-gray-50 p-4 border border-gray-200 rounded-lg shadow-sm">
+        <h3 className="sr-only">{FIELD_LABELS.KEYWORDS_SECTION_TITLE}</h3>
+        <div className="flex flex-wrap gap-2">
+          {bookmark.keywords.length > 0 ? (
+            bookmark.keywords.map((kw) => (
+              <span
+                key={kw.id}
+                className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 border border-blue-200"
+              >
+                {kw.name}
+              </span>
+            ))
+          ) : (
+            <span className="text-sm text-gray-400 italic">
+              {FIELD_LABELS.NO_KEYWORDS_ATTACHED}
+            </span>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 概要
詳細画面 (`BookmarkPage`) において、現在一つのブロックに混在している「キーワード追加フォーム」と「割当済みキーワード一覧」を、論理的・視覚的に独立したブロックに分離しました。

### 変更内容
- **第2ブロック**: キーワード追加フォーム（入力ボックス、追加ボタン）を独立。
- **第3ブロック**: 割当済みキーワード一覧（バッジ表示）を独立。
- 各ブロックに適切な余白とスタイリングを適用。