### PR TITLE
feat: D&D 可能なリスト表示の共通化 (DraggableList / DraggableItem) (#267)

### DIFF
--- a/shared/schemas/draggable.ts
+++ b/shared/schemas/draggable.ts
@@ -1,0 +1,3 @@
+export interface DraggableEntity {
+  id: string | number
+}

--- a/src/components/DraggableItem.tsx
+++ b/src/components/DraggableItem.tsx
@@ -1,0 +1,44 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import type {
+  DraggableAttributes,
+  DraggableSyntheticListeners,
+} from '@dnd-kit/core'
+import type { DraggableEntity } from '@shared/schemas/draggable'
+
+export type DraggableItemProps<T extends DraggableEntity> = {
+  item: T
+  children: (props: {
+    setNodeRef: (node: HTMLElement | null) => void
+    attributes: DraggableAttributes
+    listeners: DraggableSyntheticListeners
+    style: React.CSSProperties
+    isDragging: boolean
+  }) => React.ReactNode
+}
+
+export const DraggableItem = <T extends DraggableEntity>({
+  item,
+  children,
+}: DraggableItemProps<T>) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: item.id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 50 : undefined,
+    position: isDragging ? ('relative' as const) : undefined,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  return (
+    <>{children({ setNodeRef, attributes, listeners, style, isDragging })}</>
+  )
+}

--- a/src/components/DraggableList.test.tsx
+++ b/src/components/DraggableList.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '../test/utils'
+import { DraggableList } from './DraggableList'
+import { DraggableItem } from './DraggableItem'
+import * as sortable from '@dnd-kit/sortable'
+
+// DndContext をモック
+vi.mock('@dnd-kit/core', async () => {
+  const actual = await vi.importActual('@dnd-kit/core')
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragEnd,
+    }: {
+      children: React.ReactNode
+      onDragEnd: (event: {
+        active: { id: string | number }
+        over: { id: string | number } | null
+      }) => void
+    }) => (
+      <div
+        data-testid="dnd-context"
+        onClick={() => onDragEnd({ active: { id: '1' }, over: { id: '2' } })}
+      >
+        {children}
+      </div>
+    ),
+  }
+})
+
+// useSortable をモック可能にする
+vi.mock('@dnd-kit/sortable', async () => {
+  const actual = await vi.importActual('@dnd-kit/sortable')
+  return {
+    ...actual,
+    useSortable: vi.fn(),
+  }
+})
+
+describe('DraggableList', () => {
+  const mockItems = [
+    { id: '1', name: 'Item 1' },
+    { id: '2', name: 'Item 2' },
+  ]
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // デフォルトの useSortable の戻り値
+    vi.mocked(sortable.useSortable).mockReturnValue({
+      attributes: {},
+      listeners: {},
+      setNodeRef: () => {},
+      transform: null,
+      transition: null,
+      isDragging: false,
+    } as unknown as ReturnType<typeof sortable.useSortable>)
+  })
+
+  it('アイテムを正しくレンダリングできること', () => {
+    const onReorder = vi.fn()
+    render(
+      <DraggableList
+        items={mockItems}
+        onReorder={onReorder}
+        renderItem={(item) => (
+          <DraggableItem key={item.id} item={item}>
+            {({ setNodeRef, attributes, listeners, style }) => (
+              <div
+                ref={setNodeRef}
+                style={style}
+                {...attributes}
+                {...listeners}
+                data-testid={`item-${item.id}`}
+              >
+                {item.name}
+              </div>
+            )}
+          </DraggableItem>
+        )}
+      />,
+    )
+
+    expect(screen.getByTestId('item-1')).toHaveTextContent('Item 1')
+    expect(screen.getByTestId('item-2')).toHaveTextContent('Item 2')
+  })
+
+  it('ドラッグ終了時に onReorder が正しい引数で呼び出されること', () => {
+    const onReorder = vi.fn()
+    render(
+      <DraggableList
+        items={mockItems}
+        onReorder={onReorder}
+        renderItem={(item) => (
+          <DraggableItem key={item.id} item={item}>
+            {({ setNodeRef }) => <div ref={setNodeRef}>{item.name}</div>}
+          </DraggableItem>
+        )}
+      />,
+    )
+
+    const context = screen.getByTestId('dnd-context')
+    context.click()
+
+    expect(onReorder).toHaveBeenCalledWith('1', '2')
+  })
+
+  it('ドラッグ中のアイテムに適切なスタイルが適用されること (Branch Coverage用)', () => {
+    const onReorder = vi.fn()
+
+    // ID '1' のアイテムだけドラッグ中とする
+    vi.mocked(sortable.useSortable).mockImplementation(
+      ({ id }: { id: string | number }) =>
+        ({
+          attributes: {},
+          listeners: {},
+          setNodeRef: () => {},
+          transform: null,
+          transition: null,
+          isDragging: id === '1',
+        }) as unknown as ReturnType<typeof sortable.useSortable>,
+    )
+
+    render(
+      <DraggableList
+        items={mockItems}
+        onReorder={onReorder}
+        renderItem={(item) => (
+          <DraggableItem key={item.id} item={item}>
+            {({ setNodeRef, style }) => (
+              <div
+                ref={setNodeRef}
+                style={style}
+                data-testid={`item-${item.id}`}
+              >
+                {item.name}
+              </div>
+            )}
+          </DraggableItem>
+        )}
+      />,
+    )
+
+    const item1 = screen.getByTestId('item-1')
+    const item2 = screen.getByTestId('item-2')
+
+    // ドラッグ中のスタイルを確認
+    expect(item1.style.opacity).toBe('0.5')
+    expect(item1.style.zIndex).toBe('50')
+
+    // 非ドラッグ中のスタイルを確認
+    expect(item2.style.opacity).toBe('1')
+    expect(item2.style.zIndex).toBe('')
+  })
+})

--- a/src/components/DraggableList.tsx
+++ b/src/components/DraggableList.tsx
@@ -1,0 +1,60 @@
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import type { DragEndEvent } from '@dnd-kit/core'
+import type { DraggableEntity } from '@shared/schemas/draggable'
+
+export type DraggableListProps<T extends DraggableEntity> = {
+  items: T[]
+  onReorder: (activeId: string | number, overId: string | number) => void
+  renderItem: (item: T, index: number) => React.ReactNode
+  strategy?: typeof verticalListSortingStrategy
+}
+
+export const DraggableList = <T extends DraggableEntity>({
+  items,
+  onReorder,
+  renderItem,
+  strategy = verticalListSortingStrategy,
+}: DraggableListProps<T>) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 5,
+      },
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+
+    if (over && active.id !== over.id) {
+      onReorder(active.id, over.id)
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext items={items.map((i) => i.id)} strategy={strategy}>
+        {items.map((item, index) => renderItem(item, index))}
+      </SortableContext>
+    </DndContext>
+  )
+}


### PR DESCRIPTION
### 概要
ブックマークやキーワードなど、ドラッグ＆ドロップ（D&D）機能を伴うリスト表示を汎用的に扱うための共通基盤コンポーネントを作成しました。
これにより、複雑な D&D ロジックを一箇所に集約し、保守性と再利用性を向上させます。

### 変更内容
- **`shared/schemas/draggable.ts`**: 共通の `DraggableEntity` インターフェースを定義。
- **`src/components/DraggableList.tsx`**: `@dnd-kit` のコンテキスト管理とセンサー設定を集約した汎用リストコンポーネント。
- **`src/components/DraggableItem.tsx`**: 個々のアイテムの並び替えロジックをカプセル化したラッパーコンポーネント。Render Props パターンを採用し、表示内容の柔軟性を確保。
- **テスト**: 共通コンポーネントの基本的なレンダリングとプロパティ伝搬を確認するユニットテストを追加。

### 検証内容
- `npm run lint` パス。
- `npm run type-check:client` パス。
- `vitest src/components/DraggableList.test.tsx` パス。