### PR TITLE
feat(frontend): キーワード選択の UI 反映 (#289)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   API_PATHS,
+  ARIA_ATTRIBUTES,
   ARIA_ROLES,
   FIELD_LABELS,
   HTTP_STATUS,
@@ -253,5 +254,34 @@ describe('App Integration', () => {
       { timeout: 2000 },
     )
     expect(await screen.findByText(MOCK_BOOKMARK_2.title)).toBeInTheDocument()
+  })
+
+  describe('Keyword Selection', () => {
+    it('キーワードをクリックすると選択状態が切り替わり、複数選択が可能であること', async () => {
+      const { user } = setup()
+
+      // キーワード一覧が表示されるのを待機
+      const keyword1 = await screen.findByRole('button', {
+        name: MOCK_KEYWORDS[0].name,
+      })
+      const keyword2 = await screen.findByRole('button', {
+        name: MOCK_KEYWORDS[1].name,
+      })
+
+      // 1. キーワード1を選択
+      await user.click(keyword1)
+      expect(keyword1).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'true')
+      expect(keyword2).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'false')
+
+      // 2. キーワード2を追加選択 (複数選択)
+      await user.click(keyword2)
+      expect(keyword1).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'true')
+      expect(keyword2).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'true')
+
+      // 3. キーワード1を解除
+      await user.click(keyword1)
+      expect(keyword1).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'false')
+      expect(keyword2).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'true')
+    })
   })
 })

--- a/src/components/KeywordItem.test.tsx
+++ b/src/components/KeywordItem.test.tsx
@@ -69,4 +69,29 @@ describe('KeywordItem', () => {
     const button = screen.getByRole(ARIA_ROLES.BUTTON)
     expect(listItem).toContainElement(button)
   })
+
+  describe('スタイル制御', () => {
+    it('isSelected が false の時、デフォルトのスタイルが適用されること', () => {
+      render(<KeywordItem {...defaultProps} isSelected={false} />)
+      const button = screen.getByRole(ARIA_ROLES.BUTTON)
+      // デフォルトの背景色クラス
+      expect(button).toHaveClass('bg-gray-100')
+      // 太字ではないこと
+      expect(screen.getByText(mockKeyword.name)).not.toHaveClass('font-bold')
+    })
+
+    it('isSelected が true の時、選択中のスタイル（青背景・白文字）が適用され、太字が解除されること', () => {
+      render(<KeywordItem {...defaultProps} isSelected={true} />)
+      const button = screen.getByRole(ARIA_ROLES.BUTTON)
+      const nameElement = screen.getByText(mockKeyword.name)
+
+      // 選択時のクラス
+      expect(button).toHaveClass('bg-blue-600')
+      expect(button).toHaveClass('text-white')
+      // デフォルトの背景色が解除されていること
+      expect(button).not.toHaveClass('bg-gray-100')
+      // 太字が解除されていること
+      expect(nameElement).not.toHaveClass('font-bold')
+    })
+  })
 })

--- a/src/components/KeywordItem.tsx
+++ b/src/components/KeywordItem.tsx
@@ -33,14 +33,17 @@ export const KeywordItem = memo(
     style,
     isDragging = false,
   }: KeywordItemProps) => {
-    // BookmarkItem とデザインを合わせつつ、キーワード用の配色を適用（例：グレー背景）
-    const itemClassName = `flex items-center transition-colors cursor-pointer hover:bg-gray-200 bg-gray-100 text-sm text-left text-gray-900 select-none group border-b border-gray-300 ${
+    // 選択状態に応じたスタイル。選択時は青背景、未選択時はグレー背景。
+    const bgColorClass = isSelected
+      ? 'bg-blue-600 text-white hover:bg-blue-700'
+      : 'bg-gray-100 text-gray-900 hover:bg-gray-200'
+
+    const itemClassName = `flex items-center transition-colors cursor-pointer text-sm text-left select-none group border-b border-gray-300 ${bgColorClass} ${
       isDragging ? 'shadow-lg' : ''
     }`
 
-    const contentClassName = `flex-1 px-2 py-1 truncate ${
-      isSelected ? 'font-bold' : ''
-    }`
+    // 選択時に bold にするスタイルは削除 (要件に従い)
+    const contentClassName = 'flex-1 px-2 py-1 truncate'
 
     return (
       <div ref={setNodeRef} style={style} role={ARIA_ROLES.LISTITEM}>
@@ -61,7 +64,9 @@ export const KeywordItem = memo(
         >
           {/* ドラッグハンドル */}
           <div
-            className="w-8 h-full flex items-center justify-center px-2 cursor-grab active:cursor-grabbing text-gray-400 hover:text-blue-600 transition-colors"
+            className={`w-8 h-full flex items-center justify-center px-2 cursor-grab active:cursor-grabbing transition-colors ${
+              isSelected ? 'text-blue-200' : 'text-gray-400 hover:text-blue-600'
+            }`}
             {...attributes}
             {...listeners}
             onClick={(e) => e.stopPropagation()}

--- a/src/components/KeywordList.test.tsx
+++ b/src/components/KeywordList.test.tsx
@@ -1,31 +1,26 @@
 import { describe, it, expect, vi } from 'vitest'
-import { ARIA_ROLES, UI_MESSAGES } from '@shared/constants'
+import { ARIA_ATTRIBUTES, ARIA_ROLES, UI_MESSAGES } from '@shared/constants'
 import { render, screen } from '../test/utils'
 import { KeywordList } from './KeywordList'
-import type { Keyword, KeywordId } from '@shared/schemas/keyword'
+import { MOCK_KEYWORDS } from '@shared/test/fixtures'
 
 describe('KeywordList', () => {
-  const mockKeywords: Keyword[] = [
-    { id: '1' as KeywordId, name: 'Keyword 1' },
-    { id: '2' as KeywordId, name: 'Keyword 2' },
-  ]
-
   const defaultProps = {
-    keywords: mockKeywords,
+    keywords: MOCK_KEYWORDS,
     onKeywordClick: vi.fn(),
     onReorder: vi.fn(),
   }
 
   it('キーワード一覧が正常に表示されること', () => {
     render(<KeywordList {...defaultProps} />)
-    expect(screen.getByText('Keyword 1')).toBeInTheDocument()
-    expect(screen.getByText('Keyword 2')).toBeInTheDocument()
+    expect(screen.getByText(MOCK_KEYWORDS[0].name)).toBeInTheDocument()
+    expect(screen.getByText(MOCK_KEYWORDS[1].name)).toBeInTheDocument()
 
     const list = screen.getByRole(ARIA_ROLES.LIST)
     expect(list).toBeInTheDocument()
 
     const items = screen.getAllByRole(ARIA_ROLES.LISTITEM)
-    expect(items).toHaveLength(2)
+    expect(items).toHaveLength(MOCK_KEYWORDS.length)
   })
 
   it('キーワードがない場合に適切なメッセージが表示されること', () => {
@@ -33,5 +28,20 @@ describe('KeywordList', () => {
     expect(
       screen.getByText(UI_MESSAGES.NO_KEYWORDS_AVAILABLE),
     ).toBeInTheDocument()
+  })
+
+  it('selectedKeywordIds で指定された複数のキーワードが選択状態として描画されること', () => {
+    const selectedKeywordIds = [MOCK_KEYWORDS[0].id, MOCK_KEYWORDS[1].id]
+    render(
+      <KeywordList {...defaultProps} selectedKeywordIds={selectedKeywordIds} />,
+    )
+
+    // aria-selected 属性を持つボタン要素を取得
+    const items = screen.getAllByRole('button')
+    // ドラッグハンドルもボタンに含まれる可能性があるため、フィルタリングまたは数を確認
+    const selectedItems = items.filter(
+      (item) => item.getAttribute(ARIA_ATTRIBUTES.SELECTED) === 'true',
+    )
+    expect(selectedItems).toHaveLength(2)
   })
 })

--- a/src/components/KeywordList.tsx
+++ b/src/components/KeywordList.tsx
@@ -7,7 +7,7 @@ import type { Keyword, KeywordId } from '@shared/schemas/keyword'
 
 interface KeywordListProps {
   keywords: Keyword[]
-  selectedId?: KeywordId | null
+  selectedKeywordIds?: KeywordId[]
   onKeywordClick?: (id: KeywordId) => void
   onReorder?: (activeId: KeywordId, overId: KeywordId) => void
   onClose?: () => void
@@ -16,7 +16,7 @@ interface KeywordListProps {
 
 export const KeywordList = ({
   keywords,
-  selectedId,
+  selectedKeywordIds,
   onKeywordClick,
   onReorder,
   onClose,
@@ -44,10 +44,10 @@ export const KeywordList = ({
             {(dndProps) => (
               <KeywordItem
                 keyword={keyword}
-                isSelected={selectedId === keyword.id}
+                isSelected={selectedKeywordIds?.includes(keyword.id) ?? false}
                 isFocusable={
-                  selectedId === keyword.id ||
-                  (selectedId === null && index === 0)
+                  (selectedKeywordIds?.includes(keyword.id) ?? false) ||
+                  (selectedKeywordIds?.length === 0 && index === 0)
                 }
                 onClick={onKeywordClick ?? (() => {})}
                 onClose={onClose}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -12,12 +12,14 @@ export function HomePage({ appState }: HomePageProps) {
     bookmarks,
     keywords,
     selectedId,
+    selectedKeywordIds,
     isLoading,
     error,
     handleRowClick,
     handleOpen,
     handleClose,
     handleReorder,
+    toggleKeywordSelection,
   } = appState
 
   return (
@@ -30,7 +32,11 @@ export function HomePage({ appState }: HomePageProps) {
               {FIELD_LABELS.KEYWORDS_HEADING}
             </h2>
             <div className="flex-1 overflow-y-auto">
-              <KeywordList keywords={keywords} />
+              <KeywordList
+                keywords={keywords}
+                selectedKeywordIds={selectedKeywordIds}
+                onKeywordClick={toggleKeywordSelection}
+              />
             </div>
           </aside>
 


### PR DESCRIPTION
### 概要
ブックマーク一覧画面のサイドバーにおいて、キーワードをクリックして選択・解除（トグル）し、その状態を視覚的に表示する機能を実装しました。
これは将来的な AND 検索によるフィルタリング機能の UI 基盤となります。

### 変更内容
- **UI/スタイル**: `KeywordItem` の選択状態の配色を変更（青背景・白文字）。
- **コンポーネント**: `KeywordList` を単一選択から複数選択 (`selectedKeywordIds`) 対応に拡張。
- **統合**: `HomePage` でロジックと UI を接続。
- **テスト**: 複数選択の挙動を検証するテスト（結合テストおよびユニットテスト）を追加。

Closes #289