### PR TITLE
chore: Dependabot の自動リベースを無効化 (#299)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'Asia/Tokyo'
+    rebase-strategy: 'disabled'
     open-pull-requests-limit: 10
     groups:
       npm-dependencies:


### PR DESCRIPTION
### 概要
Dependabot による PR の自動的な上書き（リベース・強制プッシュ）を無効化しました。

### 変更内容
- `rebase-strategy: disabled` を設定に追加。

### 背景
新バージョンがリリースされた際やベースブランチが更新された際に、検証中の PR が意図せず上書きされるのを防ぐためです。リベースが必要な場合は、手動で `@dependabot rebase` をコメントすることで実行可能です。