### PR TITLE
refactor: キーボード操作に使用するキー名を定数化 (#305)

### DIFF
--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -387,3 +387,14 @@ export const VALIDATION_MESSAGES = {
   REORDER_MAX_ITEMS: '一度に並び替えられるのは1000件までです',
   REORDER_DUPLICATE_IDS: 'IDリストに重複が含まれています',
 } as const
+
+/**
+ * キーボードのキー名定数
+ */
+export const KEY_VALUES = {
+  ENTER: 'Enter',
+  ESCAPE: 'Escape',
+  SPACE: ' ',
+  ARROW_UP: 'ArrowUp',
+  ARROW_DOWN: 'ArrowDown',
+} as const

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -9,6 +9,7 @@ import {
   FIELD_LABELS,
   HTTP_STATUS,
   DEFAULT_API_URL,
+  KEY_VALUES,
 } from '@shared/constants'
 import {
   MOCK_BOOKMARK_1,
@@ -337,7 +338,7 @@ describe('App Integration', () => {
       expect(keywordBtn1).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'true')
 
       // 2. Enter キーを押下
-      fireEvent.keyDown(window, { key: 'Enter' })
+      fireEvent.keyDown(window, { key: KEY_VALUES.ENTER })
 
       // 3. 一括起動の検証
       expect(window.open).toHaveBeenCalledTimes(2)
@@ -363,7 +364,7 @@ describe('App Integration', () => {
       expect(keyword2).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'true')
 
       // 2. Escape キーを押下
-      fireEvent.keyDown(window, { key: 'Escape' })
+      fireEvent.keyDown(window, { key: KEY_VALUES.ESCAPE })
 
       // 3. 全ての選択が解除されていることを検証
       expect(keyword1).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'false')

--- a/src/components/BookmarkItem.test.tsx
+++ b/src/components/BookmarkItem.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { ARIA_ATTRIBUTES, ARIA_ROLES, HTML_ATTRIBUTES } from '@shared/constants'
+import {
+  ARIA_ATTRIBUTES,
+  ARIA_ROLES,
+  HTML_ATTRIBUTES,
+  KEY_VALUES,
+} from '@shared/constants'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
 import { render, screen } from '../test/utils'
 import userEvent from '@testing-library/user-event'
@@ -56,7 +61,7 @@ describe('BookmarkItem', () => {
         name: new RegExp(MOCK_BOOKMARK_1.title),
       })
       item.focus()
-      await user.keyboard('{Enter}')
+      await user.keyboard(`{${KEY_VALUES.ENTER}}`)
       expect(onOpen).toHaveBeenCalled()
     })
 
@@ -71,7 +76,7 @@ describe('BookmarkItem', () => {
         name: new RegExp(MOCK_BOOKMARK_1.title),
       })
       item.focus()
-      await user.keyboard('{Enter}')
+      await user.keyboard(`{${KEY_VALUES.ENTER}}`)
       expect(onOpen).not.toHaveBeenCalled()
     })
 
@@ -84,7 +89,7 @@ describe('BookmarkItem', () => {
         name: new RegExp(MOCK_BOOKMARK_1.title),
       })
       item.focus()
-      await user.keyboard(' ')
+      await user.keyboard(KEY_VALUES.SPACE)
       expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
     })
 
@@ -97,7 +102,7 @@ describe('BookmarkItem', () => {
         name: new RegExp(MOCK_BOOKMARK_1.title),
       })
       item.focus()
-      await user.keyboard('{Escape}')
+      await user.keyboard(`{${KEY_VALUES.ESCAPE}}`)
       expect(onClose).toHaveBeenCalled()
     })
 

--- a/src/components/BookmarkItem.tsx
+++ b/src/components/BookmarkItem.tsx
@@ -1,5 +1,10 @@
 import { memo } from 'react'
-import { ARIA_ROLES, ARIA_ATTRIBUTES, HTML_ATTRIBUTES } from '@shared/constants'
+import {
+  ARIA_ROLES,
+  ARIA_ATTRIBUTES,
+  HTML_ATTRIBUTES,
+  KEY_VALUES,
+} from '@shared/constants'
 import type {
   DraggableAttributes,
   DraggableSyntheticListeners,
@@ -53,12 +58,12 @@ export const BookmarkItem = memo(
           {...{ [ARIA_ATTRIBUTES.SELECTED]: isSelected }}
           onClick={() => onRowClick(bookmark.id)}
           onKeyDown={(e) => {
-            if (e.key === 'Enter' && isSelected) {
+            if (e.key === KEY_VALUES.ENTER && isSelected) {
               onOpen()
-            } else if (e.key === ' ') {
+            } else if (e.key === KEY_VALUES.SPACE) {
               e.preventDefault()
               onRowClick(bookmark.id)
-            } else if (e.key === 'Escape') {
+            } else if (e.key === KEY_VALUES.ESCAPE) {
               onClose()
             }
           }}

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -8,6 +8,7 @@ import {
   UI_MESSAGES,
   TEST_MESSAGES,
   ERROR_MESSAGES,
+  KEY_VALUES,
 } from '@shared/constants'
 import {
   MOCK_BOOKMARK_1,
@@ -199,7 +200,7 @@ describe('BookmarkList', () => {
     })
 
     items[1]!.focus()
-    await user.keyboard('{Enter}')
+    await user.keyboard(`{${KEY_VALUES.ENTER}}`)
 
     expect(onOpen).toHaveBeenCalled()
   })
@@ -212,7 +213,8 @@ describe('BookmarkList', () => {
     const items = screen.getAllByRole(ARIA_ROLES.BUTTON, {
       name: new RegExp(MOCK_BOOKMARK_TITLE_PREFIX),
     })
-    await user.type(items[0]!, ' ')
+    items[0]!.focus()
+    await user.keyboard(KEY_VALUES.SPACE)
     expect(onRowClick).toHaveBeenCalledWith(MOCK_BOOKMARK_1.id)
   })
 

--- a/src/components/KeywordItem.test.tsx
+++ b/src/components/KeywordItem.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { ARIA_ROLES } from '@shared/constants'
+import { ARIA_ROLES, KEY_VALUES } from '@shared/constants'
 import { render, screen } from '../test/utils'
 import userEvent from '@testing-library/user-event'
 import type { DraggableAttributes } from '@dnd-kit/core'
@@ -47,7 +47,7 @@ describe('KeywordItem', () => {
 
     const item = screen.getByRole(ARIA_ROLES.BUTTON)
     item.focus()
-    await user.keyboard(' ')
+    await user.keyboard(KEY_VALUES.SPACE)
     expect(onClick).toHaveBeenCalledWith(mockKeyword.id)
   })
 
@@ -58,7 +58,7 @@ describe('KeywordItem', () => {
 
     const item = screen.getByRole(ARIA_ROLES.BUTTON)
     item.focus()
-    await user.keyboard('{Enter}')
+    await user.keyboard(`{${KEY_VALUES.ENTER}}`)
     expect(onClick).not.toHaveBeenCalled()
   })
 
@@ -69,7 +69,7 @@ describe('KeywordItem', () => {
 
     const item = screen.getByRole(ARIA_ROLES.BUTTON)
     item.focus()
-    await user.keyboard('{Escape}')
+    await user.keyboard(`{${KEY_VALUES.ESCAPE}}`)
     expect(onClose).toHaveBeenCalled()
   })
 

--- a/src/components/KeywordItem.tsx
+++ b/src/components/KeywordItem.tsx
@@ -1,5 +1,10 @@
 import { memo } from 'react'
-import { ARIA_ROLES, ARIA_ATTRIBUTES, HTML_ATTRIBUTES } from '@shared/constants'
+import {
+  ARIA_ROLES,
+  ARIA_ATTRIBUTES,
+  HTML_ATTRIBUTES,
+  KEY_VALUES,
+} from '@shared/constants'
 import type {
   DraggableAttributes,
   DraggableSyntheticListeners,
@@ -59,13 +64,13 @@ export const KeywordItem = memo(
             }
           }}
           onKeyDown={(e) => {
-            if (e.key === ' ') {
+            if (e.key === KEY_VALUES.SPACE) {
               // Space キーで選択（トグル）
               e.preventDefault()
               onClick(keyword.id)
-            } else if (e.key === 'Escape') {
+            } else if (e.key === KEY_VALUES.ESCAPE) {
               onClose?.()
-            } else if (e.key === 'Enter') {
+            } else if (e.key === KEY_VALUES.ENTER) {
               // Enter キーによるブラウザ標準の合成クリック発火を防止
               // これにより、HomePage の一括起動のみが実行されるようになる
               e.preventDefault()

--- a/src/hooks/useBookmarkPage.test.ts
+++ b/src/hooks/useBookmarkPage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act, waitFor } from '../test/utils'
 import { createDragStartEvent, createDragEndEvent } from '../test/dnd-utils'
+import { createKeyboardEvent } from '../test/event-utils'
 import { useBookmarkPage } from './useBookmarkPage'
 import { MOCK_BOOKMARK_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
 import { http, HttpResponse, delay } from 'msw'
@@ -10,6 +11,7 @@ import {
   HTTP_STATUS,
   LOG_MESSAGES,
   DROPPABLE_IDS,
+  KEY_VALUES,
 } from '@shared/constants'
 import { fireEvent } from '@testing-library/react'
 import * as urlUtils from '@shared/utils/url'
@@ -172,11 +174,7 @@ describe('useBookmarkPage Hook', () => {
     })
 
     act(() => {
-      const event = {
-        key: 'Enter',
-        shiftKey: false,
-        preventDefault: vi.fn(),
-      } as unknown as React.KeyboardEvent
+      const event = createKeyboardEvent(KEY_VALUES.ENTER)
       result.current.handleKeywordKeyDown(event)
     })
 
@@ -328,7 +326,7 @@ describe('useBookmarkPage Hook', () => {
     it('Escape キーで handleBack が呼ばれること', async () => {
       renderHook(() => useBookmarkPage())
 
-      fireEvent.keyDown(window, { key: 'Escape' })
+      fireEvent.keyDown(window, { key: KEY_VALUES.ESCAPE })
       expect(mockNavigate).toHaveBeenCalledWith(APP_PATHS.HOME)
     })
 
@@ -336,7 +334,7 @@ describe('useBookmarkPage Hook', () => {
       const { result } = renderHook(() => useBookmarkPage())
       await waitFor(() => expect(result.current.bookmark).not.toBeUndefined())
 
-      fireEvent.keyDown(window, { key: 'Enter' })
+      fireEvent.keyDown(window, { key: KEY_VALUES.ENTER })
       expect(urlUtils.openUrlInNewTab).toHaveBeenCalledWith(MOCK_BOOKMARK_1.url)
     })
 
@@ -352,7 +350,7 @@ describe('useBookmarkPage Hook', () => {
       const { result } = renderHook(() => useBookmarkPage())
       await waitFor(() => expect(result.current.bookmark).not.toBeUndefined())
 
-      fireEvent.keyDown(window, { key: 'Enter', ctrlKey: true })
+      fireEvent.keyDown(window, { key: KEY_VALUES.ENTER, ctrlKey: true })
 
       await waitFor(() => expect(patchCalled).toBe(true))
     })

--- a/src/hooks/useBookmarkPage.ts
+++ b/src/hooks/useBookmarkPage.ts
@@ -5,6 +5,7 @@ import {
   LOG_MESSAGES,
   DROPPABLE_IDS,
   ELEMENT_IDS,
+  KEY_VALUES,
 } from '@shared/constants'
 import { BookmarkIdSchema } from '@shared/schemas/bookmark'
 import {
@@ -176,7 +177,7 @@ export const useBookmarkPage = (onBack?: () => void) => {
 
   const handleKeywordKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
+      if (e.key === KEY_VALUES.ENTER && !e.shiftKey) {
         e.preventDefault()
         handleAddKeyword()
       }
@@ -237,9 +238,9 @@ export const useBookmarkPage = (onBack?: () => void) => {
   // 5. キーボードショートカット
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
+      if (e.key === KEY_VALUES.ESCAPE) {
         handleBack()
-      } else if (e.key === 'Enter') {
+      } else if (e.key === KEY_VALUES.ENTER) {
         if (e.metaKey || e.ctrlKey) {
           handleUpdate()
         } else if (

--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -8,6 +8,7 @@ import {
   FIELD_LABELS,
   LOG_MESSAGES,
   UI_MESSAGES,
+  KEY_VALUES,
 } from '@shared/constants'
 import { updateBookmarkSchema } from '@shared/schemas/bookmark'
 import { MOCK_BOOKMARK_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
@@ -289,7 +290,7 @@ describe('BookmarkPage Component', () => {
 
     const input = await screen.findByLabelText(FIELD_LABELS.ADD_KEYWORD_LABEL)
     fireEvent.change(input, { target: { value: 'EnterTag' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.keyDown(input, { key: KEY_VALUES.ENTER })
 
     await waitFor(() => expect(createCalled).toBe(true))
   })
@@ -414,7 +415,7 @@ describe('BookmarkPage Component', () => {
       )
       await screen.findByLabelText(FIELD_LABELS.TITLE)
 
-      fireEvent.keyDown(window, { key: 'Enter' })
+      fireEvent.keyDown(window, { key: KEY_VALUES.ENTER })
 
       await waitFor(() => {
         expect(urlUtils.openUrlInNewTab).toHaveBeenCalledWith(
@@ -430,7 +431,7 @@ describe('BookmarkPage Component', () => {
       )
       await screen.findByLabelText(FIELD_LABELS.TITLE)
 
-      fireEvent.keyDown(window, { key: 'Escape' })
+      fireEvent.keyDown(window, { key: KEY_VALUES.ESCAPE })
       expect(await screen.findByText('Home')).toBeInTheDocument()
     })
   })

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import { FIELD_LABELS } from '@shared/constants'
+import { FIELD_LABELS, KEY_VALUES } from '@shared/constants'
 import { BookmarkList } from '../components/BookmarkList'
 import { KeywordList } from '../components/KeywordList'
 import { useApp } from '../hooks/useApp'
@@ -28,7 +28,7 @@ export function HomePage({ appState }: HomePageProps) {
   // キーボードショートカットの設定
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Enter') {
+      if (e.key === KEY_VALUES.ENTER) {
         // 入力フィールド（キーワード入力欄など）にフォーカスがある場合は、そちらを優先
         if (
           e.target instanceof HTMLInputElement ||
@@ -45,7 +45,7 @@ export function HomePage({ appState }: HomePageProps) {
         }
 
         handleOpen()
-      } else if (e.key === 'Escape') {
+      } else if (e.key === KEY_VALUES.ESCAPE) {
         // キーワードが選択されている場合、Escape で全解除
         if (selectedKeywordIds.length > 0) {
           e.preventDefault()

--- a/src/test/event-utils.ts
+++ b/src/test/event-utils.ts
@@ -1,0 +1,22 @@
+import { vi } from 'vitest'
+import type React from 'react'
+
+/**
+ * テスト用の KeyboardEvent を作成するユーティリティ
+ * 型アサーションをこの関数内に封じ込めることで、テストコードの可読性と保守性を向上させる
+ */
+export const createKeyboardEvent = (
+  key: string,
+  options: Partial<React.KeyboardEvent> = {},
+): React.KeyboardEvent => {
+  return {
+    key,
+    shiftKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    ...options,
+  } as unknown as React.KeyboardEvent
+}


### PR DESCRIPTION
### 概要
プロジェクト全体で使用されているキーボードのキー名（'Enter', 'Escape' 等）を定数化し、マジックストリングを排除しました。

### 変更内容
- `shared/constants.ts` に `KEY_VALUES` 定数を定義。
- 実装コードおよびテストコード内の該当箇所をすべて置換。

### 効果
- タイポの防止。
- キー名の一元管理による保守性の向上。

Closes #305