### PR TITLE
feat(frontend): URL クエリパラメータからキーワード選択状態を復元する (#307)

### DIFF
--- a/src/hooks/useKeywordListState.test.ts
+++ b/src/hooks/useKeywordListState.test.ts
@@ -2,29 +2,49 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '../test/utils'
 import { useKeywordListState } from './useKeywordListState'
 import { KeywordIdSchema } from '@shared/schemas/keyword'
+import { useState } from 'react'
 
-// react-router-dom のモックを改善（状態を持たせ、関数型更新に対応）
-let currentParams = new URLSearchParams()
-const mockSetSearchParams = vi.fn((next) => {
-  if (typeof next === 'function') {
-    currentParams = next(currentParams)
-  } else {
-    currentParams = new URLSearchParams(next)
-  }
-})
+// URLSearchParams の状態を外部から覗き見るための変数
+let capturedParams = new URLSearchParams()
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom')
   return {
     ...actual,
-    useSearchParams: () => [currentParams, mockSetSearchParams],
+    useSearchParams: () => {
+      const [params, setParams] = useState(() => {
+        const initialParams = new URLSearchParams(window.location.search)
+        capturedParams = initialParams
+        return initialParams
+      })
+      const updateParams = (
+        next:
+          | string
+          | URLSearchParams
+          | ((prev: URLSearchParams) => URLSearchParams),
+      ) => {
+        if (typeof next === 'function') {
+          setParams((prev: URLSearchParams) => {
+            const nextParams = next(new URLSearchParams(prev))
+            capturedParams = nextParams
+            return nextParams
+          })
+        } else {
+          const nextParams = new URLSearchParams(next)
+          capturedParams = nextParams
+          setParams(nextParams)
+        }
+      }
+      return [params, updateParams]
+    },
   }
 })
 
 describe('useKeywordListState', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    currentParams = new URLSearchParams()
+    vi.stubGlobal('location', { search: '' })
+    capturedParams = new URLSearchParams()
   })
 
   it('初期状態では選択キーワードは空であること', () => {
@@ -32,98 +52,71 @@ describe('useKeywordListState', () => {
     expect(result.current.selectedKeywordIds).toEqual([])
   })
 
-  it('クリックでキーワードが選択され、再度クリックで解除されること', () => {
+  it('URL に keywords パラメータがある場合、初期化時に復元されること', () => {
+    vi.stubGlobal('location', { search: '?keywords=1,2' })
+    const { result } = renderHook(() => useKeywordListState())
+
+    expect(result.current.selectedKeywordIds).toEqual([
+      KeywordIdSchema.parse('1'),
+      KeywordIdSchema.parse('2'),
+    ])
+  })
+
+  it('不正な形式の ID が URL に含まれている場合、無視して正常なものだけ復元されること', () => {
+    vi.stubGlobal('location', { search: '?keywords=1,, ,invalid!' })
+    const { result } = renderHook(() => useKeywordListState())
+
+    expect(result.current.selectedKeywordIds).toEqual([
+      KeywordIdSchema.parse('1'),
+    ])
+  })
+
+  it('クリックでキーワードが選択され、再度クリックで解除されること', async () => {
     const { result } = renderHook(() => useKeywordListState())
     const keywordId = KeywordIdSchema.parse('1')
 
-    // 選択
-    act(() => {
+    await act(async () => {
       result.current.toggleKeywordSelection(keywordId)
     })
     expect(result.current.selectedKeywordIds).toContain(keywordId)
+    expect(capturedParams.get('keywords')).toBe('1')
 
-    // 解除
-    act(() => {
+    await act(async () => {
       result.current.toggleKeywordSelection(keywordId)
     })
     expect(result.current.selectedKeywordIds).not.toContain(keywordId)
+    expect(capturedParams.has('keywords')).toBe(false)
   })
 
-  it('複数のキーワードを選択・解除できること', () => {
+  it('複数のキーワードを選択した際、カンマ区切りで URL パラメータに反映されること', async () => {
     const { result } = renderHook(() => useKeywordListState())
     const id1 = KeywordIdSchema.parse('1')
     const id2 = KeywordIdSchema.parse('2')
 
-    act(() => {
+    await act(async () => {
       result.current.toggleKeywordSelection(id1)
+    })
+    await act(async () => {
       result.current.toggleKeywordSelection(id2)
     })
+
     expect(result.current.selectedKeywordIds).toEqual([id1, id2])
-
-    act(() => {
-      result.current.toggleKeywordSelection(id1)
-    })
-    expect(result.current.selectedKeywordIds).toEqual([id2])
+    expect(capturedParams.get('keywords')).toBe('1,2')
   })
 
-  it('clearKeywordSelection で全ての選択が解除されること', () => {
+  it('clearKeywordSelection で全ての選択が解除され、URL からも削除されること', async () => {
     const { result } = renderHook(() => useKeywordListState())
     const id1 = KeywordIdSchema.parse('1')
-    const id2 = KeywordIdSchema.parse('2')
 
-    act(() => {
+    await act(async () => {
       result.current.toggleKeywordSelection(id1)
-      result.current.toggleKeywordSelection(id2)
     })
-    expect(result.current.selectedKeywordIds).toHaveLength(2)
+    expect(capturedParams.has('keywords')).toBe(true)
 
-    act(() => {
+    await act(async () => {
       result.current.clearKeywordSelection()
     })
     expect(result.current.selectedKeywordIds).toEqual([])
-  })
-
-  it('キーワードを選択した際、URLのクエリパラメータ（keywords）が更新されること', () => {
-    const { result } = renderHook(() => useKeywordListState())
-    const id1 = KeywordIdSchema.parse('1')
-
-    act(() => {
-      result.current.toggleKeywordSelection(id1)
-    })
-
-    // setSearchParams が呼ばれ、正しい値がセットされていることを確認
-    expect(mockSetSearchParams).toHaveBeenCalled()
-    expect(currentParams.get('keywords')).toBe('1')
-  })
-
-  it('複数のキーワードを選択した際、カンマ区切りで URL パラメータに反映されること', () => {
-    const { result } = renderHook(() => useKeywordListState())
-    const id1 = KeywordIdSchema.parse('1')
-    const id2 = KeywordIdSchema.parse('2')
-
-    act(() => {
-      result.current.toggleKeywordSelection(id1)
-    })
-    act(() => {
-      result.current.toggleKeywordSelection(id2)
-    })
-
-    expect(currentParams.get('keywords')).toBe('1,2')
-  })
-
-  it('キーワードを全解除した際、URL パラメータから keywords が削除されること', () => {
-    const { result } = renderHook(() => useKeywordListState())
-    const id1 = KeywordIdSchema.parse('1')
-
-    act(() => {
-      result.current.toggleKeywordSelection(id1)
-    })
-    expect(currentParams.has('keywords')).toBe(true)
-
-    act(() => {
-      result.current.clearKeywordSelection()
-    })
-
-    expect(currentParams.has('keywords')).toBe(false)
+    expect(capturedParams.has('keywords')).toBe(false)
   })
 })

--- a/src/hooks/useKeywordListState.ts
+++ b/src/hooks/useKeywordListState.ts
@@ -1,47 +1,80 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { KeywordIdSchema } from '@shared/schemas/keyword'
 import type { KeywordId } from '@shared/schemas/keyword'
 
 /**
+ * URL クエリパラメータからキーワード ID 配列を抽出・検証する
+ */
+const getIdsFromParams = (params: URLSearchParams): KeywordId[] => {
+  const keywordsStr = params.get('keywords')
+  if (!keywordsStr) return []
+
+  return keywordsStr.split(',').flatMap((id) => {
+    const trimmedId = id.trim()
+    if (!trimmedId) return []
+    const result = KeywordIdSchema.safeParse(trimmedId)
+    return result.success ? [result.data] : []
+  })
+}
+
+/**
  * キーワードの選択状態を管理するカスタムフック
+ * URL クエリパラメータを「唯一の正（Source of Truth）」として管理する
  */
 export const useKeywordListState = () => {
-  const [, setSearchParams] = useSearchParams()
-  const [selectedKeywordIds, setSelectedKeywordIds] = useState<KeywordId[]>([])
+  const [searchParams, setSearchParams] = useSearchParams()
 
-  // 選択状態が変化した際、URL クエリパラメータに反映する (State -> URL)
-  useEffect(() => {
-    setSearchParams(
-      (prevParams) => {
-        const nextParams = new URLSearchParams(prevParams)
+  // 1. URL パラメータから現在の選択状態を算出
+  const selectedKeywordIds = useMemo(
+    () => getIdsFromParams(searchParams),
+    [searchParams],
+  )
 
-        if (selectedKeywordIds.length > 0) {
-          nextParams.set('keywords', selectedKeywordIds.join(','))
+  // 2. URL パラメータを更新する内部共通ヘルパー (関数型更新パターン)
+  // updater には現在の ID 配列が渡され、新しい ID 配列を返すことを期待する
+  const updateSelectedIds = useCallback(
+    (updater: (currentIds: KeywordId[]) => KeywordId[]) => {
+      setSearchParams(
+        (prevParams) => {
+          const currentIds = getIdsFromParams(prevParams)
+          const nextIds = updater(currentIds)
+          const nextParams = new URLSearchParams(prevParams)
+          const nextIdsStr = nextIds.join(',')
+
+          if (nextIdsStr) {
+            nextParams.set('keywords', nextIdsStr)
+          } else {
+            nextParams.delete('keywords')
+          }
+          return nextParams
+        },
+        { replace: true },
+      )
+    },
+    [setSearchParams],
+  )
+
+  // 3. キーワードの選択・解除
+  const toggleKeywordSelection = useCallback(
+    (id: KeywordId) => {
+      updateSelectedIds((currentIds) => {
+        const next = new Set(currentIds)
+        if (next.has(id)) {
+          next.delete(id)
         } else {
-          nextParams.delete('keywords')
+          next.add(id)
         }
+        return Array.from(next).sort((a, b) => a.localeCompare(b))
+      })
+    },
+    [updateSelectedIds],
+  )
 
-        return nextParams
-      },
-      { replace: true },
-    )
-  }, [selectedKeywordIds, setSearchParams])
-
-  const toggleKeywordSelection = useCallback((id: KeywordId) => {
-    setSelectedKeywordIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(id)) {
-        next.delete(id)
-      } else {
-        next.add(id)
-      }
-      return Array.from(next)
-    })
-  }, [])
-
+  // 4. 全解除
   const clearKeywordSelection = useCallback(() => {
-    setSelectedKeywordIds([])
-  }, [])
+    updateSelectedIds(() => [])
+  }, [updateSelectedIds])
 
   return { selectedKeywordIds, toggleKeywordSelection, clearKeywordSelection }
 }


### PR DESCRIPTION
### 概要
URL クエリパラメータ（`?keywords=1,2`）とキーワードの選択状態を双方向に同期し、ページロードやブラウザ操作時に状態を復元できるようにしました。

### 変更内容
- **リファクタリング**: `useKeywordListState` を URL 駆動（URLSearchParams を唯一の正とする）設計に変更。
- **復元**: 初期化時および `searchParams` 変化時にクエリをパースして選択状態に反映。
- **堅牢性**: 不正な ID を Zod でバリデーションして排除。
- **テスト**: `useState` を組み込んだ高度な `useSearchParams` モックを導入し、複雑な同期挙動を検証。

Closes #307