### PR TITLE
refactor: テストおよびコンポーネントにおける ARIA ロール指定の定数化 (#316)

### DIFF
--- a/extension/src/Options.test.tsx
+++ b/extension/src/Options.test.tsx
@@ -1,13 +1,16 @@
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { Options } from './Options'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import {
+  ARIA_ROLES,
   DEFAULT_API_URL,
   FIELD_LABELS,
   UI_STATUS,
 } from '@shared/constants'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
 import { useOptions } from './hooks/useOptions'
+import { Options } from './Options'
 
 // useOptions フックをモック化
 vi.mock('./hooks/useOptions')
@@ -30,15 +33,9 @@ describe('Options Component', () => {
   it('正しくタイトルと入力欄が表示されること', () => {
     render(<Options />)
 
-    expect(
-      screen.getByText(FIELD_LABELS.OPTIONS_TITLE),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByLabelText(FIELD_LABELS.URL),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByDisplayValue(DEFAULT_API_URL),
-    ).toBeInTheDocument()
+    expect(screen.getByText(FIELD_LABELS.OPTIONS_TITLE)).toBeInTheDocument()
+    expect(screen.getByLabelText(FIELD_LABELS.URL)).toBeInTheDocument()
+    expect(screen.getByDisplayValue(DEFAULT_API_URL)).toBeInTheDocument()
   })
 
   it('入力欄の値を変更したときに setApiUrl が呼ばれること', async () => {
@@ -73,7 +70,7 @@ describe('Options Component', () => {
     render(<Options />)
 
     expect(screen.getByText(message)).toBeInTheDocument()
-    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByRole(ARIA_ROLES.STATUS)).toBeInTheDocument()
   })
 
   it('エラーメッセージがある場合に正しく表示されること', () => {
@@ -86,6 +83,6 @@ describe('Options Component', () => {
     render(<Options />)
 
     expect(screen.getByText(message)).toBeInTheDocument()
-    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByRole(ARIA_ROLES.ALERT)).toBeInTheDocument()
   })
 })

--- a/extension/src/Popup.test.tsx
+++ b/extension/src/Popup.test.tsx
@@ -1,14 +1,17 @@
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { Popup } from './Popup'
-import { usePopup } from './hooks/usePopup'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import {
+  ARIA_ROLES,
   COMMON_MESSAGES,
   FIELD_LABELS,
   UI_STATUS,
 } from '@shared/constants'
 import { VALID_URLS } from '@shared/test/fixtures'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { usePopup } from './hooks/usePopup'
+import { Popup } from './Popup'
 
 // usePopup フックをモック化
 vi.mock('./hooks/usePopup')
@@ -78,7 +81,7 @@ describe('Popup Component', () => {
     // ボタンとステータスエリアの両方に表示される
     const elements = screen.getAllByText(COMMON_MESSAGES.SAVING)
     expect(elements.length).toBe(2)
-    expect(screen.getByRole('button')).toBeDisabled()
+    expect(screen.getByRole(ARIA_ROLES.BUTTON)).toBeDisabled()
   })
 
   it('エラーメッセージが正しく表示されること', () => {
@@ -91,7 +94,7 @@ describe('Popup Component', () => {
     render(<Popup />)
 
     expect(screen.getByText(errorMessage)).toBeInTheDocument()
-    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByRole(ARIA_ROLES.ALERT)).toBeInTheDocument()
   })
 
   it('成功メッセージが正しく表示されること', () => {
@@ -104,6 +107,6 @@ describe('Popup Component', () => {
     render(<Popup />)
 
     expect(screen.getByText(successMessage)).toBeInTheDocument()
-    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByRole(ARIA_ROLES.STATUS)).toBeInTheDocument()
   })
 })

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -233,6 +233,7 @@ export const ARIA_ROLES = {
   ALERT: 'alert',
   ROWGROUP: 'rowgroup',
   TABLE: 'table',
+  LINK: 'link',
 } as const
 
 export const ARIA_ATTRIBUTES = {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
@@ -7,9 +7,9 @@ import {
   API_PATHS,
   ARIA_ATTRIBUTES,
   ARIA_ROLES,
+  DEFAULT_API_URL,
   FIELD_LABELS,
   HTTP_STATUS,
-  DEFAULT_API_URL,
   KEY_VALUES,
 } from '@shared/constants'
 import {
@@ -17,12 +17,12 @@ import {
   MOCK_BOOKMARK_2,
   MOCK_KEYWORDS,
 } from '@shared/test/fixtures'
-import { render, screen, waitFor, within, fireEvent } from './test/utils'
-import { createDragEndEvent } from './test/dnd-utils'
 import userEvent from '@testing-library/user-event'
 
 import App from './App'
+import { createDragEndEvent } from './test/dnd-utils'
 import { server } from './test/setup'
+import { fireEvent, render, screen, waitFor, within } from './test/utils'
 
 import type { DragEndEvent } from '@dnd-kit/core'
 
@@ -279,10 +279,10 @@ describe('App Integration', () => {
       const { user } = setup()
 
       // キーワード一覧が表示されるのを待機
-      const keyword1 = await screen.findByRole('button', {
+      const keyword1 = await screen.findByRole(ARIA_ROLES.BUTTON, {
         name: MOCK_KEYWORDS[0].name,
       })
-      const keyword2 = await screen.findByRole('button', {
+      const keyword2 = await screen.findByRole(ARIA_ROLES.BUTTON, {
         name: MOCK_KEYWORDS[1].name,
       })
 
@@ -312,7 +312,7 @@ describe('App Integration', () => {
       const { user } = setup([b1, b2])
 
       // 1. キーワード1を選択
-      const keywordBtn1 = await screen.findByRole('button', {
+      const keywordBtn1 = await screen.findByRole(ARIA_ROLES.BUTTON, {
         name: kw1.name,
       })
       await user.click(keywordBtn1)
@@ -326,10 +326,10 @@ describe('App Integration', () => {
       ).toBeInTheDocument()
 
       // 3. 各セクションの内容を検証
-      const matchedSection = screen.getByRole('list', {
+      const matchedSection = screen.getByRole(ARIA_ROLES.LIST, {
         name: FIELD_LABELS.MATCHED_BOOKMARKS_LABEL,
       })
-      const otherSection = screen.getByRole('list', {
+      const otherSection = screen.getByRole(ARIA_ROLES.LIST, {
         name: FIELD_LABELS.OTHER_BOOKMARKS_LABEL,
       })
 
@@ -348,7 +348,7 @@ describe('App Integration', () => {
       const { user } = setup([b1, b2])
 
       // 1. キーワード1を選択
-      const keywordBtn1 = await screen.findByRole('button', {
+      const keywordBtn1 = await screen.findByRole(ARIA_ROLES.BUTTON, {
         name: kw1.name,
       })
       await user.click(keywordBtn1)
@@ -367,10 +367,10 @@ describe('App Integration', () => {
     it('キーワード選択中に Escape キーを押すと、すべての選択が解除されること', async () => {
       const { user } = setup()
 
-      const keyword1 = await screen.findByRole('button', {
+      const keyword1 = await screen.findByRole(ARIA_ROLES.BUTTON, {
         name: MOCK_KEYWORDS[0].name,
       })
-      const keyword2 = await screen.findByRole('button', {
+      const keyword2 = await screen.findByRole(ARIA_ROLES.BUTTON, {
         name: MOCK_KEYWORDS[1].name,
       })
 
@@ -417,7 +417,9 @@ describe('App Integration', () => {
       const { user } = setup([b1, b2])
 
       // 1. キーワード1を選択 (b1, b2 ともに「その他」セクションへ移動)
-      const keywordBtn = await screen.findByRole('button', { name: kw1.name })
+      const keywordBtn = await screen.findByRole(ARIA_ROLES.BUTTON, {
+        name: kw1.name,
+      })
       await user.click(keywordBtn)
 
       // 2. 「一致」セクションの見出し（DroppableTarget）を取得

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -20,7 +20,7 @@ import { render, screen } from '../test/utils'
 import userEvent from '@testing-library/user-event'
 
 import { BookmarkList } from './BookmarkList'
-import { type BookmarkProps } from './BookmarkList'
+import type { BookmarkProps } from './BookmarkList'
 
 // DndContext をモック化して内部のイベントをトリガーしやすくする
 vi.mock('@dnd-kit/core', async () => {
@@ -252,7 +252,7 @@ describe('BookmarkList', () => {
     expect(otherItem).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'false')
   })
 
-  it('正しい階層構造 (role="list" > role="listitem" > role="button") でレンダリングされること', () => {
+  it(`正しい階層構造 (${ARIA_ROLES.LIST} > ${ARIA_ROLES.LISTITEM} > ${ARIA_ROLES.BUTTON}) でレンダリングされること`, () => {
     render(<BookmarkList {...defaultProps} />)
 
     const list = screen.getByRole(ARIA_ROLES.LIST)

--- a/src/components/KeywordItem.test.tsx
+++ b/src/components/KeywordItem.test.tsx
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
+
 import { ARIA_ROLES, KEY_VALUES } from '@shared/constants'
-import { render, screen } from '../test/utils'
 import userEvent from '@testing-library/user-event'
+
+import { render, screen } from '../test/utils'
+import { KeywordItem } from './KeywordItem'
+
 import type { DraggableAttributes } from '@dnd-kit/core'
 import type { Keyword, KeywordId } from '@shared/schemas/keyword'
-
-import { KeywordItem } from './KeywordItem'
 
 describe('KeywordItem', () => {
   const mockKeyword: Keyword = {
@@ -73,7 +75,7 @@ describe('KeywordItem', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('正しい階層構造 (role="listitem" > role="button") でレンダリングされること', () => {
+  it(`正しい階層構造 (${ARIA_ROLES.LISTITEM} > ${ARIA_ROLES.BUTTON}) でレンダリングされること`, () => {
     render(<KeywordItem {...defaultProps} />)
 
     const listItem = screen.getByRole(ARIA_ROLES.LISTITEM)

--- a/src/components/KeywordList.test.tsx
+++ b/src/components/KeywordList.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
 import { ARIA_ATTRIBUTES, ARIA_ROLES, UI_MESSAGES } from '@shared/constants'
+import { MOCK_KEYWORDS } from '@shared/test/fixtures'
+
 import { render, screen } from '../test/utils'
 import { KeywordList } from './KeywordList'
-import { MOCK_KEYWORDS } from '@shared/test/fixtures'
 
 describe('KeywordList', () => {
   const defaultProps = {
@@ -37,7 +39,7 @@ describe('KeywordList', () => {
     )
 
     // aria-selected 属性を持つボタン要素を取得
-    const items = screen.getAllByRole('button')
+    const items = screen.getAllByRole(ARIA_ROLES.BUTTON)
     // ドラッグハンドルもボタンに含まれる可能性があるため、フィルタリングまたは数を確認
     const selectedItems = items.filter(
       (item) => item.getAttribute(ARIA_ATTRIBUTES.SELECTED) === 'true',

--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -4,11 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   APP_PATHS,
+  ARIA_ROLES,
   DROPPABLE_IDS,
   FIELD_LABELS,
+  KEY_VALUES,
   LOG_MESSAGES,
   UI_MESSAGES,
-  KEY_VALUES,
 } from '@shared/constants'
 import { updateBookmarkSchema } from '@shared/schemas/bookmark'
 import { MOCK_BOOKMARK_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
@@ -100,7 +101,7 @@ describe('BookmarkPage Component', () => {
     fireEvent.change(titleInput, { target: { value: 'New Title' } })
     fireEvent.change(urlInput, { target: { value: 'https://new-url.com' } })
 
-    const updateButton = screen.getByRole('button', {
+    const updateButton = screen.getByRole(ARIA_ROLES.BUTTON, {
       name: FIELD_LABELS.BUTTON_UPDATE,
     })
     fireEvent.click(updateButton)
@@ -259,7 +260,7 @@ describe('BookmarkPage Component', () => {
     const input = await screen.findByLabelText(FIELD_LABELS.ADD_KEYWORD_LABEL)
     fireEvent.change(input, { target: { value: 'NewTag' } })
 
-    const addButton = screen.getByRole('button', {
+    const addButton = screen.getByRole(ARIA_ROLES.BUTTON, {
       name: FIELD_LABELS.BUTTON_ADD,
     })
     fireEvent.click(addButton)
@@ -301,7 +302,7 @@ describe('BookmarkPage Component', () => {
       APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
     )
 
-    const addButton = await screen.findByRole('button', {
+    const addButton = await screen.findByRole(ARIA_ROLES.BUTTON, {
       name: FIELD_LABELS.BUTTON_ADD,
     })
     expect(addButton).toBeDisabled()
@@ -366,7 +367,7 @@ describe('BookmarkPage Component', () => {
 
     const input = await screen.findByLabelText(FIELD_LABELS.ADD_KEYWORD_LABEL)
     fireEvent.change(input, { target: { value: 'ErrorTag' } })
-    const addButton = screen.getByRole('button', {
+    const addButton = screen.getByRole(ARIA_ROLES.BUTTON, {
       name: FIELD_LABELS.BUTTON_ADD,
     })
     fireEvent.click(addButton)
@@ -400,7 +401,7 @@ describe('BookmarkPage Component', () => {
     expect(await screen.findByText(/Bookmark not found/i)).toBeInTheDocument()
 
     // 閉じるボタンの動作確認
-    const closeButton = screen.getByRole('button', {
+    const closeButton = screen.getByRole(ARIA_ROLES.BUTTON, {
       name: FIELD_LABELS.BUTTON_CLOSE,
     })
     fireEvent.click(closeButton)

--- a/src/pages/KeywordPage.test.tsx
+++ b/src/pages/KeywordPage.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect } from 'vitest'
-import { Routes, Route } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+
+import { APP_PATHS, ARIA_ROLES, FIELD_LABELS } from '@shared/constants'
+
 import { render, screen } from '../test/utils'
 import { KeywordPage } from './KeywordPage'
-import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
 
 describe('KeywordPage', () => {
   it('URL パラメータから取得したキーワード ID が表示されること', () => {
@@ -29,7 +31,7 @@ describe('KeywordPage', () => {
 
   it('戻るリンクが表示されていること', () => {
     render(<KeywordPage />)
-    const link = screen.getByRole('link', {
+    const link = screen.getByRole(ARIA_ROLES.LINK, {
       name: new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i'),
     })
     expect(link).toBeInTheDocument()


### PR DESCRIPTION
### 概要
コードベース全体（主にテストコード）で使用されていた生の文字列による ARIA ロール指定を `ARIA_ROLES` 定数へ置き換え、マジックストリングを排除しました。

### 変更内容
- `shared/constants.ts` に `LINK` ロール定義を追加。
- 各テストファイル (`.test.tsx`) およびコンポーネントにおける `role` 指定を定数参照へリファクタリング。
- アクセシビリティ関連定義の一貫性向上。

Closes #316