### PR TITLE
chore: eslint-plugin-import を導入し、インポート順序を自動化 (#318)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import eslintConfigPrettier from 'eslint-config-prettier'
+import importX from 'eslint-plugin-import-x'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
@@ -12,13 +13,56 @@ export default defineConfig([
     files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,
-      tseslint.configs.recommended,
+      ...tseslint.configs.recommended,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+    plugins: {
+      'import-x': importX,
+    },
+    settings: {
+      'import-x/resolver': {
+        typescript: true,
+        node: true,
+      },
+    },
+    rules: {
+      'import-x/order': [
+        'error',
+        {
+          groups: [
+            'builtin',
+            'external',
+            'internal',
+            ['parent', 'sibling'],
+            'index',
+            'object',
+            'type',
+          ],
+          pathGroups: [
+            {
+              pattern: 'react',
+              group: 'builtin',
+              position: 'before',
+            },
+            {
+              pattern: '@shared/**',
+              group: 'internal',
+              position: 'before',
+            },
+          ],
+          pathGroupsExcludedImportTypes: ['react'],
+          'newlines-between': 'always',
+          alphabetize: {
+            order: 'asc',
+            caseInsensitive: true,
+          },
+        },
+      ],
     },
   },
   eslintConfigPrettier,

--- a/extension/src/Options.test.tsx
+++ b/extension/src/Options.test.tsx
@@ -1,3 +1,5 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -6,8 +8,6 @@ import {
   FIELD_LABELS,
   UI_STATUS,
 } from '@shared/constants'
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 
 import { useOptions } from './hooks/useOptions'
 import { Options } from './Options'

--- a/extension/src/Popup.test.tsx
+++ b/extension/src/Popup.test.tsx
@@ -1,3 +1,5 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -7,8 +9,6 @@ import {
   UI_STATUS,
 } from '@shared/constants'
 import { VALID_URLS } from '@shared/test/fixtures'
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 
 import { usePopup } from './hooks/usePopup'
 import { Popup } from './Popup'

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,4 +1,5 @@
 import { QueryClient } from '@tanstack/react-query'
+
 import {
   BOOKMARK_STATUS,
   EXTENSION_ICONS,
@@ -9,6 +10,7 @@ import {
 } from '@shared/constants'
 import type { Bookmark, BookmarksResponse } from '@shared/schemas/bookmark'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
+
 import { QUERY_KEYS } from '../../src/lib/queryKeys'
 
 /**

--- a/extension/src/hooks/useOptions.test.ts
+++ b/extension/src/hooks/useOptions.test.ts
@@ -1,3 +1,4 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -15,12 +16,10 @@ import {
   MOCK_BOOKMARK_2,
   VALID_URLS,
 } from '@shared/test/fixtures'
-import { act, renderHook, waitFor } from '@testing-library/react'
 
 import { useOptions } from './useOptions'
 
 import type { ErrorTestCase } from '../../test/setup'
-
 import type { MockInstance } from 'vitest'
 
 describe('useOptions Hook', () => {

--- a/extension/src/hooks/useOptions.ts
+++ b/extension/src/hooks/useOptions.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { storage } from '../lib/storage'
+
 import {
   API_PATHS,
   COMMON_MESSAGES,
@@ -14,6 +14,8 @@ import {
 import { bookmarksResponseSchema } from '@shared/schemas/bookmark'
 import { validateApiUrl, getOrigin } from '@shared/utils/url'
 
+import { storage } from '../lib/storage'
+
 const DEFAULT_SETTINGS = {
   [STORAGE_KEYS.API_URL]: DEFAULT_API_URL,
 }
@@ -23,7 +25,10 @@ const apiResponseSchema = bookmarksResponseSchema
 
 export const useOptions = () => {
   const [apiUrl, setApiUrl] = useState('')
-  const [status, setStatus] = useState<StatusInfo>({ type: UI_STATUS.IDLE, message: '' })
+  const [status, setStatus] = useState<StatusInfo>({
+    type: UI_STATUS.IDLE,
+    message: '',
+  })
 
   // 初期値の読み込み
   useEffect(() => {
@@ -72,7 +77,10 @@ export const useOptions = () => {
       const sanitizedUrl = getOrigin(apiUrl)
       await storage.set({ [STORAGE_KEYS.API_URL]: sanitizedUrl })
       setApiUrl(sanitizedUrl)
-      setStatus({ type: UI_STATUS.SUCCESS, message: EXTENSION_MESSAGES.SETTINGS_SAVED })
+      setStatus({
+        type: UI_STATUS.SUCCESS,
+        message: EXTENSION_MESSAGES.SETTINGS_SAVED,
+      })
     } catch (err) {
       console.error(LOG_MESSAGES.EXTENSION_SETTING_SAVE_FAILED, err)
       setStatus({

--- a/extension/src/hooks/usePopup.test.ts
+++ b/extension/src/hooks/usePopup.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { usePopup } from './usePopup'
+
 import {
   EXTENSION_CONSTANTS,
   EXTENSION_MESSAGES,
@@ -11,6 +11,8 @@ import {
   UI_STATUS,
   EXTENSION_MESSAGE_TYPES,
 } from '@shared/constants'
+
+import { usePopup } from './usePopup'
 import { storage } from '../lib/storage'
 
 // chrome API のモック
@@ -91,7 +93,7 @@ describe('usePopup Hook', () => {
     mockChrome.tabs.query.mockResolvedValue([
       { title: 'Test', url: 'https://example.com' },
     ])
-    
+
     // fetch の成功レスポンスをモック
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -115,12 +117,12 @@ describe('usePopup Hook', () => {
     )
     expect(result.current.status.type).toBe(UI_STATUS.SUCCESS)
     expect(result.current.status.message).toBe(EXTENSION_MESSAGES.POPUP_SAVED)
-    
+
     // キャッシュ無効化メッセージが送信されたことを検証
     expect(mockChrome.runtime.sendMessage).toHaveBeenCalledWith({
       type: EXTENSION_MESSAGE_TYPES.INVALIDATE_CACHE,
     })
-    
+
     // 時間を進めて window.close の呼び出しを確認
     act(() => {
       vi.advanceTimersByTime(EXTENSION_CONSTANTS.POPUP_CLOSE_DELAY_MS)
@@ -130,77 +132,110 @@ describe('usePopup Hook', () => {
 
   describe('handleSave エラー系テスト', () => {
     it('入力バリデーションエラー（タイトル空）の場合にエラーメッセージを表示すること', async () => {
-      mockChrome.tabs.query.mockResolvedValue([{ title: '', url: 'https://example.com' }])
+      mockChrome.tabs.query.mockResolvedValue([
+        { title: '', url: 'https://example.com' },
+      ])
       const { result } = renderHook(() => usePopup())
-      
+
       // URL がセットされるのを待機
-      await vi.waitFor(() => expect(result.current.url).toBe('https://example.com'))
+      await vi.waitFor(() =>
+        expect(result.current.url).toBe('https://example.com'),
+      )
 
       await act(async () => {
         await result.current.handleSave()
       })
 
       expect(result.current.status.type).toBe(UI_STATUS.ERROR)
-      expect(result.current.status.message).toBe(VALIDATION_MESSAGES.TITLE_REQUIRED)
+      expect(result.current.status.message).toBe(
+        VALIDATION_MESSAGES.TITLE_REQUIRED,
+      )
     })
 
     const errorCases = [
       {
         name: 'API URL のバリデーションエラー',
-        setup: () => vi.spyOn(storage, 'get').mockResolvedValue({ [STORAGE_KEYS.API_URL]: 'invalid-url' }),
+        setup: () =>
+          vi
+            .spyOn(storage, 'get')
+            .mockResolvedValue({ [STORAGE_KEYS.API_URL]: 'invalid-url' }),
         expectedMessage: VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
       },
       {
         name: 'HTTP ステータスエラー (500)',
         setup: () =>
-          vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-            ok: false,
-            status: 500,
-          })),
+          vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+              ok: false,
+              status: 500,
+            }),
+          ),
         expectedMessage: 'HTTP error! status: 500',
       },
       {
         name: 'API 側での論理エラー (success: false)',
         setup: () =>
-          vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-            ok: true,
-            json: () => Promise.resolve({ success: false, error: { message: 'Custom Error' } }),
-          })),
+          vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue({
+              ok: true,
+              json: () =>
+                Promise.resolve({
+                  success: false,
+                  error: { message: 'Custom Error' },
+                }),
+            }),
+          ),
         expectedMessage: 'Custom Error',
       },
       {
         name: 'ネットワークエラー (fetch 失敗)',
-        setup: () => vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network Fail'))),
+        setup: () =>
+          vi.stubGlobal(
+            'fetch',
+            vi.fn().mockRejectedValue(new Error('Network Fail')),
+          ),
         expectedMessage: 'Network Fail',
       },
       {
         name: '不明なエラー（Error以外がスローされた場合）',
-        setup: () => vi.stubGlobal('fetch', vi.fn().mockRejectedValue('String Error')),
+        setup: () =>
+          vi.stubGlobal('fetch', vi.fn().mockRejectedValue('String Error')),
         expectedMessage: EXTENSION_MESSAGES.POPUP_SAVE_FAILED,
         checkLog: true,
-      }
+      },
     ]
 
     errorCases.forEach(({ name, setup, expectedMessage, checkLog }) => {
-      it(name + ' の場合にエラーメッセージを表示し、必要に応じてログを出力すること', async () => {
-        const consoleSpy = vi.spyOn(console, 'error')
-        mockChrome.tabs.query.mockResolvedValue([{ title: 'Test', url: 'https://example.com' }])
-        await setup()
+      it(
+        name +
+          ' の場合にエラーメッセージを表示し、必要に応じてログを出力すること',
+        async () => {
+          const consoleSpy = vi.spyOn(console, 'error')
+          mockChrome.tabs.query.mockResolvedValue([
+            { title: 'Test', url: 'https://example.com' },
+          ])
+          await setup()
 
-        const { result } = renderHook(() => usePopup())
-        await vi.waitFor(() => expect(result.current.title).toBe('Test'))
+          const { result } = renderHook(() => usePopup())
+          await vi.waitFor(() => expect(result.current.title).toBe('Test'))
 
-        await act(async () => {
-          await result.current.handleSave()
-        })
+          await act(async () => {
+            await result.current.handleSave()
+          })
 
-        expect(result.current.status.type).toBe(UI_STATUS.ERROR)
-        expect(result.current.status.message).toContain(expectedMessage)
-        
-        if (checkLog) {
-             expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.CREATE_BOOKMARK_FAILED, 'String Error')
-        }
-      })
+          expect(result.current.status.type).toBe(UI_STATUS.ERROR)
+          expect(result.current.status.message).toContain(expectedMessage)
+
+          if (checkLog) {
+            expect(consoleSpy).toHaveBeenCalledWith(
+              LOG_MESSAGES.CREATE_BOOKMARK_FAILED,
+              'String Error',
+            )
+          }
+        },
+      )
     })
   })
 })

--- a/extension/src/main-options.tsx
+++ b/extension/src/main-options.tsx
@@ -1,5 +1,7 @@
 import { StrictMode } from 'react'
+
 import { createRoot } from 'react-dom/client'
+
 import { Options } from './Options'
 import './style.css'
 

--- a/extension/src/main-popup.tsx
+++ b/extension/src/main-popup.tsx
@@ -1,5 +1,7 @@
 import { StrictMode } from 'react'
+
 import { createRoot } from 'react-dom/client'
+
 import { Popup } from './Popup'
 import './style.css'
 

--- a/extension/sync-version.test.ts
+++ b/extension/sync-version.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import fs from 'fs'
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
 import { syncVersion } from './sync-version'
 import { LOG_MESSAGES } from '../shared/constants'
 

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import path from 'path'
 import { fileURLToPath } from 'url'
+
+import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+import tsconfigPaths from 'vite-tsconfig-paths'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -21,7 +22,9 @@ export default defineConfig({
       },
       output: {
         entryFileNames: (chunkInfo) => {
-          return chunkInfo.name === 'background' ? '[name].js' : 'assets/[name]-[hash].js'
+          return chunkInfo.name === 'background'
+            ? '[name].js'
+            : 'assets/[name]-[hash].js'
         },
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bookmark-page",
-  "version": "1.9.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bookmark-page",
-      "version": "1.9.0",
+      "version": "1.10.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -42,6 +42,8 @@
         "drizzle-kit": "^0.31.9",
         "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
@@ -648,6 +650,40 @@
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -1573,6 +1609,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
@@ -1595,6 +1644,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@package-json/types": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
+      "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2398,6 +2454,17 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2858,6 +2925,299 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.2.0",
@@ -3586,6 +3946,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
+      "integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4166,6 +4536,156 @@
         "eslint": ">=7.0.0"
       }
     },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+      "integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
+      "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@package-json/types": "^0.0.12",
+        "@typescript-eslint/types": "^8.56.0",
+        "comment-parser": "^1.4.1",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.9",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3 || ^10.1.2",
+        "semver": "^7.7.2",
+        "stable-hash-x": "^0.2.0",
+        "unrs-resolver": "^1.9.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-import-x"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint-import-resolver-node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
@@ -4743,6 +5263,29 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -5613,6 +6156,22 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6430,6 +6989,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6891,6 +7460,41 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
     },
     "node_modules/until-async": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "drizzle-kit": "^0.31.9",
     "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,9 +1,12 @@
+import path from 'path'
+
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
-import path from 'path'
 import { z } from 'zod'
+
 import { LOG_MESSAGES, DB_CONSTANTS, ENV_NAMES } from '@shared/constants'
+
 import * as schema from './db/schema'
 
 const isTestEnvironment = () => process.env.NODE_ENV === ENV_NAMES.TEST

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,10 @@
 import { serve } from '@hono/node-server'
-import app from './app'
-import { initializeDatabase } from './db'
+
 import { LOG_MESSAGES, DEFAULT_SERVER_PORT } from '@shared/constants'
 import { validatePort } from '@shared/utils/url'
+
+import app from './app'
+import { initializeDatabase } from './db'
 
 // データベースの初期化
 try {

--- a/server/routes/bookmarks.test.ts
+++ b/server/routes/bookmarks.test.ts
@@ -10,8 +10,8 @@ import { VALID_URLS } from '@shared/test/fixtures'
 
 import app from '../app'
 import { db, initializeDatabase, resetDatabase, sqlite } from '../db'
-import { API_ERROR_CODES } from '../utils/error'
 import { createBookmark, createKeyword, attachKeyword } from '../test/seedUtils'
+import { API_ERROR_CODES } from '../utils/error'
 
 describe('Bookmarks API', () => {
   beforeEach(() => {

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -1,8 +1,8 @@
+import { zValidator } from '@hono/zod-validator'
+import { and, eq, sql, inArray } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { z } from 'zod'
-import { and, eq, sql, inArray } from 'drizzle-orm'
 
-import { zValidator } from '@hono/zod-validator'
 import { ERROR_MESSAGES, LOG_MESSAGES, HTTP_STATUS } from '@shared/constants'
 import {
   BookmarkIdSchema,

--- a/server/routes/keywords.test.ts
+++ b/server/routes/keywords.test.ts
@@ -10,8 +10,8 @@ import { VALID_URLS } from '@shared/test/fixtures'
 
 import app from '../app'
 import { db, initializeDatabase, resetDatabase, sqlite } from '../db'
-import { API_ERROR_CODES } from '../utils/error'
 import { attachKeyword, createBookmark, createKeyword } from '../test/seedUtils'
+import { API_ERROR_CODES } from '../utils/error'
 
 describe(`GET ${API_PATHS.KEYWORDS}`, () => {
   beforeEach(() => {

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -1,7 +1,7 @@
+import { zValidator } from '@hono/zod-validator'
 import { count, eq } from 'drizzle-orm'
 import { Hono } from 'hono'
 
-import { zValidator } from '@hono/zod-validator'
 import { ERROR_MESSAGES, HTTP_STATUS, LOG_MESSAGES } from '@shared/constants'
 import {
   createKeywordRequestSchema,

--- a/server/test/seedUtils.ts
+++ b/server/test/seedUtils.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod'
+
 import { sqlite } from '../db'
+
 import type { Statement } from 'better-sqlite3'
 
 const BookmarkIdResultSchema = z.object({ bookmark_id: z.number() })

--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
+
 import {
   createApiSuccessSchema,
   ApiErrorSchema,
@@ -21,8 +22,9 @@ describe('API Schemas', () => {
       expect(successSchema.safeParse({ success: true, data: {} }).success).toBe(
         false,
       )
-      expect(successSchema.safeParse({ success: false, data: { id: 1 } }).success)
-        .toBe(false)
+      expect(
+        successSchema.safeParse({ success: false, data: { id: 1 } }).success,
+      ).toBe(false)
     })
   })
 
@@ -36,9 +38,9 @@ describe('API Schemas', () => {
     })
 
     it('必須項目が欠けているエラーを拒否すること', () => {
-      expect(ApiErrorSchema.safeParse({ success: false, error: {} }).success).toBe(
-        false,
-      )
+      expect(
+        ApiErrorSchema.safeParse({ success: false, error: {} }).success,
+      ).toBe(false)
     })
   })
 

--- a/shared/schemas/bookmark.test.ts
+++ b/shared/schemas/bookmark.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'vitest'
+
 import {
   bookmarkSchema,
   createBookmarkSchema,
   reorderBookmarksSchema,
   updateBookmarkSchema,
 } from './bookmark'
-import { MOCK_BOOKMARK_1, INVALID_URLS, VALID_URLS } from '../test/fixtures'
 import { VALIDATION_MESSAGES } from '../constants'
+import { MOCK_BOOKMARK_1, INVALID_URLS, VALID_URLS } from '../test/fixtures'
 
 describe('bookmarkSchema', () => {
   it.each([

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -1,9 +1,8 @@
 import { z } from 'zod'
-import { isHttpUrl } from '../utils/url'
+
 import { VALIDATION_MESSAGES } from '../constants'
-import {
-  keywordSchema,
-} from './keyword'
+import { keywordSchema } from './keyword'
+import { isHttpUrl } from '../utils/url'
 
 export {
   KeywordIdSchema,

--- a/shared/schemas/keyword.test.ts
+++ b/shared/schemas/keyword.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+
 import {
   KeywordIdSchema,
   keywordSchema,
@@ -27,7 +28,9 @@ describe('Keyword Schemas', () => {
     })
 
     it('不正なデータを拒否すること', () => {
-      expect(() => keywordSchema.parse({ id: 'invalid', name: 'Test' })).toThrow()
+      expect(() =>
+        keywordSchema.parse({ id: 'invalid', name: 'Test' }),
+      ).toThrow()
       expect(() => keywordSchema.parse({ id: '1' })).toThrow() // name missing
     })
   })

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+
 import { VALIDATION_MESSAGES } from '@shared/constants'
 
 export const KeywordIdSchema = z

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -1,6 +1,7 @@
 import { BookmarkIdSchema } from '../schemas/bookmark'
-import type { Bookmark } from '../schemas/bookmark'
 import { KeywordIdSchema } from '../schemas/keyword'
+
+import type { Bookmark } from '../schemas/bookmark'
 import type { Keyword } from '../schemas/keyword'
 
 export const MOCK_BOOKMARK_TITLE_PREFIX = 'Test Bookmark'

--- a/shared/utils/url.test.ts
+++ b/shared/utils/url.test.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import {
-  isHttpUrl,
-  getOrigin,
-  validateApiUrl,
-  openUrlInNewTab,
-  validatePort,
-  getPortFromUrl,
-} from './url'
+
 import {
   ERROR_MESSAGES,
   VALIDATION_MESSAGES,
@@ -15,6 +8,15 @@ import {
   DEFAULT_PORTS,
 } from '@shared/constants'
 import { VALID_URLS, INVALID_URLS } from '@shared/test/fixtures'
+
+import {
+  isHttpUrl,
+  getOrigin,
+  validateApiUrl,
+  openUrlInNewTab,
+  validatePort,
+  getPortFromUrl,
+} from './url'
 
 describe('url utilities', () => {
   describe('isHttpUrl', () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,6 @@
 import { type ReactNode } from 'react'
+
+import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
@@ -12,13 +14,12 @@ import {
   KEY_VALUES,
   DROPPABLE_IDS,
 } from '@shared/constants'
+import type { Bookmark } from '@shared/schemas/bookmark'
 import {
   MOCK_BOOKMARK_1,
   MOCK_BOOKMARK_2,
   MOCK_KEYWORDS,
 } from '@shared/test/fixtures'
-import type { Bookmark } from '@shared/schemas/bookmark'
-import userEvent from '@testing-library/user-event'
 
 import App from './App'
 import { createDragEndEvent } from './test/dnd-utils'

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,12 @@
 import { Routes, Route } from 'react-router-dom'
+
 import './App.css'
+import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
+
 import { SettingsPanel } from './components/SettingsPanel'
 import { useApp } from './hooks/useApp'
-import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
-import { HomePage } from './pages/HomePage'
 import { BookmarkPage } from './pages/BookmarkPage'
+import { HomePage } from './pages/HomePage'
 import { KeywordPage } from './pages/KeywordPage'
 
 function App() {

--- a/src/components/BookmarkItem.test.tsx
+++ b/src/components/BookmarkItem.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -7,11 +8,11 @@ import {
   KEY_VALUES,
 } from '@shared/constants'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
-import { render, screen } from '../test/utils'
-import userEvent from '@testing-library/user-event'
-import type { DraggableAttributes } from '@dnd-kit/core'
 
 import { BookmarkItem } from './BookmarkItem'
+import { render, screen } from '../test/utils'
+
+import type { DraggableAttributes } from '@dnd-kit/core'
 
 describe('BookmarkItem', () => {
   const defaultProps = {

--- a/src/components/BookmarkItem.tsx
+++ b/src/components/BookmarkItem.tsx
@@ -1,15 +1,17 @@
 import { memo } from 'react'
+
 import {
   ARIA_ROLES,
   ARIA_ATTRIBUTES,
   HTML_ATTRIBUTES,
   KEY_VALUES,
 } from '@shared/constants'
+import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
+
 import type {
   DraggableAttributes,
   DraggableSyntheticListeners,
 } from '@dnd-kit/core'
-import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
 
 interface BookmarkItemProps {
   bookmark: Bookmark

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 
 import {
@@ -16,10 +17,10 @@ import {
   MOCK_BOOKMARKS,
   MOCK_BOOKMARK_TITLE_PREFIX,
 } from '@shared/test/fixtures'
-import { render, screen } from '../test/utils'
-import userEvent from '@testing-library/user-event'
 
 import { BookmarkList } from './BookmarkList'
+import { render, screen } from '../test/utils'
+
 import type { BookmarkProps } from './BookmarkList'
 
 // DndContext をモック化して内部のイベントをトリガーしやすくする

--- a/src/components/BookmarkList.tsx
+++ b/src/components/BookmarkList.tsx
@@ -5,13 +5,12 @@ import {
   FIELD_LABELS,
   UI_MESSAGES,
 } from '@shared/constants'
-
-import { BookmarkItem } from './BookmarkItem'
-import { DraggableList } from './DraggableList'
-import { DraggableItem } from './DraggableItem'
-
 import { BookmarkIdSchema } from '@shared/schemas/bookmark'
 import type { Bookmark, BookmarkId } from '@shared/schemas/bookmark'
+
+import { BookmarkItem } from './BookmarkItem'
+import { DraggableItem } from './DraggableItem'
+import { DraggableList } from './DraggableList'
 
 export type BookmarkProps = {
   bookmarks: Bookmark[]

--- a/src/components/DraggableItem.tsx
+++ b/src/components/DraggableItem.tsx
@@ -1,10 +1,12 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+
+import type { DraggableEntity } from '@shared/schemas/draggable'
+
 import type {
   DraggableAttributes,
   DraggableSyntheticListeners,
 } from '@dnd-kit/core'
-import type { DraggableEntity } from '@shared/schemas/draggable'
 
 export type DraggableItemProps<T extends DraggableEntity> = {
   item: T

--- a/src/components/DraggableList.test.tsx
+++ b/src/components/DraggableList.test.tsx
@@ -1,11 +1,14 @@
+import * as sortable from '@dnd-kit/sortable'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { z } from 'zod'
-import { render, screen } from '../test/utils'
-import { DraggableList } from './DraggableList'
-import { DraggableItem } from './DraggableItem'
-import * as sortable from '@dnd-kit/sortable'
-import { createDragEndEvent } from 'src/test/dnd-utils'
+
 import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2 } from '@shared/test/fixtures'
+
+import { createDragEndEvent } from 'src/test/dnd-utils'
+
+import { DraggableItem } from './DraggableItem'
+import { DraggableList } from './DraggableList'
+import { render, screen } from '../test/utils'
 
 const mockIdSchema = z.string()
 

--- a/src/components/DraggableList.tsx
+++ b/src/components/DraggableList.tsx
@@ -1,4 +1,3 @@
-import { z } from 'zod'
 import {
   closestCenter,
   DndContext,
@@ -12,9 +11,12 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
-import type { DragEndEvent } from '@dnd-kit/core'
+import { z } from 'zod'
+
 import { ERROR_MESSAGES } from '@shared/constants'
 import type { DraggableEntity } from '@shared/schemas/draggable'
+
+import type { DragEndEvent } from '@dnd-kit/core'
 
 export type DraggableListProps<T extends DraggableEntity> = {
   items: T[]

--- a/src/components/KeywordItem.test.tsx
+++ b/src/components/KeywordItem.test.tsx
@@ -1,13 +1,13 @@
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ARIA_ROLES, KEY_VALUES } from '@shared/constants'
-import userEvent from '@testing-library/user-event'
+import type { Keyword, KeywordId } from '@shared/schemas/keyword'
 
-import { render, screen } from '../test/utils'
 import { KeywordItem } from './KeywordItem'
+import { render, screen } from '../test/utils'
 
 import type { DraggableAttributes } from '@dnd-kit/core'
-import type { Keyword, KeywordId } from '@shared/schemas/keyword'
 
 describe('KeywordItem', () => {
   const mockKeyword: Keyword = {

--- a/src/components/KeywordItem.tsx
+++ b/src/components/KeywordItem.tsx
@@ -1,15 +1,17 @@
 import { memo } from 'react'
+
 import {
   ARIA_ROLES,
   ARIA_ATTRIBUTES,
   HTML_ATTRIBUTES,
   KEY_VALUES,
 } from '@shared/constants'
+import type { Keyword, KeywordId } from '@shared/schemas/keyword'
+
 import type {
   DraggableAttributes,
   DraggableSyntheticListeners,
 } from '@dnd-kit/core'
-import type { Keyword, KeywordId } from '@shared/schemas/keyword'
 
 interface KeywordItemProps {
   keyword: Keyword

--- a/src/components/KeywordList.test.tsx
+++ b/src/components/KeywordList.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, it, vi } from 'vitest'
 import { ARIA_ATTRIBUTES, ARIA_ROLES, UI_MESSAGES } from '@shared/constants'
 import { MOCK_KEYWORDS } from '@shared/test/fixtures'
 
-import { render, screen } from '../test/utils'
 import { KeywordList } from './KeywordList'
+import { render, screen } from '../test/utils'
 
 describe('KeywordList', () => {
   const defaultProps = {

--- a/src/components/KeywordList.tsx
+++ b/src/components/KeywordList.tsx
@@ -1,9 +1,10 @@
 import { ARIA_ROLES, FIELD_LABELS, UI_MESSAGES } from '@shared/constants'
-import { DraggableList } from './DraggableList'
-import { DraggableItem } from './DraggableItem'
-import { KeywordItem } from './KeywordItem'
 import { KeywordIdSchema } from '@shared/schemas/keyword'
 import type { Keyword, KeywordId } from '@shared/schemas/keyword'
+
+import { DraggableItem } from './DraggableItem'
+import { DraggableList } from './DraggableList'
+import { KeywordItem } from './KeywordItem'
 
 interface KeywordListProps {
   keywords: Keyword[]

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen, fireEvent, act } from '../test/utils'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { SettingsPanel } from './SettingsPanel'
+
 import { FIELD_LABELS, COMMON_MESSAGES } from '@shared/constants'
+
+import { SettingsPanel } from './SettingsPanel'
 import { useExtensionSync } from '../hooks/useExtensionSync'
+import { render, screen, fireEvent, act } from '../test/utils'
 
 // useExtensionSync をモック化
 vi.mock('../hooks/useExtensionSync', () => ({
@@ -31,14 +33,18 @@ describe('SettingsPanel', () => {
     render(<SettingsPanel {...defaultProps} />)
 
     expect(screen.getByText(FIELD_LABELS.SETTING_TITLE)).toBeInTheDocument()
-    expect(screen.getByDisplayValue(defaultProps.currentApiUrl)).toBeInTheDocument()
-    expect(screen.getByText(COMMON_MESSAGES.API_URL_DESCRIPTION)).toBeInTheDocument()
+    expect(
+      screen.getByDisplayValue(defaultProps.currentApiUrl),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText(COMMON_MESSAGES.API_URL_DESCRIPTION),
+    ).toBeInTheDocument()
   })
 
   it('入力値を変更できること', () => {
     render(<SettingsPanel {...defaultProps} />)
     const input = screen.getByLabelText(FIELD_LABELS.URL)
-    
+
     const validUrl = 'http://127.0.0.1:4000'
     fireEvent.change(input, { target: { value: validUrl } })
     expect(input).toHaveValue(validUrl)
@@ -47,7 +53,7 @@ describe('SettingsPanel', () => {
   it('保存して適用ボタンで onSave が呼ばれること', () => {
     render(<SettingsPanel {...defaultProps} />)
     const saveButton = screen.getByText(FIELD_LABELS.BUTTON_SAVE_AND_APPLY)
-    
+
     fireEvent.click(saveButton)
     expect(defaultProps.onSave).toHaveBeenCalledWith(defaultProps.currentApiUrl)
   })
@@ -56,7 +62,7 @@ describe('SettingsPanel', () => {
     const errorMsg = 'Validation Error'
     const onSave = vi.fn(() => errorMsg)
     render(<SettingsPanel {...defaultProps} onSave={onSave} />)
-    
+
     const saveButton = screen.getByText(FIELD_LABELS.BUTTON_SAVE_AND_APPLY)
     fireEvent.click(saveButton)
 
@@ -77,7 +83,9 @@ describe('SettingsPanel', () => {
 
     expect(mockSyncFromExtension).toHaveBeenCalled()
     expect(screen.getByDisplayValue(syncedUrl)).toBeInTheDocument()
-    expect(screen.getByText(COMMON_MESSAGES.SETTINGS_SYNCED)).toBeInTheDocument()
+    expect(
+      screen.getByText(COMMON_MESSAGES.SETTINGS_SYNCED),
+    ).toBeInTheDocument()
   })
 
   it('同期エラー時にエラーメッセージが表示されること', () => {
@@ -95,7 +103,7 @@ describe('SettingsPanel', () => {
   it('閉じるボタンで onClose が呼ばれること', () => {
     render(<SettingsPanel {...defaultProps} />)
     const closeButton = screen.getByText(FIELD_LABELS.BUTTON_CLOSE)
-    
+
     fireEvent.click(closeButton)
     expect(defaultProps.onClose).toHaveBeenCalled()
   })

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,8 +1,14 @@
 import { useState } from 'react'
-import { useExtensionSync } from '../hooks/useExtensionSync'
+
+import {
+  COMMON_MESSAGES,
+  FIELD_LABELS,
+  DEFAULT_API_URL,
+} from '@shared/constants'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
-import { COMMON_MESSAGES, FIELD_LABELS, DEFAULT_API_URL } from '@shared/constants'
+
+import { useExtensionSync } from '../hooks/useExtensionSync'
 
 interface SettingsPanelProps {
   onClose: () => void
@@ -40,7 +46,7 @@ export const SettingsPanel = ({
       setValidationError(error)
       return
     }
-    
+
     // 成功時は親コンポーネント側で閉じられる
   }
 

--- a/src/contexts/ApiContext.test.tsx
+++ b/src/contexts/ApiContext.test.tsx
@@ -1,7 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { act, renderHook as renderHookOriginal } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import {
+  STORAGE_KEYS,
+  DEFAULT_API_URL,
+  LOG_MESSAGES,
+  ERROR_MESSAGES,
+} from '@shared/constants'
+
 import { useApi } from './ApiContext'
-import { STORAGE_KEYS, DEFAULT_API_URL, LOG_MESSAGES, ERROR_MESSAGES } from '@shared/constants'
 import { renderHook } from '../test/utils'
 
 describe('ApiContext', () => {
@@ -37,7 +44,7 @@ describe('ApiContext', () => {
     expect(result.current.apiUrl).toBe(DEFAULT_API_URL)
     expect(console.warn).toHaveBeenCalledWith(
       LOG_MESSAGES.INVALID_STORAGE_URL,
-      expect.any(String)
+      expect.any(String),
     )
   })
 
@@ -80,14 +87,14 @@ describe('ApiContext', () => {
     expect(result.current.apiUrl).toBe(DEFAULT_API_URL)
     expect(consoleSpy).toHaveBeenCalledWith(
       ERROR_MESSAGES.UPDATE_API_URL_FAILED,
-      expect.any(String)
+      expect.any(String),
     )
   })
 
   it('ApiProvider 外で useApi を呼び出した場合にエラーを投げること', () => {
     // コンソール出力を抑制
     vi.spyOn(console, 'error').mockImplementation(() => {})
-    
+
     // カスタムラッパーを介さず、本体の renderHook を使用
     expect(() => {
       renderHookOriginal(() => useApi())

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -1,4 +1,3 @@
-import { hc } from 'hono/client'
 import {
   createContext,
   useCallback,
@@ -8,7 +7,14 @@ import {
   type ReactNode,
 } from 'react'
 
-import { DEFAULT_API_URL, STORAGE_KEYS, LOG_MESSAGES, ERROR_MESSAGES } from '@shared/constants'
+import { hc } from 'hono/client'
+
+import {
+  DEFAULT_API_URL,
+  STORAGE_KEYS,
+  LOG_MESSAGES,
+  ERROR_MESSAGES,
+} from '@shared/constants'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
 
 import type { AppType } from '../../server/app'
@@ -51,10 +57,7 @@ export const ApiProvider = ({ children, initialUrl }: ApiProviderProps) => {
         return savedUrl
       }
       // 不正な場合はログを出力してデフォルトへフォールバック
-      console.warn(
-        LOG_MESSAGES.INVALID_STORAGE_URL,
-        error,
-      )
+      console.warn(LOG_MESSAGES.INVALID_STORAGE_URL, error)
     }
 
     return DEFAULT_API_URL

--- a/src/hooks/useApp.test.tsx
+++ b/src/hooks/useApp.test.tsx
@@ -1,9 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useApp } from './useApp'
-import { TEST_MESSAGES } from '@shared/constants'
 import { http, HttpResponse } from 'msw'
-import { server } from '../test/setup'
-import { renderHook, waitFor, act } from '../test/utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { TEST_MESSAGES } from '@shared/constants'
 import { BookmarkIdSchema } from '@shared/schemas/bookmark'
 import {
   MOCK_BOOKMARK_1,
@@ -12,6 +10,10 @@ import {
   MOCK_KEYWORDS,
 } from '@shared/test/fixtures'
 import { openUrlInNewTab } from '@shared/utils/url'
+
+import { useApp } from './useApp'
+import { server } from '../test/setup'
+import { renderHook, waitFor, act } from '../test/utils'
 
 // openUrlInNewTab をモック化
 vi.mock('@shared/utils/url', async () => {

--- a/src/hooks/useApp.ts
+++ b/src/hooks/useApp.ts
@@ -1,20 +1,24 @@
+import { useMemo, useCallback, useState } from 'react'
+
+import { z } from 'zod'
+
+import { DROPPABLE_IDS } from '@shared/constants'
+import { BookmarkIdSchema } from '@shared/schemas/bookmark'
+import type { Bookmark } from '@shared/schemas/bookmark'
+import { openUrlInNewTab } from '@shared/utils/url'
+
+import { useBookmarkListState } from './useBookmarkListState'
+import { useBookmarkReorder } from './useBookmarkReorder'
 import {
   useBookmarks,
   useKeywords,
   useAttachKeyword,
   useDetachKeyword,
 } from './useBookmarks'
-import { useSettings } from './useSettings'
-import { useBookmarkListState } from './useBookmarkListState'
 import { useKeywordListState } from './useKeywordListState'
-import { useBookmarkReorder } from './useBookmarkReorder'
-import { openUrlInNewTab } from '@shared/utils/url'
-import { useMemo, useCallback, useState } from 'react'
+import { useSettings } from './useSettings'
+
 import type { DragStartEvent, DragEndEvent } from '@dnd-kit/core'
-import { BookmarkIdSchema } from '@shared/schemas/bookmark'
-import type { Bookmark } from '@shared/schemas/bookmark'
-import { DROPPABLE_IDS } from '@shared/constants'
-import { z } from 'zod'
 
 export const useApp = () => {
   // 1. 設定管理

--- a/src/hooks/useBookmarkListState.test.ts
+++ b/src/hooks/useBookmarkListState.test.ts
@@ -1,8 +1,10 @@
 import { act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useBookmarkListState } from './useBookmarkListState'
-import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
+
 import { APP_PATHS } from '@shared/constants'
+import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
+
+import { useBookmarkListState } from './useBookmarkListState'
 import { renderHook } from '../test/utils'
 
 // useNavigate のモック

--- a/src/hooks/useBookmarkListState.ts
+++ b/src/hooks/useBookmarkListState.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback } from 'react'
+
 import { useNavigate } from 'react-router-dom'
+
 import { APP_PATHS } from '@shared/constants'
 import type { BookmarkId } from '@shared/schemas/bookmark'
 

--- a/src/hooks/useBookmarkPage.test.ts
+++ b/src/hooks/useBookmarkPage.test.ts
@@ -1,11 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, act, waitFor } from '../test/utils'
-import { createDragStartEvent, createDragEndEvent } from '../test/dnd-utils'
-import { createKeyboardEvent } from '../test/event-utils'
-import { useBookmarkPage } from './useBookmarkPage'
-import { MOCK_BOOKMARK_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
+import { fireEvent } from '@testing-library/react'
 import { http, HttpResponse, delay } from 'msw'
-import { server } from '../test/setup'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
 import {
   APP_PATHS,
   HTTP_STATUS,
@@ -13,8 +9,14 @@ import {
   DROPPABLE_IDS,
   KEY_VALUES,
 } from '@shared/constants'
-import { fireEvent } from '@testing-library/react'
+import { MOCK_BOOKMARK_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
 import * as urlUtils from '@shared/utils/url'
+
+import { useBookmarkPage } from './useBookmarkPage'
+import { createDragStartEvent, createDragEndEvent } from '../test/dnd-utils'
+import { createKeyboardEvent } from '../test/event-utils'
+import { server } from '../test/setup'
+import { renderHook, act, waitFor } from '../test/utils'
 
 // モックの設定
 const mockNavigate = vi.fn()

--- a/src/hooks/useBookmarkPage.ts
+++ b/src/hooks/useBookmarkPage.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback, useEffect, useMemo } from 'react'
+
 import { useParams, useNavigate } from 'react-router-dom'
+
 import {
   APP_PATHS,
   LOG_MESSAGES,
@@ -8,6 +10,10 @@ import {
   KEY_VALUES,
 } from '@shared/constants'
 import { BookmarkIdSchema } from '@shared/schemas/bookmark'
+import { KeywordIdSchema } from '@shared/schemas/keyword'
+import type { Keyword, KeywordId } from '@shared/schemas/keyword'
+import { openUrlInNewTab } from '@shared/utils/url'
+
 import {
   useBookmarks,
   useKeywords,
@@ -17,10 +23,8 @@ import {
   useAttachKeyword,
   useDetachKeyword,
 } from './useBookmarks'
-import { openUrlInNewTab } from '@shared/utils/url'
+
 import type { DragStartEvent, DragEndEvent } from '@dnd-kit/core'
-import { KeywordIdSchema } from '@shared/schemas/keyword'
-import type { Keyword, KeywordId } from '@shared/schemas/keyword'
 
 /**
  * ブックマーク詳細画面のロジックを管理するカスタムフック

--- a/src/hooks/useBookmarkReorder.test.tsx
+++ b/src/hooks/useBookmarkReorder.test.tsx
@@ -1,10 +1,12 @@
 import { act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useBookmarkReorder } from './useBookmarkReorder'
-import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2 } from '@shared/test/fixtures'
-import { renderHook } from '../test/utils'
-import { useReorderBookmarks, useBookmarks } from './useBookmarks'
+
 import { LOG_MESSAGES, TEST_MESSAGES } from '@shared/constants'
+import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2 } from '@shared/test/fixtures'
+
+import { useBookmarkReorder } from './useBookmarkReorder'
+import { useReorderBookmarks, useBookmarks } from './useBookmarks'
+import { renderHook } from '../test/utils'
 
 describe('useBookmarkReorder Hook (DI Pattern)', () => {
   const mockMutate = vi.fn()
@@ -15,13 +17,13 @@ describe('useBookmarkReorder Hook (DI Pattern)', () => {
 
   const renderReorderHook = (
     rHook: unknown = mockReorderHook,
-    bHook: unknown = mockBookmarksHook
+    bHook: unknown = mockBookmarksHook,
   ) => {
-    return renderHook(() => 
+    return renderHook(() =>
       useBookmarkReorder(
         rHook as unknown as typeof useReorderBookmarks,
-        bHook as unknown as typeof useBookmarks
-      )
+        bHook as unknown as typeof useBookmarks,
+      ),
     )
   }
 
@@ -31,13 +33,17 @@ describe('useBookmarkReorder Hook (DI Pattern)', () => {
 
   it('handleReorder が同じ ID の場合は何もしないこと', async () => {
     const { result } = renderReorderHook()
-    act(() => { result.current.handleReorder(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_1.id) })
+    act(() => {
+      result.current.handleReorder(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_1.id)
+    })
     expect(mockMutate).not.toHaveBeenCalled()
   })
 
   it('有効な ID の組み合わせで handleReorder が呼ばれた場合、全 ID リストを構築して mutate を呼び出すこと', async () => {
     const { result } = renderReorderHook()
-    act(() => { result.current.handleReorder(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_2.id) })
+    act(() => {
+      result.current.handleReorder(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_2.id)
+    })
     expect(mockMutate).toHaveBeenCalledWith({
       ids: [MOCK_BOOKMARK_2.id, MOCK_BOOKMARK_1.id],
     })
@@ -45,23 +51,37 @@ describe('useBookmarkReorder Hook (DI Pattern)', () => {
 
   it('ブックマークデータが存在しない、または ID が見つからない場合は何もしないこと', async () => {
     // データなしケース
-    const { result: res1 } = renderReorderHook(mockReorderHook, vi.fn(() => ({ data: null })))
-    act(() => { res1.current.handleReorder(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_2.id) })
+    const { result: res1 } = renderReorderHook(
+      mockReorderHook,
+      vi.fn(() => ({ data: null })),
+    )
+    act(() => {
+      res1.current.handleReorder(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_2.id)
+    })
     expect(mockMutate).not.toHaveBeenCalled()
 
     // ID見つからないケース
     const { result: res2 } = renderReorderHook()
-    act(() => { res2.current.handleReorder('invalid', MOCK_BOOKMARK_2.id) })
+    act(() => {
+      res2.current.handleReorder('invalid', MOCK_BOOKMARK_2.id)
+    })
     expect(mockMutate).not.toHaveBeenCalled()
   })
 
   it('例外が発生した場合にキャッチしてログを出力すること', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-    mockMutate.mockImplementationOnce(() => { throw new Error(TEST_MESSAGES.MUTATION_FAILED) })
+    mockMutate.mockImplementationOnce(() => {
+      throw new Error(TEST_MESSAGES.MUTATION_FAILED)
+    })
 
     const { result } = renderReorderHook()
-    act(() => { result.current.handleReorder(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_2.id) })
+    act(() => {
+      result.current.handleReorder(MOCK_BOOKMARK_1.id, MOCK_BOOKMARK_2.id)
+    })
 
-    expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGES.REORDER_FAILED_CONSOLE, expect.any(Error))
+    expect(consoleSpy).toHaveBeenCalledWith(
+      LOG_MESSAGES.REORDER_FAILED_CONSOLE,
+      expect.any(Error),
+    )
   })
 })

--- a/src/hooks/useBookmarkReorder.ts
+++ b/src/hooks/useBookmarkReorder.ts
@@ -1,6 +1,8 @@
 import { arrayMove } from '@dnd-kit/sortable'
-import { useBookmarks, useReorderBookmarks } from './useBookmarks'
+
 import { LOG_MESSAGES } from '@shared/constants'
+
+import { useBookmarks, useReorderBookmarks } from './useBookmarks'
 
 /**
  * ブックマークの並び替えロジックを管理するフック
@@ -8,7 +10,7 @@ import { LOG_MESSAGES } from '@shared/constants'
  */
 export const useBookmarkReorder = (
   reorderHook = useReorderBookmarks,
-  bookmarksHook = useBookmarks
+  bookmarksHook = useBookmarks,
 ) => {
   const { mutate } = reorderHook()
   const { data } = bookmarksHook()
@@ -25,7 +27,7 @@ export const useBookmarkReorder = (
       if (oldIndex !== -1 && newIndex !== -1) {
         const newBookmarks = arrayMove(data.bookmarks, oldIndex, newIndex)
         const newIds = newBookmarks.map((b) => b.id)
-        
+
         // 全 ID リストを送信して整合性を保つ
         mutate({ ids: newIds })
       }

--- a/src/hooks/useBookmarks.test.tsx
+++ b/src/hooks/useBookmarks.test.tsx
@@ -2,10 +2,9 @@ import { http, HttpResponse } from 'msw'
 import { describe, expect, it, vi } from 'vitest'
 
 import { API_PATHS, LOG_MESSAGES } from '@shared/constants'
+import type { BookmarkId } from '@shared/schemas/bookmark'
 import { MOCK_BOOKMARK_1 } from '@shared/test/fixtures'
-import { renderHook, waitFor } from '../test/utils'
 
-import { server } from '../test/setup'
 import {
   BookmarkApiError,
   useBookmarks,
@@ -13,7 +12,8 @@ import {
   useReorderBookmarks,
   useUpdateBookmark,
 } from './useBookmarks'
-import type { BookmarkId } from '@shared/schemas/bookmark'
+import { server } from '../test/setup'
+import { renderHook, waitFor } from '../test/utils'
 
 describe('useBookmarks Hook', () => {
   it('useBookmarks が正常にデータを取得すること', async () => {
@@ -104,7 +104,10 @@ describe('useBookmarks Hook', () => {
     server.use(
       http.delete(`*${API_PATHS.BOOKMARKS}/:id`, () => {
         return HttpResponse.json(
-          { success: false, error: { message: 'Delete Failed', code: 'DELETE_ERROR' } },
+          {
+            success: false,
+            error: { message: 'Delete Failed', code: 'DELETE_ERROR' },
+          },
           { status: 400 },
         )
       }),

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -1,9 +1,6 @@
-import { HTTP_STATUS, LOG_MESSAGES, UI_MESSAGES } from '@shared/constants'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-import { useApi } from '../contexts/ApiContext'
-import { QUERY_KEYS } from '../lib/queryKeys'
-
+import { HTTP_STATUS, LOG_MESSAGES, UI_MESSAGES } from '@shared/constants'
 import type {
   BookmarkId,
   BookmarksResponse,
@@ -16,6 +13,9 @@ import type {
   KeywordsResponse,
   CreateKeywordRequest,
 } from '@shared/schemas/keyword'
+
+import { useApi } from '../contexts/ApiContext'
+import { QUERY_KEYS } from '../lib/queryKeys'
 
 /**
  * API エラー情報を保持するカスタムエラークラス

--- a/src/hooks/useExtensionSync.test.ts
+++ b/src/hooks/useExtensionSync.test.ts
@@ -1,7 +1,9 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { useExtensionSync } from './useExtensionSync'
+
 import { UI_MESSAGES } from '@shared/constants'
+
+import { useExtensionSync } from './useExtensionSync'
 
 describe('useExtensionSync Hook', () => {
   const mockExtensionId = 'test-extension-id'
@@ -42,7 +44,7 @@ describe('useExtensionSync Hook', () => {
     ;(window as unknown as { chrome: unknown }).chrome = undefined
 
     const { result } = renderHook(() => useExtensionSync())
-    
+
     await act(async () => {
       const syncedUrl = await result.current.syncFromExtension()
       expect(syncedUrl).toBeNull()
@@ -53,9 +55,9 @@ describe('useExtensionSync Hook', () => {
 
   it('VITE_EXTENSION_ID が設定されていない場合にエラーを返すこと', async () => {
     vi.stubEnv('VITE_EXTENSION_ID', '')
-    
+
     const { result } = renderHook(() => useExtensionSync())
-    
+
     await act(async () => {
       const syncedUrl = await result.current.syncFromExtension()
       expect(syncedUrl).toBeNull()
@@ -66,7 +68,9 @@ describe('useExtensionSync Hook', () => {
 
   it('拡張機能側でエラーが発生した場合にエラーを返すこと', async () => {
     const mockSendMessage = vi.fn((_id, _msg, callback) => {
-      const win = window as unknown as { chrome: { runtime: { lastError: unknown } } }
+      const win = window as unknown as {
+        chrome: { runtime: { lastError: unknown } }
+      }
       win.chrome.runtime.lastError = { message: 'Extension error' }
       callback({ success: false })
     })
@@ -79,7 +83,7 @@ describe('useExtensionSync Hook', () => {
     }
 
     const { result } = renderHook(() => useExtensionSync())
-    
+
     await act(async () => {
       const syncedUrl = await result.current.syncFromExtension()
       expect(syncedUrl).toBeNull()
@@ -101,7 +105,7 @@ describe('useExtensionSync Hook', () => {
     }
 
     const { result } = renderHook(() => useExtensionSync())
-    
+
     await act(async () => {
       const syncedUrl = await result.current.syncFromExtension()
       expect(syncedUrl).toBeNull()

--- a/src/hooks/useExtensionSync.ts
+++ b/src/hooks/useExtensionSync.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
+
 import { EXTENSION_MESSAGE_TYPES, UI_MESSAGES } from '@shared/constants'
 
 /**
@@ -18,7 +19,7 @@ interface ChromeWindow {
       sendMessage: (
         extensionId: string,
         message: unknown,
-        callback: (response: ExtensionResponse) => void
+        callback: (response: ExtensionResponse) => void,
       ) => void
       lastError?: {
         message?: string
@@ -71,7 +72,9 @@ export const useExtensionSync = () => {
 
           if (lastError) {
             if (isMounted.current) {
-              setSyncError(lastError.message || UI_MESSAGES.SYNC_CONNECTION_FAILED)
+              setSyncError(
+                lastError.message || UI_MESSAGES.SYNC_CONNECTION_FAILED,
+              )
             }
           } else if (response?.success && response.apiUrl) {
             result = response.apiUrl
@@ -85,7 +88,7 @@ export const useExtensionSync = () => {
             setIsSyncing(false)
           }
           resolve(result)
-        }
+        },
       )
     })
   }, [])

--- a/src/hooks/useKeywordListState.test.ts
+++ b/src/hooks/useKeywordListState.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { renderHook, act } from '../test/utils'
-import { useKeywordListState } from './useKeywordListState'
-import { KeywordIdSchema } from '@shared/schemas/keyword'
 import { useState, useCallback } from 'react'
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { KeywordIdSchema } from '@shared/schemas/keyword'
+
+import { useKeywordListState } from './useKeywordListState'
+import { renderHook, act } from '../test/utils'
 
 // URLSearchParams の状態を外部から覗き見るための変数
 let capturedParams = new URLSearchParams()

--- a/src/hooks/useKeywordListState.ts
+++ b/src/hooks/useKeywordListState.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from 'react'
+
 import { useSearchParams } from 'react-router-dom'
+
 import { KeywordIdSchema } from '@shared/schemas/keyword'
 import type { KeywordId } from '@shared/schemas/keyword'
 

--- a/src/hooks/useSettings.test.ts
+++ b/src/hooks/useSettings.test.ts
@@ -1,3 +1,4 @@
+import { act } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -10,11 +11,10 @@ import {
   ERROR_MESSAGES,
 } from '@shared/constants'
 import { INVALID_URLS } from '@shared/test/fixtures'
-import { act } from '@testing-library/react'
 
-import { renderHook } from '../test/utils'
 import { useSettings } from './useSettings'
 import * as apiContext from '../contexts/ApiContext'
+import { renderHook } from '../test/utils'
 
 describe('useSettings Hook', () => {
   beforeEach(() => {

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,7 +1,8 @@
 import { useCallback, useState } from 'react'
 
-import { COMMON_MESSAGES, LOG_MESSAGES } from '@shared/constants'
 import { useQueryClient } from '@tanstack/react-query'
+
+import { COMMON_MESSAGES, LOG_MESSAGES } from '@shared/constants'
 
 import { useApi } from '../contexts/ApiContext'
 

--- a/src/lib/queryKeys.test.ts
+++ b/src/lib/queryKeys.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { QUERY_KEYS } from './queryKeys'
 
 describe('QUERY_KEYS', () => {
@@ -38,13 +39,16 @@ describe('QUERY_KEYS', () => {
         { id: 0, expected: '0' },
         { id: '0', expected: '0' },
         { id: -1, expected: '-1' },
-      ])('エッジケース ($id) でも正しく文字列化されること', ({ id, expected }) => {
-        expect(QUERY_KEYS.BOOKMARKS.DETAIL(id)).toEqual([
-          'bookmarks',
-          'detail',
-          expected,
-        ])
-      })
+      ])(
+        'エッジケース ($id) でも正しく文字列化されること',
+        ({ id, expected }) => {
+          expect(QUERY_KEYS.BOOKMARKS.DETAIL(id)).toEqual([
+            'bookmarks',
+            'detail',
+            expected,
+          ])
+        },
+      )
     })
   })
 })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,9 @@
 import { StrictMode } from 'react'
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
 import './index.css'
 import App from './App.tsx'
 import { ApiProvider } from './contexts/ApiContext'

--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -15,9 +15,9 @@ import { updateBookmarkSchema } from '@shared/schemas/bookmark'
 import { MOCK_BOOKMARK_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
 import * as urlUtils from '@shared/utils/url'
 
+import { BookmarkPage } from './BookmarkPage'
 import { server } from '../test/setup'
 import { fireEvent, render, screen, waitFor } from '../test/utils'
-import { BookmarkPage } from './BookmarkPage'
 
 // openUrlInNewTab をモック
 vi.mock('@shared/utils/url', async () => {

--- a/src/pages/BookmarkPage.tsx
+++ b/src/pages/BookmarkPage.tsx
@@ -1,21 +1,23 @@
 import {
+  DndContext,
+  closestCorners,
+  useDroppable,
+  DragOverlay,
+} from '@dnd-kit/core'
+
+import {
   FIELD_LABELS,
   PLACEHOLDERS,
   UI_MESSAGES,
   DROPPABLE_IDS,
   ELEMENT_IDS,
 } from '@shared/constants'
-import {
-  DndContext,
-  closestCorners,
-  useDroppable,
-  DragOverlay,
-} from '@dnd-kit/core'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
-import { useBookmarkPage } from '../hooks/useBookmarkPage'
-import { KeywordList } from '../components/KeywordList'
+
 import { KeywordItem } from '../components/KeywordItem'
+import { KeywordList } from '../components/KeywordList'
+import { useBookmarkPage } from '../hooks/useBookmarkPage'
 
 interface BookmarkPageProps {
   onBack?: () => void

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,13 +1,5 @@
-import {
-  FIELD_LABELS,
-  KEY_VALUES,
-  DROPPABLE_IDS,
-  UI_MESSAGES,
-} from '@shared/constants'
-import { BookmarkList } from '../components/BookmarkList'
-import { KeywordList } from '../components/KeywordList'
-import { useApp } from '../hooks/useApp'
 import { useEffect } from 'react'
+
 import {
   DndContext,
   DragOverlay,
@@ -19,7 +11,18 @@ import {
   useDroppable,
 } from '@dnd-kit/core'
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+
+import {
+  FIELD_LABELS,
+  KEY_VALUES,
+  DROPPABLE_IDS,
+  UI_MESSAGES,
+} from '@shared/constants'
+
 import { BookmarkItem } from '../components/BookmarkItem'
+import { BookmarkList } from '../components/BookmarkList'
+import { KeywordList } from '../components/KeywordList'
+import { useApp } from '../hooks/useApp'
 
 interface HomePageProps {
   appState: ReturnType<typeof useApp>

--- a/src/pages/KeywordPage.test.tsx
+++ b/src/pages/KeywordPage.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, it } from 'vitest'
 
 import { APP_PATHS, ARIA_ROLES, FIELD_LABELS } from '@shared/constants'
 
-import { render, screen } from '../test/utils'
 import { KeywordPage } from './KeywordPage'
+import { render, screen } from '../test/utils'
 
 describe('KeywordPage', () => {
   it('URL パラメータから取得したキーワード ID が表示されること', () => {

--- a/src/pages/KeywordPage.tsx
+++ b/src/pages/KeywordPage.tsx
@@ -1,4 +1,5 @@
 import { useParams, Link } from 'react-router-dom'
+
 import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
 
 export function KeywordPage() {

--- a/src/test/event-utils.ts
+++ b/src/test/event-utils.ts
@@ -1,5 +1,6 @@
-import { vi } from 'vitest'
 import type React from 'react'
+
+import { vi } from 'vitest'
 
 /**
  * テスト用の KeyboardEvent を作成するユーティリティ

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
-import { beforeAll, afterEach, afterAll, vi } from 'vitest'
 import { setupServer } from 'msw/node'
+import { beforeAll, afterEach, afterAll, vi } from 'vitest'
 
 export const server = setupServer()
 

--- a/src/test/utils.test.tsx
+++ b/src/test/utils.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from './utils'
 import { type ReactNode } from 'react'
+
+import { describe, it, expect } from 'vitest'
+
+import { render, screen } from './utils'
 
 describe('src/test/utils.tsx functional verification', () => {
   it('customRender supports additional wrapper', () => {
@@ -12,7 +14,9 @@ describe('src/test/utils.tsx functional verification', () => {
 
     expect(screen.getByTestId('custom-wrapper')).toBeInTheDocument()
     expect(screen.getByTestId('content')).toBeInTheDocument()
-    expect(screen.getByTestId('custom-wrapper')).toContainElement(screen.getByTestId('content'))
+    expect(screen.getByTestId('custom-wrapper')).toContainElement(
+      screen.getByTestId('content'),
+    )
   })
 
   it('customRender still provides AllTheProviders context', () => {

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,9 +1,12 @@
 import { useMemo, type ReactNode, type ReactElement } from 'react'
-import { render, renderHook } from '@testing-library/react'
-import type { RenderOptions, RenderHookOptions } from '@testing-library/react'
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, renderHook } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
+
 import { ApiProvider } from '../contexts/ApiContext'
+
+import type { RenderOptions, RenderHookOptions } from '@testing-library/react'
 
 /**
  * テスト用の QueryClient を作成

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
-import { defineConfig, loadEnv } from 'vite'
-import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import { defineConfig, loadEnv } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
-import { getPortFromUrl } from './shared/utils/port'
+
 import { DEFAULT_PORTS } from './shared/constants'
+import { getPortFromUrl } from './shared/utils/port'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
### 概要
インポート文の順序を一貫させ、可読性と保守性を向上させるために `eslint-plugin-import-x` を導入しました。

### 変更内容
- **設定**: `eslint.config.js` に最新のインポート順序ルールを定義。
- **自動修正**: プロジェクト全体の全ファイルに対し、定義された順序（builtin -> external -> internal -> parent/sibling -> type）を適用。
- **検証**: インポート順序の変更による型定義やランタイム（テスト）への影響がないことを確認済み。

### 効果
- コードベース全体のインポート順序が美しく統一されました。
- 今後の開発において、インポートの書き方の揺れを手動で直す手間がなくなります。

Closes #318