### PR TITLE
refactor(extension): ブックマーク状態判定ロジックを共通ユーティリティ化 (#323)

### DIFF
--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -8,9 +8,13 @@ import {
   LOG_MESSAGES,
   ALLOWED_ORIGINS,
 } from '@shared/constants'
-import type { Bookmark, BookmarksResponse } from '@shared/schemas/bookmark'
+import type { BookmarksResponse } from '@shared/schemas/bookmark'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
 
+import {
+  findBookmarkByUrl,
+  determineBookmarkStatus,
+} from './lib/bookmark-utils'
 import { QUERY_KEYS } from '../../src/lib/queryKeys'
 
 /**
@@ -56,7 +60,7 @@ const updateIconStatus = async (
       return
     }
 
-    // 2. セキュリティバリデーション (Security fix)
+    // 2. セキュリティバリデーション
     const urlError = validateApiUrl(apiUrl)
     if (urlError) {
       console.warn(LOG_MESSAGES.INVALID_STORAGE_URL_BACKGROUND, urlError)
@@ -81,21 +85,13 @@ const updateIconStatus = async (
       },
     })
 
-    // 4. 状態判定
-    const bookmark = data.bookmarks.find((b: Bookmark) => b.url === url)
-
-    let status: keyof typeof BOOKMARK_STATUS = 'NONE'
-    if (!bookmark) {
-      status = 'NONE'
-    } else if (bookmark.title === title) {
-      status = 'REGISTERED'
-    } else {
-      status = 'MODIFIED'
-    }
+    // 4. 状態判定 (共通ユーティリティを使用)
+    const bookmark = findBookmarkByUrl(data.bookmarks, url)
+    const statusKey = determineBookmarkStatus(bookmark, title)
 
     chrome.action.setIcon({
       tabId,
-      path: EXTENSION_ICONS[BOOKMARK_STATUS[status]],
+      path: EXTENSION_ICONS[BOOKMARK_STATUS[statusKey]],
     })
   } catch (err) {
     console.error(LOG_MESSAGES.ICON_STATUS_UPDATE_FAILED, err)

--- a/extension/src/lib/bookmark-utils.test.ts
+++ b/extension/src/lib/bookmark-utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+
+import { bookmarkSchema } from '@shared/schemas/bookmark'
+
+import { findBookmarkByUrl, determineBookmarkStatus } from './bookmark-utils'
+
+describe('bookmark-utils', () => {
+  // モックデータを Zod スキーマでパースして生成（スキーマとの不整合を防止）
+  const mockBookmarks = z.array(bookmarkSchema).parse([
+    {
+      id: '1',
+      title: 'Test 1',
+      url: 'https://test1.com',
+      sortOrder: 1,
+      keywords: [],
+    },
+    {
+      id: '2',
+      title: 'Test 2',
+      url: 'https://test2.com',
+      sortOrder: 2,
+      keywords: [],
+    },
+  ])
+
+  describe('findBookmarkByUrl', () => {
+    it('URL が一致するブックマークを返すこと', () => {
+      const result = findBookmarkByUrl(mockBookmarks, 'https://test1.com')
+      expect(result).toEqual(mockBookmarks[0])
+    })
+
+    it('URL が一致しない場合は undefined を返すこと', () => {
+      const result = findBookmarkByUrl(mockBookmarks, 'https://unknown.com')
+      expect(result).toBeUndefined()
+    })
+
+    it('URL が undefined の場合は undefined を返すこと', () => {
+      const result = findBookmarkByUrl(mockBookmarks, undefined)
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('determineBookmarkStatus', () => {
+    it('ブックマークが存在しない場合は NONE を返すこと', () => {
+      const result = determineBookmarkStatus(undefined, 'Title')
+      expect(result).toBe('NONE')
+    })
+
+    it('タイトルが一致する場合は REGISTERED を返すこと', () => {
+      const bookmark = mockBookmarks[0]
+      const result = determineBookmarkStatus(bookmark, 'Test 1')
+      expect(result).toBe('REGISTERED')
+    })
+
+    it('タイトルが異なる場合は MODIFIED を返すこと', () => {
+      const bookmark = mockBookmarks[0]
+      const result = determineBookmarkStatus(bookmark, 'Different Title')
+      expect(result).toBe('MODIFIED')
+    })
+
+    it('タイトルが undefined の場合（かつブックマークあり）は MODIFIED を返すこと', () => {
+      const bookmark = mockBookmarks[0]
+      const result = determineBookmarkStatus(bookmark, undefined)
+      expect(result).toBe('MODIFIED')
+    })
+  })
+})

--- a/extension/src/lib/bookmark-utils.ts
+++ b/extension/src/lib/bookmark-utils.ts
@@ -1,0 +1,32 @@
+import { BOOKMARK_STATUS } from '@shared/constants'
+import type { Bookmark } from '@shared/schemas/bookmark'
+
+/**
+ * URL に一致するブックマークを検索する
+ */
+export const findBookmarkByUrl = (
+  bookmarks: Bookmark[],
+  url: string | undefined,
+): Bookmark | undefined => {
+  if (!url) return undefined
+  return bookmarks.find((b) => b.url === url)
+}
+
+/**
+ * ブックマークの状態を判定する
+ * - NONE: 未登録
+ * - REGISTERED: 登録済みかつタイトルも一致
+ * - MODIFIED: 登録済みだがタイトルが異なる
+ */
+export const determineBookmarkStatus = (
+  bookmark: Bookmark | undefined,
+  currentTitle: string | undefined,
+): keyof typeof BOOKMARK_STATUS => {
+  if (!bookmark) {
+    return 'NONE'
+  }
+  if (bookmark.title === currentTitle) {
+    return 'REGISTERED'
+  }
+  return 'MODIFIED'
+}


### PR DESCRIPTION
### 概要
`background.ts` にあった「登録済みかどうかの判定ロジック」を共通ユーティリティとして抽出しました。

### 変更内容
- `extension/src/lib/bookmark-utils.ts` の作成。
- `background.ts` の既存ロジックを置換。
- 抽出したロジックに対する単体テストを追加。

### 期待される効果
- コードの重複排除。
- 今後のポップアップ機能拡張（#324, #322）でのロジック共有が可能に。

Closes #323