### PR TITLE
chore: Vite のネイティブ tsconfig パス解決に移行 (#329)

### DIFF
--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -4,12 +4,14 @@ import { fileURLToPath } from 'url'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
-  plugins: [react(), tailwindcss(), tsconfigPaths()],
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    tsconfigPaths: true,
+  },
   root: path.resolve(__dirname),
   build: {
     outDir: path.resolve(__dirname, '../dist-extension'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.56.1",
         "vite": "^8.0.1",
-        "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.0.17"
       },
       "engines": {
@@ -4831,13 +4830,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -7062,27 +7054,6 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -7373,21 +7344,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
-      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
     "vite": "^8.0.1",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.0.17"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { defineConfig, loadEnv } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 import { DEFAULT_PORTS } from './shared/constants'
 import { getPortFromUrl } from './shared/utils/port'
@@ -13,7 +12,10 @@ export default defineConfig(({ mode }) => {
   const port = getPortFromUrl(frontendUrl, DEFAULT_PORTS.FRONTEND)
 
   return {
-    plugins: [react(), tailwindcss(), tsconfigPaths()],
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      tsconfigPaths: true,
+    },
     server: {
       port,
       proxy: {


### PR DESCRIPTION
### 概要
Vite の最新機能により `tsconfig.json` の `paths` 解決がネイティブでサポートされたため、従来使用していた `vite-tsconfig-paths` プラグインを廃止し、標準設定に移行しました。

### 変更内容
- `vite.config.ts` および `extension/vite.config.ts` において `resolve.tsconfigPaths: true` を設定。
- `vite-tsconfig-paths` プラグインのインポートと使用箇所を削除。
- `package.json` から `vite-tsconfig-paths` をアンインストール。

### 検証内容
- `npm run build`: 正常終了。
- `npm test`: 全 363 件パス。
- パス解決（`@shared/*` 等）が正常に機能していることを確認。

Closes #329