### PR TITLE
test: HomePage のキーボードショートカットに関するテストを追加し、カバレッジを向上させる (#330)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -290,5 +290,53 @@ describe('App Integration', () => {
 
       await waitFor(() => expect(detachCalled).toBe(true))
     })
+
+    it('キーワード選択中に Escape キーを押すと、すべての選択が解除されること', async () => {
+      const { user } = setup()
+
+      const keyword1 = await screen.findByRole(ARIA_ROLES.BUTTON, {
+        name: MOCK_KEYWORDS[0].name,
+      })
+      const keyword2 = await screen.findByRole(ARIA_ROLES.BUTTON, {
+        name: MOCK_KEYWORDS[1].name,
+      })
+
+      // 1. 2つのキーワードを選択
+      await user.click(keyword1)
+      await user.click(keyword2)
+      expect(keyword1).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'true')
+      expect(keyword2).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'true')
+
+      // 2. Escape キーを押下
+      await user.keyboard('{' + KEY_VALUES.ESCAPE + '}')
+
+      // 3. 全ての選択が解除されていることを検証
+      expect(keyword1).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'false')
+      expect(keyword2).toHaveAttribute(ARIA_ATTRIBUTES.SELECTED, 'false')
+    })
+
+    it('入力フィールドにフォーカスがある場合、Enter キーを押しても一括起動が発生しないこと', async () => {
+      const kw1 = MOCK_KEYWORDS[0]
+      const b1 = { ...MOCK_BOOKMARK_1, keywords: [kw1] }
+      const { user } = setup([b1])
+
+      // 1. キーワードを選択
+      const keywordBtn = await screen.findByRole(ARIA_ROLES.BUTTON, {
+        name: kw1.name,
+      })
+      await user.click(keywordBtn)
+
+      // 2. 設定パネルを開いて入力フィールドを取得
+      const settingsButton = screen.getByTitle(FIELD_LABELS.SETTING_TITLE)
+      await user.click(settingsButton)
+      const input = screen.getByLabelText(FIELD_LABELS.URL)
+
+      // 3. 入力フィールドにフォーカスを当てて Enter
+      await user.click(input)
+      await user.keyboard(`{${KEY_VALUES.ENTER}}`)
+
+      // 4. 一括起動が呼ばれていないことを検証
+      expect(window.open).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
### 概要
`HomePage.tsx` 内のキーボードショートカット（Enter/Escape）のロジックに対するテストを追加し、カバレッジを向上させました。

### 変更内容
- **Escape キーの検証**: キーワード選択中に Escape キーを押すと、全ての選択が解除されるテストを追加。
- **Enter キーの検証**: 入力フィールド（`InputField`）にフォーカスがある状態で Enter を押した際、ブックマークの一括起動がスキップされるテストを追加。

### 成果
- `src/pages/HomePage.tsx` の行カバレッジが **91.3%** に向上（目標 90% を達成）。
- 主要なキーボード操作に関するデグレード防止。

Closes #330