### PR TITLE
test: App.test.tsx 実行時の console.error 出力を抑制 (#331)

### DIFF
--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -366,6 +366,8 @@ export const LOG_MESSAGES = {
   ATTACH_KEYWORD_FAILED: 'Failed to attach keyword:',
   DETACH_KEYWORD_FAILED: 'Failed to detach keyword:',
   UNEXPECTED_ERROR_IN_ADD_KEYWORD: 'Unexpected error in handleAddKeyword:',
+  API_RESPONSE_PARSE_FAILED: (status: number) =>
+    `Failed to parse API response (Status: ${status}):`,
 } as const
 
 /**

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -13,6 +13,7 @@ import {
   FIELD_LABELS,
   KEY_VALUES,
   DROPPABLE_IDS,
+  LOG_MESSAGES,
 } from '@shared/constants'
 import type { Bookmark } from '@shared/schemas/bookmark'
 import {
@@ -52,6 +53,7 @@ vi.mock('@dnd-kit/core', async () => {
 describe('App Integration', () => {
   beforeEach(() => {
     vi.stubGlobal('open', vi.fn())
+    vi.spyOn(console, 'error').mockImplementation(() => {})
     localStorage.clear()
     lastOnDragEnd = null
 
@@ -102,6 +104,8 @@ describe('App Integration', () => {
   })
 
   it('ブックマーク取得失敗時にエラーメッセージが表示されること', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
     server.use(
       http.get(`${DEFAULT_API_URL}${API_PATHS.BOOKMARKS}`, () => {
         return new HttpResponse(null, { status: 500 })
@@ -109,6 +113,11 @@ describe('App Integration', () => {
     )
     setup()
     expect(await screen.findByRole(ARIA_ROLES.ALERT)).toBeInTheDocument()
+
+    expect(console.error).toHaveBeenCalledWith(
+      LOG_MESSAGES.API_RESPONSE_PARSE_FAILED(500),
+      expect.any(Error),
+    )
   })
 
   it('ブックマークをクリックすると詳細画面に遷移すること', async () => {

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -53,7 +53,7 @@ const parseResponse = async <T>(
     if (err instanceof BookmarkApiError) throw err
 
     // パース失敗時などのデバッグ情報をログ出力
-    console.error(`Failed to parse API response (Status: ${res.status}):`, err)
+    console.error(LOG_MESSAGES.API_RESPONSE_PARSE_FAILED(res.status), err)
   }
 
   throw new Error(defaultMessage)


### PR DESCRIPTION
### 概要
`App.test.tsx` の異常系テスト実行時に出力される `console.error` を抑制し、テスト結果の視認性を向上させました。

### 変更内容
- `beforeEach` で `console.error` をスパイ化し、出力を抑制。
- ブックマーク取得失敗時のテストにおいて、正しくエラーログが出力されたことを `expect(console.error).toHaveBeenCalled()` で検証。

### 効果
- テスト実行時のノイズが削減され、クリーンな出力を実現。
- `GEMINI.md` の「クリーンなテスト出力」原則の遵守。

Closes #331