### PR TITLE
feat(extension): 保存されたフロントエンド URL を使用して詳細画面を開くようにリファクタリング (#335)

### DIFF
--- a/extension/src/hooks/usePopup.test.ts
+++ b/extension/src/hooks/usePopup.test.ts
@@ -9,7 +9,6 @@ import {
   UI_STATUS,
   EXTENSION_MESSAGE_TYPES,
   EXTENSION_MESSAGES,
-  DEFAULT_PORTS,
   LOG_MESSAGES,
 } from '@shared/constants'
 
@@ -30,12 +29,16 @@ vi.stubGlobal('chrome', mockChrome)
 vi.stubGlobal('window', { close: vi.fn() })
 
 describe('usePopup Hook', () => {
+  const mockApiUrl = 'http://localhost:3030'
+  const mockFrontendUrl = 'http://localhost:5173'
+
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(console, 'error').mockImplementation(() => {})
     // デフォルトの設定値をモック
     vi.spyOn(storage, 'get').mockResolvedValue({
-      [STORAGE_KEYS.API_URL]: 'http://localhost:3030',
+      [STORAGE_KEYS.API_URL]: mockApiUrl,
+      [STORAGE_KEYS.FRONTEND_URL]: mockFrontendUrl,
     })
   })
 
@@ -93,7 +96,14 @@ describe('usePopup Hook', () => {
     })
   })
 
-  it('handleEdit が呼ばれた際、詳細画面を新しいタブで開くこと (ポート差し替え)', async () => {
+  it('handleEdit が呼ばれた際、ストレージに保存された frontendUrl を使用して詳細画面を開くこと', async () => {
+    // バリデーションをパスするように localhost のカスタムポートをシミュレート
+    const customFrontendUrl = 'http://localhost:8080'
+    vi.spyOn(storage, 'get').mockResolvedValue({
+      [STORAGE_KEYS.API_URL]: mockApiUrl,
+      [STORAGE_KEYS.FRONTEND_URL]: customFrontendUrl,
+    })
+
     mockChrome.tabs.query.mockResolvedValue([
       { title: 'Test', url: 'https://example.com' },
     ])
@@ -108,8 +118,8 @@ describe('usePopup Hook', () => {
       await result.current.handleEdit()
     })
 
-    // localhost の場合は 5173 に差し替えられることを検証
-    const expectedUrl = `http://localhost:${DEFAULT_PORTS.FRONTEND}${APP_PATHS.BOOKMARK_DETAIL('id-123')}`
+    // 保存された URL が正しく反映されることを検証
+    const expectedUrl = `${customFrontendUrl}${APP_PATHS.BOOKMARK_DETAIL('id-123')}`
     expect(mockChrome.tabs.create).toHaveBeenCalledWith({ url: expectedUrl })
     expect(window.close).toHaveBeenCalled()
   })
@@ -174,6 +184,7 @@ describe('usePopup Hook', () => {
       ])
       vi.spyOn(storage, 'get').mockResolvedValue({
         [STORAGE_KEYS.API_URL]: 'ftp://invalid',
+        [STORAGE_KEYS.FRONTEND_URL]: mockFrontendUrl,
       })
 
       const { result } = renderHook(() => usePopup())

--- a/extension/src/hooks/usePopup.ts
+++ b/extension/src/hooks/usePopup.ts
@@ -5,7 +5,7 @@ import {
   APP_PATHS,
   COMMON_MESSAGES,
   DEFAULT_API_URL,
-  DEFAULT_PORTS,
+  DEFAULT_FRONTEND_URL,
   EXTENSION_CONSTANTS,
   EXTENSION_MESSAGES,
   LOG_MESSAGES,
@@ -21,6 +21,7 @@ import { storage } from '../lib/storage'
 
 const DEFAULT_SETTINGS = {
   [STORAGE_KEYS.API_URL]: DEFAULT_API_URL,
+  [STORAGE_KEYS.FRONTEND_URL]: DEFAULT_FRONTEND_URL,
 }
 
 export const usePopup = () => {
@@ -137,31 +138,16 @@ export const usePopup = () => {
 
     try {
       const settings = await storage.get(DEFAULT_SETTINGS)
-      const baseUrl = String(settings[STORAGE_KEYS.API_URL])
+      const frontendUrl = String(settings[STORAGE_KEYS.FRONTEND_URL])
 
       // セキュリティバリデーションを追加
-      const urlError = validateApiUrl(baseUrl)
+      const urlError = validateApiUrl(frontendUrl)
       if (urlError) throw new Error(urlError)
 
-      const sanitizedBaseUrl = getOrigin(baseUrl)
-
-      // 暫定対応: API URL が localhost の場合はポートをフロントエンドに向ける
-      let frontendBaseUrl = sanitizedBaseUrl
-      try {
-        const urlObj = new URL(sanitizedBaseUrl)
-        const isLocalhost = ['localhost', '127.0.0.1', '[::1]'].includes(
-          urlObj.hostname,
-        )
-
-        if (isLocalhost) {
-          urlObj.port = String(DEFAULT_PORTS.FRONTEND)
-          frontendBaseUrl = urlObj.origin
-        }
-      } catch (err) {
-        console.error('Failed to parse frontend URL:', err, sanitizedBaseUrl)
-      }
-
-      const detailUrl = `${frontendBaseUrl}${APP_PATHS.BOOKMARK_DETAIL(registeredId)}`
+      const sanitizedBaseUrl = getOrigin(frontendUrl)
+      const detailUrl = `${sanitizedBaseUrl}${APP_PATHS.BOOKMARK_DETAIL(
+        registeredId,
+      )}`
 
       // 新しいタブで詳細画面を開く
       await chrome.tabs.create({ url: detailUrl })

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -51,6 +51,7 @@ export const DEFAULT_PORTS = {
  * プロダクト全体で共有されるデフォルト設定
  */
 export const DEFAULT_API_URL = `http://localhost:${DEFAULT_PORTS.BACKEND}`
+export const DEFAULT_FRONTEND_URL = `http://localhost:${DEFAULT_PORTS.FRONTEND}`
 export const DEFAULT_SERVER_PORT = DEFAULT_PORTS.BACKEND
 
 /**


### PR DESCRIPTION
### 概要
前回のタスク（#327）で実装した「Web アプリからの URL 通知・保存機能」を利用し、拡張機能のポップアップから常に正しい URL で詳細画面を開けるようにしました。

### 変更内容
- **ロジック**: `usePopup.ts` において、ストレージに保存された `frontendUrl` を優先的に使用して詳細画面の URL を構築するようにリファクタリングしました。
- **クリーンアップ**: 不要になった「localhost の場合にポート 5173 を強制指定する」暫定ロジックを削除しました。
- **定数**: 共通定数に `DEFAULT_FRONTEND_URL` を追加しました。
- **テスト**: 保存された任意の URL（バリデーション範囲内）が正しく遷移に使用されることを検証するテストを追加・修正しました。

### 効果
- 環境（ポート番号やドメイン）に依存せず、設定なしで常に正しい詳細画面へ遷移可能になります。

Closes #335