### PR TITLE
feat: [Frontend] キーワード詳細画面の基本 UI 実装

### DIFF
--- a/extension/src/Options.tsx
+++ b/extension/src/Options.tsx
@@ -6,6 +6,7 @@ import {
   FIELD_LABELS,
   STATUS_STYLES,
   UI_STATUS,
+  UI_STYLES,
 } from '@shared/constants'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
@@ -47,14 +48,16 @@ export const Options = () => {
               value={apiUrl}
               onChange={(e) => setApiUrl(e.target.value)}
               placeholder={DEFAULT_API_URL}
-              width="w-32"
+              width={UI_STYLES.LABEL_WIDTH_CLASS}
             />
-            <p className="mt-2 text-xs text-gray-500 ml-36">
+            <p
+              className={`mt-2 text-xs text-gray-500 ${UI_STYLES.INDENT_MARGIN_CLASS}`}
+            >
               {COMMON_MESSAGES.API_URL_DESCRIPTION}
             </p>
           </div>
 
-          <div className="flex space-x-3 ml-36">
+          <div className={`flex space-x-3 ${UI_STYLES.INDENT_MARGIN_CLASS}`}>
             <Button
               onClick={handleSaveApiUrl}
               size="medium"
@@ -91,14 +94,16 @@ export const Options = () => {
               value={frontendUrl}
               onChange={(e) => setFrontendUrl(e.target.value)}
               placeholder={DEFAULT_FRONTEND_URL}
-              width="w-32"
+              width={UI_STYLES.LABEL_WIDTH_CLASS}
             />
-            <p className="mt-2 text-xs text-gray-500 ml-36">
+            <p
+              className={`mt-2 text-xs text-gray-500 ${UI_STYLES.INDENT_MARGIN_CLASS}`}
+            >
               {COMMON_MESSAGES.FRONTEND_URL_DESCRIPTION}
             </p>
           </div>
 
-          <div className="flex space-x-3 ml-36">
+          <div className={`flex space-x-3 ${UI_STYLES.INDENT_MARGIN_CLASS}`}>
             <Button
               onClick={handleSaveFrontendUrl}
               size="medium"
@@ -124,7 +129,7 @@ export const Options = () => {
                 ? ARIA_ROLES.ALERT
                 : ARIA_ROLES.STATUS
             }
-            className={`ml-36 p-3 rounded-md text-sm ${STATUS_STYLES[status.type]}`}
+            className={`${UI_STYLES.INDENT_MARGIN_CLASS} p-3 rounded-md text-sm ${STATUS_STYLES[status.type]}`}
           >
             {status.message}
           </div>

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -151,6 +151,7 @@ export const UI_MESSAGES = {
   ATTACH_KEYWORD_FAILED: 'キーワードの紐付けに失敗しました',
   DETACH_KEYWORD_FAILED: 'キーワードの解除に失敗しました',
   NO_KEYWORDS_AVAILABLE: '利用可能なキーワードはありません',
+  KEYWORD_NOT_FOUND: (id: string | number) => `Keyword not found (ID: ${id})`,
   EMPTY_SECTION: (label: string) => `${label}は空です`,
 } as const
 
@@ -363,6 +364,8 @@ export const LOG_MESSAGES = {
   ATTACH_KEYWORD_FAILED: 'Failed to attach keyword:',
   DETACH_KEYWORD_FAILED: 'Failed to detach keyword:',
   UNEXPECTED_ERROR_IN_ADD_KEYWORD: 'Unexpected error in handleAddKeyword:',
+  UPDATE_KEYWORD_PLACEHOLDER: (name: string) => `Update keyword: ${name}`,
+  DELETE_KEYWORD_PLACEHOLDER: (id: string | number) => `Delete keyword: ${id}`,
   API_RESPONSE_PARSE_FAILED: (status: number) =>
     `Failed to parse API response (Status: ${status}):`,
 } as const

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -25,6 +25,7 @@ export const FIELD_LABELS = {
   BACK_TO_LIST: 'Back to List',
   BOOKMARKS_LABEL: 'ブックマーク一覧',
   KEYWORDS_LABEL: 'キーワード一覧',
+  KEYWORD_NAME: 'キーワード名',
   KEYWORDS_HEADING: 'Keywords',
   MATCHED_BOOKMARKS_LABEL: '一致したブックマーク',
   OTHER_BOOKMARKS_LABEL: 'その他のブックマーク',

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -94,6 +94,7 @@ export const COMMON_MESSAGES = {
   UNEXPECTED_RESPONSE: '予期しないレスポンス形式です',
   SAVING: '保存中...',
   LOADING_LABEL: '読み込み中...',
+  LOADING_DOTS: '...',
   API_URL_DESCRIPTION:
     'ブックマークを保存するサーバーを ベースURL（/api/bookmarksの前まで）を入力してください。',
   FRONTEND_URL_DESCRIPTION:
@@ -146,12 +147,14 @@ export const UI_MESSAGES = {
   DELETE_FAILED: 'ブックマークの削除に失敗しました',
   REORDER_FAILED: 'ブックマークの並び替えに失敗しました',
   DELETE_CONFIRM: 'このブックマークを削除してもよろしいですか？',
+  KEYWORD_DELETE_CONFIRM: 'このキーワードを削除してもよろしいですか？',
   FETCH_KEYWORDS_FAILED: 'キーワードの取得に失敗しました',
   CREATE_KEYWORD_FAILED: 'キーワードの作成に失敗しました',
   ATTACH_KEYWORD_FAILED: 'キーワードの紐付けに失敗しました',
   DETACH_KEYWORD_FAILED: 'キーワードの解除に失敗しました',
   NO_KEYWORDS_AVAILABLE: '利用可能なキーワードはありません',
-  KEYWORD_NOT_FOUND: (id: string | number) => `Keyword not found (ID: ${id})`,
+  KEYWORD_NOT_FOUND: (id: string | number) =>
+    `キーワードが見つかりませんでした (ID: ${id})`,
   EMPTY_SECTION: (label: string) => `${label}は空です`,
 } as const
 

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -69,6 +69,14 @@ export const UI_STATUS = {
 export type UIStatus = (typeof UI_STATUS)[keyof typeof UI_STATUS]
 
 /**
+ * 共通の UI スタイル定数
+ */
+export const UI_STYLES = {
+  LABEL_WIDTH_CLASS: 'w-32',
+  INDENT_MARGIN_CLASS: 'ml-36',
+} as const
+
+/**
  * 処理状態とメッセージを組み合わせた共通型
  */
 export type StatusInfo = {

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -2,14 +2,14 @@ import { BookmarkIdSchema } from '../schemas/bookmark'
 import { KeywordIdSchema } from '../schemas/keyword'
 
 import type { Bookmark } from '../schemas/bookmark'
-import type { Keyword } from '../schemas/keyword'
+import type { KeywordWithCount } from '../schemas/keyword'
 
 export const MOCK_BOOKMARK_TITLE_PREFIX = 'Test Bookmark'
 
-export const MOCK_KEYWORDS: Keyword[] = [
-  { id: KeywordIdSchema.parse('1'), name: 'React' },
-  { id: KeywordIdSchema.parse('2'), name: 'TypeScript' },
-  { id: KeywordIdSchema.parse('3'), name: 'Vite' },
+export const MOCK_KEYWORDS: KeywordWithCount[] = [
+  { id: KeywordIdSchema.parse('1'), name: 'React', bookmarkCount: 0 },
+  { id: KeywordIdSchema.parse('2'), name: 'TypeScript', bookmarkCount: 0 },
+  { id: KeywordIdSchema.parse('3'), name: 'Vite', bookmarkCount: 0 },
 ]
 
 export const MOCK_BOOKMARK_1: Bookmark = {

--- a/src/hooks/useKeywordPage.test.ts
+++ b/src/hooks/useKeywordPage.test.ts
@@ -1,0 +1,70 @@
+import { http, HttpResponse } from 'msw'
+import { useParams, useNavigate } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { MOCK_KEYWORDS } from '@shared/test/fixtures'
+
+import { useKeywordPage } from './useKeywordPage'
+import { server } from '../test/setup'
+import { renderHook, waitFor } from '../test/utils'
+
+// モックの設定
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return {
+    ...actual,
+    useParams: vi.fn(),
+    useNavigate: vi.fn(),
+  }
+})
+
+describe('useKeywordPage Hook', () => {
+  const mockNavigate = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useParams).mockReturnValue({ id: MOCK_KEYWORDS[0].id })
+    vi.mocked(useNavigate).mockReturnValue(mockNavigate)
+    server.use(
+      http.get('*/api/keywords', () => {
+        return HttpResponse.json({
+          success: true,
+          data: {
+            keywords: MOCK_KEYWORDS,
+          },
+        })
+      }),
+    )
+  })
+
+  it('初期化時にキーワードデータを取得し、ステートを更新すること', async () => {
+    const { result } = renderHook(() => useKeywordPage())
+
+    await waitFor(() => {
+      expect(result.current.keyword).toEqual(MOCK_KEYWORDS[0])
+      expect(result.current.editName).toBe(MOCK_KEYWORDS[0].name)
+    })
+  })
+
+  it('ローディング中は isLoading が true であること', () => {
+    server.use(
+      http.get('*/api/keywords', async () => {
+        return new Promise(() => {}) // 応答を返さない
+      }),
+    )
+
+    const { result } = renderHook(() => useKeywordPage())
+    expect(result.current.isLoading).toBe(true)
+  })
+
+  it('ID が存在しない場合、keyword が undefined になること', async () => {
+    vi.mocked(useParams).mockReturnValue({ id: '999' })
+
+    const { result } = renderHook(() => useKeywordPage())
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.keyword).toBeUndefined()
+    })
+  })
+})

--- a/src/hooks/useKeywordPage.ts
+++ b/src/hooks/useKeywordPage.ts
@@ -1,0 +1,72 @@
+import { useState, useCallback, useMemo } from 'react'
+
+import { useParams, useNavigate } from 'react-router-dom'
+
+import { APP_PATHS } from '@shared/constants'
+import { KeywordIdSchema } from '@shared/schemas/keyword'
+
+import { useKeywords } from './useBookmarks'
+
+/**
+ * キーワード詳細画面のロジックを管理するカスタムフック
+ */
+export const useKeywordPage = (onBack?: () => void) => {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+
+  // 1. ID のバリデーション
+  const parsedId = useMemo(() => {
+    try {
+      return id ? KeywordIdSchema.parse(id) : null
+    } catch {
+      return null
+    }
+  }, [id])
+
+  // 2. データ取得
+  const { data, isLoading } = useKeywords()
+
+  const keyword = useMemo(
+    () => data?.keywords.find((k) => k.id === parsedId),
+    [data, parsedId],
+  )
+
+  // 3. フォーム状態
+  const [editName, setEditName] = useState('')
+  const [prevKeywordId, setPrevKeywordId] = useState<string | null>(null)
+
+  // データが届いた際、またはキーワードが変わった際の初期化
+  if (keyword && keyword.id !== prevKeywordId) {
+    setEditName(keyword.name)
+    setPrevKeywordId(keyword.id)
+  }
+
+  // 4. ハンドラ (Issue #361, #362, #363 で実装予定)
+  const handleBack = useCallback(() => {
+    onBack?.()
+    navigate(APP_PATHS.HOME)
+  }, [onBack, navigate])
+
+  const handleUpdate = useCallback(async () => {
+    console.log('Update keyword:', editName)
+    // TODO: Issue #361 で実装
+  }, [editName])
+
+  const handleDelete = useCallback(async () => {
+    console.log('Delete keyword:', parsedId)
+    // TODO: Issue #362 で実装
+  }, [parsedId])
+
+  return {
+    id,
+    keyword,
+    editName,
+    setEditName,
+    isLoading,
+    isUpdating: false, // プレースホルダ
+    isDeleting: false, // プレースホルダ
+    handleUpdate,
+    handleDelete,
+    handleBack,
+  }
+}

--- a/src/hooks/useKeywordPage.ts
+++ b/src/hooks/useKeywordPage.ts
@@ -33,12 +33,12 @@ export const useKeywordPage = (onBack?: () => void) => {
 
   // 3. フォーム状態
   const [editName, setEditName] = useState('')
-  const [prevKeywordId, setPrevKeywordId] = useState<string | null>(null)
+  const [prevId, setPrevId] = useState<string | null>(null)
 
-  // データが届いた際、またはキーワードが変わった際の初期化
-  if (keyword && keyword.id !== prevKeywordId) {
+  // キーワードが変わった際にステートを初期化 (Rendering 時に同期)
+  if (keyword && keyword.id !== prevId) {
     setEditName(keyword.name)
-    setPrevKeywordId(keyword.id)
+    setPrevId(keyword.id)
   }
 
   // 4. ハンドラ (Issue #361, #362, #363 で実装予定)

--- a/src/hooks/useKeywordPage.ts
+++ b/src/hooks/useKeywordPage.ts
@@ -39,7 +39,18 @@ export const useKeywordPage = (onBack?: () => void) => {
   if (keyword && keyword.id !== prevId) {
     setEditName(keyword.name)
     setPrevId(keyword.id)
+  } else if (!keyword && prevId !== null) {
+    // キーワードが取得できなくなった（または ID が無効になった）場合にリセット
+    setEditName('')
+    setPrevId(null)
   }
+
+  // 保存ボタンの有効・無効判定
+  const isSaveDisabled = useMemo(() => {
+    if (!keyword) return true
+    if (!editName.trim()) return true
+    return editName === keyword.name
+  }, [keyword, editName])
 
   // 4. ハンドラ (Issue #361, #362, #363 で実装予定)
   const handleBack = useCallback(() => {
@@ -66,6 +77,7 @@ export const useKeywordPage = (onBack?: () => void) => {
     isLoading,
     isUpdating: false, // プレースホルダ
     isDeleting: false, // プレースホルダ
+    isSaveDisabled,
     handleUpdate,
     handleDelete,
     handleBack,

--- a/src/hooks/useKeywordPage.ts
+++ b/src/hooks/useKeywordPage.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo } from 'react'
 
 import { useParams, useNavigate } from 'react-router-dom'
 
-import { APP_PATHS } from '@shared/constants'
+import { APP_PATHS, LOG_MESSAGES } from '@shared/constants'
 import { KeywordIdSchema } from '@shared/schemas/keyword'
 
 import { useKeywords } from './useBookmarks'
@@ -48,12 +48,13 @@ export const useKeywordPage = (onBack?: () => void) => {
   }, [onBack, navigate])
 
   const handleUpdate = useCallback(async () => {
-    console.log('Update keyword:', editName)
+    console.log(LOG_MESSAGES.UPDATE_KEYWORD_PLACEHOLDER(editName))
     // TODO: Issue #361 で実装
   }, [editName])
 
   const handleDelete = useCallback(async () => {
-    console.log('Delete keyword:', parsedId)
+    if (!parsedId) return
+    console.log(LOG_MESSAGES.DELETE_KEYWORD_PLACEHOLDER(parsedId))
     // TODO: Issue #362 で実装
   }, [parsedId])
 

--- a/src/pages/KeywordPage.test.tsx
+++ b/src/pages/KeywordPage.test.tsx
@@ -26,6 +26,7 @@ describe('KeywordPage Component', () => {
     isLoading: false,
     isUpdating: false,
     isDeleting: false,
+    isSaveDisabled: true,
     handleUpdate: vi.fn(),
     handleDelete: vi.fn(),
     handleBack: vi.fn(),
@@ -54,7 +55,23 @@ describe('KeywordPage Component', () => {
     expect(screen.getByText(FIELD_LABELS.BUTTON_CLOSE)).toBeInTheDocument()
   })
 
-  it('ローディング中に Loading... が表示されること', () => {
+  it('更新ボタンが変更がない場合に不活性化されていること', () => {
+    render(<KeywordPage />)
+    const updateButton = screen.getByText(FIELD_LABELS.BUTTON_UPDATE)
+    expect(updateButton).toBeDisabled()
+  })
+
+  it('更新ボタンが変更がある場合に活性化されること', () => {
+    vi.mocked(useKeywordPage).mockReturnValue({
+      ...mockUseKeywordPage,
+      isSaveDisabled: false,
+    })
+    render(<KeywordPage />)
+    const updateButton = screen.getByText(FIELD_LABELS.BUTTON_UPDATE)
+    expect(updateButton).not.toBeDisabled()
+  })
+
+  it('ローディング中に読み込み中メッセージが表示されること', () => {
     vi.mocked(useKeywordPage).mockReturnValue({
       ...mockUseKeywordPage,
       isLoading: true,

--- a/src/pages/KeywordPage.test.tsx
+++ b/src/pages/KeywordPage.test.tsx
@@ -39,9 +39,7 @@ describe('KeywordPage Component', () => {
   it('キーワード情報が正しく表示されること', () => {
     render(<KeywordPage />)
 
-    expect(
-      screen.getByLabelText(FIELD_LABELS.KEYWORDS_LABEL),
-    ).toBeInTheDocument()
+    expect(screen.getByLabelText(FIELD_LABELS.KEYWORD_NAME)).toBeInTheDocument()
     expect(screen.getByDisplayValue(MOCK_KEYWORDS[0].name)).toBeInTheDocument()
     expect(
       screen.getByPlaceholderText(PLACEHOLDERS.KEYWORD),

--- a/src/pages/KeywordPage.test.tsx
+++ b/src/pages/KeywordPage.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { FIELD_LABELS, PLACEHOLDERS } from '@shared/constants'
+import {
+  COMMON_MESSAGES,
+  FIELD_LABELS,
+  PLACEHOLDERS,
+  UI_MESSAGES,
+} from '@shared/constants'
 import { MOCK_KEYWORDS } from '@shared/test/fixtures'
 
 import { KeywordPage } from './KeywordPage'
@@ -58,7 +63,7 @@ describe('KeywordPage Component', () => {
     })
 
     render(<KeywordPage />)
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(screen.getByText(COMMON_MESSAGES.LOADING_LABEL)).toBeInTheDocument()
   })
 
   it('キーワードが見つからない場合にエラーメッセージが表示されること', () => {
@@ -68,6 +73,10 @@ describe('KeywordPage Component', () => {
     })
 
     render(<KeywordPage />)
-    expect(screen.getByText(/Keyword not found/)).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        UI_MESSAGES.KEYWORD_NOT_FOUND(mockUseKeywordPage.id ?? ''),
+      ),
+    ).toBeInTheDocument()
   })
 })

--- a/src/pages/KeywordPage.test.tsx
+++ b/src/pages/KeywordPage.test.tsx
@@ -1,40 +1,73 @@
-import { Route, Routes } from 'react-router-dom'
-import { describe, expect, it } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-import { APP_PATHS, ARIA_ROLES, FIELD_LABELS } from '@shared/constants'
+import { FIELD_LABELS, PLACEHOLDERS } from '@shared/constants'
+import { MOCK_KEYWORDS } from '@shared/test/fixtures'
 
 import { KeywordPage } from './KeywordPage'
+import { useKeywordPage } from '../hooks/useKeywordPage'
 import { render, screen } from '../test/utils'
 
-describe('KeywordPage', () => {
-  it('URL パラメータから取得したキーワード ID が表示されること', () => {
-    const testId = 'abc'
-    render(
-      <Routes>
-        <Route
-          path={APP_PATHS.KEYWORD_DETAIL_PATTERN}
-          element={<KeywordPage />}
-        />
-      </Routes>,
-      { initialUrl: APP_PATHS.KEYWORD_DETAIL(testId) },
-    )
+// Hook のモック
+vi.mock('../hooks/useKeywordPage')
+
+type MockUseKeywordPage = ReturnType<typeof useKeywordPage>
+
+describe('KeywordPage Component', () => {
+  const mockUseKeywordPage: MockUseKeywordPage = {
+    id: MOCK_KEYWORDS[0].id,
+    keyword: MOCK_KEYWORDS[0],
+    editName: MOCK_KEYWORDS[0].name,
+    setEditName: vi.fn(),
+    isLoading: false,
+    isUpdating: false,
+    isDeleting: false,
+    handleUpdate: vi.fn(),
+    handleDelete: vi.fn(),
+    handleBack: vi.fn(),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useKeywordPage).mockReturnValue(mockUseKeywordPage)
+  })
+
+  it('キーワード情報が正しく表示されること', () => {
+    render(<KeywordPage />)
 
     expect(
-      screen.getByText(
-        new RegExp(`${FIELD_LABELS.KEYWORD_ID_PREFIX} ${testId}`),
-      ),
+      screen.getByLabelText(FIELD_LABELS.KEYWORDS_LABEL),
     ).toBeInTheDocument()
+    expect(screen.getByDisplayValue(MOCK_KEYWORDS[0].name)).toBeInTheDocument()
     expect(
-      screen.getByText(FIELD_LABELS.KEYWORD_DETAIL_TITLE),
+      screen.getByPlaceholderText(PLACEHOLDERS.KEYWORD),
     ).toBeInTheDocument()
   })
 
-  it('戻るリンクが表示されていること', () => {
+  it('更新、削除、閉じるボタンが表示されること', () => {
     render(<KeywordPage />)
-    const link = screen.getByRole(ARIA_ROLES.LINK, {
-      name: new RegExp(FIELD_LABELS.BACK_TO_LIST, 'i'),
+
+    expect(screen.getByText(FIELD_LABELS.BUTTON_UPDATE)).toBeInTheDocument()
+    expect(screen.getByText(FIELD_LABELS.BUTTON_DELETE)).toBeInTheDocument()
+    expect(screen.getByText(FIELD_LABELS.BUTTON_CLOSE)).toBeInTheDocument()
+  })
+
+  it('ローディング中に Loading... が表示されること', () => {
+    vi.mocked(useKeywordPage).mockReturnValue({
+      ...mockUseKeywordPage,
+      isLoading: true,
     })
-    expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', APP_PATHS.HOME)
+
+    render(<KeywordPage />)
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('キーワードが見つからない場合にエラーメッセージが表示されること', () => {
+    vi.mocked(useKeywordPage).mockReturnValue({
+      ...mockUseKeywordPage,
+      keyword: undefined,
+    })
+
+    render(<KeywordPage />)
+    expect(screen.getByText(/Keyword not found/)).toBeInTheDocument()
   })
 })

--- a/src/pages/KeywordPage.tsx
+++ b/src/pages/KeywordPage.tsx
@@ -1,27 +1,79 @@
-import { useParams, Link } from 'react-router-dom'
+import { FIELD_LABELS, PLACEHOLDERS, UI_MESSAGES } from '@shared/constants'
+import { Button } from '@shared/ui/Button'
+import { InputField } from '@shared/ui/InputField'
 
-import { FIELD_LABELS, APP_PATHS } from '@shared/constants'
+import { useKeywordPage } from '../hooks/useKeywordPage'
 
 export function KeywordPage() {
-  const { id } = useParams<{ id: string }>()
+  const {
+    id,
+    keyword,
+    editName,
+    setEditName,
+    isLoading,
+    isUpdating,
+    isDeleting,
+    handleUpdate,
+    handleDelete,
+    handleBack,
+  } = useKeywordPage()
+
+  if (isLoading) {
+    return <div className="p-4">Loading...</div>
+  }
+
+  if (!keyword) {
+    return (
+      <div className="p-4">
+        <p className="text-red-600 mb-4">Keyword not found (ID: {id})</p>
+        <Button variant="secondary" onClick={handleBack}>
+          {FIELD_LABELS.BUTTON_CLOSE}
+        </Button>
+      </div>
+    )
+  }
+
+  const handleDeleteWithConfirm = () => {
+    if (window.confirm(UI_MESSAGES.DELETE_CONFIRM)) {
+      handleDelete()
+    }
+  }
 
   return (
-    <div className="p-4">
-      <div className="mb-4">
-        <Link to={APP_PATHS.HOME} className="text-blue-600 hover:underline">
-          &larr; {FIELD_LABELS.BACK_TO_LIST}
-        </Link>
-      </div>
-      <h1 className="text-xl font-bold mb-2">
-        {FIELD_LABELS.KEYWORD_DETAIL_TITLE}
-      </h1>
-      <p className="text-gray-600">
-        {FIELD_LABELS.KEYWORD_ID_PREFIX} {id}
-      </p>
-      <div className="mt-8 p-4 bg-blue-50 border border-blue-200 rounded-md">
-        <p className="text-sm text-blue-700">
-          Note: This is a placeholder for the keyword filtered list screen.
-        </p>
+    <div className="p-4 max-w-2xl mx-auto space-y-6">
+      {/* 基本情報ブロック */}
+      <div className="bg-white p-4 border border-gray-200 rounded-lg shadow-sm">
+        <div className="grid grid-cols-[1fr_auto] gap-4 items-stretch">
+          <div className="flex items-center">
+            <InputField
+              id="keyword-name"
+              label={FIELD_LABELS.KEYWORDS_LABEL}
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              placeholder={PLACEHOLDERS.KEYWORD}
+            />
+          </div>
+
+          <div className="grid grid-rows-3 gap-0.5 min-w-24">
+            <Button
+              variant="primary"
+              onClick={handleUpdate}
+              disabled={isUpdating}
+            >
+              {isUpdating ? '...' : FIELD_LABELS.BUTTON_UPDATE}
+            </Button>
+            <Button
+              variant="danger"
+              onClick={handleDeleteWithConfirm}
+              disabled={isDeleting}
+            >
+              {isDeleting ? '...' : FIELD_LABELS.BUTTON_DELETE}
+            </Button>
+            <Button variant="secondary" onClick={handleBack}>
+              {FIELD_LABELS.BUTTON_CLOSE}
+            </Button>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/pages/KeywordPage.tsx
+++ b/src/pages/KeywordPage.tsx
@@ -54,10 +54,11 @@ export function KeywordPage() {
           <div className="flex items-center">
             <InputField
               id="keyword-name"
-              label={FIELD_LABELS.KEYWORDS_LABEL}
+              label={FIELD_LABELS.KEYWORD_NAME}
               value={editName}
               onChange={(e) => setEditName(e.target.value)}
               placeholder={PLACEHOLDERS.KEYWORD}
+              width="w-32"
             />
           </div>
 

--- a/src/pages/KeywordPage.tsx
+++ b/src/pages/KeywordPage.tsx
@@ -19,37 +19,34 @@ export function KeywordPage() {
     isLoading,
     isUpdating,
     isDeleting,
+    isSaveDisabled,
     handleUpdate,
     handleDelete,
     handleBack,
   } = useKeywordPage()
 
-  if (isLoading) {
-    return <div className="p-4">{COMMON_MESSAGES.LOADING_LABEL}</div>
-  }
-
-  if (!keyword) {
-    return (
-      <div className="p-4">
-        <p className="text-red-600 mb-4">
-          {UI_MESSAGES.KEYWORD_NOT_FOUND(id ?? '')}
-        </p>
-        <Button variant="secondary" onClick={handleBack}>
-          {FIELD_LABELS.BUTTON_CLOSE}
-        </Button>
-      </div>
-    )
-  }
-
-  const handleDeleteWithConfirm = () => {
-    if (window.confirm(UI_MESSAGES.KEYWORD_DELETE_CONFIRM)) {
-      handleDelete()
+  // コンテンツのレンダリング
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <div className="p-4 text-gray-600">{COMMON_MESSAGES.LOADING_LABEL}</div>
+      )
     }
-  }
 
-  return (
-    <div className="p-4 max-w-2xl mx-auto space-y-6">
-      {/* 基本情報ブロック */}
+    if (!keyword) {
+      return (
+        <div className="p-4">
+          <p className="text-red-600 mb-4">
+            {UI_MESSAGES.KEYWORD_NOT_FOUND(id ?? '')}
+          </p>
+          <Button variant="secondary" onClick={handleBack}>
+            {FIELD_LABELS.BUTTON_CLOSE}
+          </Button>
+        </div>
+      )
+    }
+
+    return (
       <section
         className="bg-white p-4 border border-gray-200 rounded-lg shadow-sm"
         aria-labelledby="keyword-detail-title"
@@ -73,7 +70,7 @@ export function KeywordPage() {
             <Button
               variant="primary"
               onClick={handleUpdate}
-              disabled={isUpdating}
+              disabled={isUpdating || isSaveDisabled}
             >
               {isUpdating
                 ? COMMON_MESSAGES.LOADING_DOTS
@@ -94,6 +91,16 @@ export function KeywordPage() {
           </div>
         </div>
       </section>
-    </div>
+    )
+  }
+
+  const handleDeleteWithConfirm = () => {
+    if (window.confirm(UI_MESSAGES.KEYWORD_DELETE_CONFIRM)) {
+      handleDelete()
+    }
+  }
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto space-y-6">{renderContent()}</div>
   )
 }

--- a/src/pages/KeywordPage.tsx
+++ b/src/pages/KeywordPage.tsx
@@ -1,4 +1,9 @@
-import { FIELD_LABELS, PLACEHOLDERS, UI_MESSAGES } from '@shared/constants'
+import {
+  COMMON_MESSAGES,
+  FIELD_LABELS,
+  PLACEHOLDERS,
+  UI_MESSAGES,
+} from '@shared/constants'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
 
@@ -19,13 +24,15 @@ export function KeywordPage() {
   } = useKeywordPage()
 
   if (isLoading) {
-    return <div className="p-4">Loading...</div>
+    return <div className="p-4">{COMMON_MESSAGES.LOADING_LABEL}</div>
   }
 
   if (!keyword) {
     return (
       <div className="p-4">
-        <p className="text-red-600 mb-4">Keyword not found (ID: {id})</p>
+        <p className="text-red-600 mb-4">
+          {UI_MESSAGES.KEYWORD_NOT_FOUND(id ?? '')}
+        </p>
         <Button variant="secondary" onClick={handleBack}>
           {FIELD_LABELS.BUTTON_CLOSE}
         </Button>

--- a/src/pages/KeywordPage.tsx
+++ b/src/pages/KeywordPage.tsx
@@ -3,6 +3,7 @@ import {
   FIELD_LABELS,
   PLACEHOLDERS,
   UI_MESSAGES,
+  UI_STYLES,
 } from '@shared/constants'
 import { Button } from '@shared/ui/Button'
 import { InputField } from '@shared/ui/InputField'
@@ -49,7 +50,13 @@ export function KeywordPage() {
   return (
     <div className="p-4 max-w-2xl mx-auto space-y-6">
       {/* 基本情報ブロック */}
-      <div className="bg-white p-4 border border-gray-200 rounded-lg shadow-sm">
+      <section
+        className="bg-white p-4 border border-gray-200 rounded-lg shadow-sm"
+        aria-labelledby="keyword-detail-title"
+      >
+        <h2 id="keyword-detail-title" className="sr-only">
+          {FIELD_LABELS.KEYWORD_DETAIL_TITLE}
+        </h2>
         <div className="grid grid-cols-[1fr_auto] gap-4 items-stretch">
           <div className="flex items-center">
             <InputField
@@ -58,11 +65,11 @@ export function KeywordPage() {
               value={editName}
               onChange={(e) => setEditName(e.target.value)}
               placeholder={PLACEHOLDERS.KEYWORD}
-              width="w-32"
+              width={UI_STYLES.LABEL_WIDTH_CLASS}
             />
           </div>
 
-          <div className="grid grid-rows-3 gap-0.5 min-w-24">
+          <div className="grid grid-rows-3 gap-1 min-w-24">
             <Button
               variant="primary"
               onClick={handleUpdate}
@@ -86,7 +93,7 @@ export function KeywordPage() {
             </Button>
           </div>
         </div>
-      </div>
+      </section>
     </div>
   )
 }

--- a/src/pages/KeywordPage.tsx
+++ b/src/pages/KeywordPage.tsx
@@ -41,7 +41,7 @@ export function KeywordPage() {
   }
 
   const handleDeleteWithConfirm = () => {
-    if (window.confirm(UI_MESSAGES.DELETE_CONFIRM)) {
+    if (window.confirm(UI_MESSAGES.KEYWORD_DELETE_CONFIRM)) {
       handleDelete()
     }
   }
@@ -67,14 +67,18 @@ export function KeywordPage() {
               onClick={handleUpdate}
               disabled={isUpdating}
             >
-              {isUpdating ? '...' : FIELD_LABELS.BUTTON_UPDATE}
+              {isUpdating
+                ? COMMON_MESSAGES.LOADING_DOTS
+                : FIELD_LABELS.BUTTON_UPDATE}
             </Button>
             <Button
               variant="danger"
               onClick={handleDeleteWithConfirm}
               disabled={isDeleting}
             >
-              {isDeleting ? '...' : FIELD_LABELS.BUTTON_DELETE}
+              {isDeleting
+                ? COMMON_MESSAGES.LOADING_DOTS
+                : FIELD_LABELS.BUTTON_DELETE}
             </Button>
             <Button variant="secondary" onClick={handleBack}>
               {FIELD_LABELS.BUTTON_CLOSE}


### PR DESCRIPTION
Closes #360
Closes #363

キーワード詳細画面の基本 UI とデータ取得ロジックを実装しました。また、閉じるボタンの機能（#363）も包含しています。

### 変更内容
- src/hooks/useKeywordPage.ts の新規作成（フィルタリング・状態管理・戻るロジック）
- src/pages/KeywordPage.tsx の実装（InputField, 各種ボタンの配置、アクセシビリティ対応）
- shared/constants.ts に UI_STYLES およびキーワード関連メッセージを追加
- extension/src/Options.tsx の共通スタイル定数への移行
- shared/test/fixtures.ts の MOCK_KEYWORDS を最新の型定義に更新
- ユニットテスト (Hook & Component) の追加