### PR TITLE
feat: [Shared] 共通スキーマの UUID 移行とフィクスチャの刷新

### DIFF
--- a/shared/schemas/bookmark.test.ts
+++ b/shared/schemas/bookmark.test.ts
@@ -7,7 +7,12 @@ import {
   updateBookmarkSchema,
 } from './bookmark'
 import { VALIDATION_MESSAGES } from '../constants'
-import { MOCK_BOOKMARK_1, INVALID_URLS, VALID_URLS } from '../test/fixtures'
+import {
+  MOCK_BOOKMARK_1,
+  INVALID_URLS,
+  VALID_URLS,
+  MOCK_IDS,
+} from '../test/fixtures'
 
 describe('bookmarkSchema', () => {
   it.each([
@@ -98,12 +103,14 @@ describe('updateBookmarkSchema', () => {
 
 describe('reorderBookmarksSchema', () => {
   it('正常な ID リストを受け入れること', () => {
-    const valid = { ids: ['1', '2', '3'] }
+    const valid = { ids: [MOCK_IDS.BOOKMARK_1, MOCK_IDS.BOOKMARK_2] }
     expect(reorderBookmarksSchema.safeParse(valid).success).toBe(true)
   })
 
   it('重複した ID が含まれる場合にエラーを返すこと', () => {
-    const invalid = { ids: ['1', '2', '1'] }
+    const invalid = {
+      ids: [MOCK_IDS.BOOKMARK_1, MOCK_IDS.BOOKMARK_2, MOCK_IDS.BOOKMARK_1],
+    }
     const result = reorderBookmarksSchema.safeParse(invalid)
     expect(result.success).toBe(false)
     if (!result.success) {
@@ -114,7 +121,11 @@ describe('reorderBookmarksSchema', () => {
   })
 
   it('上限を超える ID リストを拒否すること', () => {
-    const manyIds = Array.from({ length: 1001 }, (_, i) => String(i + 1))
+    // 1001個の有効な UUID を生成
+    const manyIds = Array.from(
+      { length: 1001 },
+      (_, i) => `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`,
+    )
     const result = reorderBookmarksSchema.safeParse({ ids: manyIds })
     expect(result.success).toBe(false)
     if (!result.success) {

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -11,10 +11,7 @@ export {
   type Keyword,
 } from './keyword'
 
-export const BookmarkIdSchema = z
-  .string()
-  .regex(/^[1-9]\d*$/)
-  .brand<'BookmarkId'>()
+export const BookmarkIdSchema = z.string().uuid().brand<'BookmarkId'>()
 export type BookmarkId = z.infer<typeof BookmarkIdSchema>
 
 export const bookmarkSchema = z.object({

--- a/shared/schemas/keyword.test.ts
+++ b/shared/schemas/keyword.test.ts
@@ -7,24 +7,23 @@ import {
   keywordsResponseSchema,
   updateKeywordRequestSchema,
 } from './keyword'
+import { MOCK_IDS } from '../test/fixtures'
 
 describe('Keyword Schemas', () => {
   describe('KeywordIdSchema', () => {
-    it('正の整数文字列を受け入れること', () => {
-      expect(KeywordIdSchema.parse('1')).toBe('1')
-      expect(KeywordIdSchema.parse('123')).toBe('123')
+    it('有効な UUID を受け入れること', () => {
+      expect(KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1)).toBe(MOCK_IDS.KEYWORD_1)
     })
 
-    it('0や負の数、非数値を拒否すること', () => {
-      expect(() => KeywordIdSchema.parse('0')).toThrow()
-      expect(() => KeywordIdSchema.parse('-1')).toThrow()
-      expect(() => KeywordIdSchema.parse('abc')).toThrow()
+    it('不正な形式の文字列を拒否すること', () => {
+      expect(() => KeywordIdSchema.parse('1')).toThrow()
+      expect(() => KeywordIdSchema.parse('not-a-uuid')).toThrow()
     })
   })
 
   describe('keywordSchema', () => {
     it('正しいキーワードオブジェクトを受け入れること', () => {
-      const validKeyword = { id: '1', name: 'Test' }
+      const validKeyword = { id: MOCK_IDS.KEYWORD_1, name: 'Test' }
       expect(keywordSchema.parse(validKeyword)).toEqual(validKeyword)
     })
 
@@ -32,19 +31,23 @@ describe('Keyword Schemas', () => {
       expect(() =>
         keywordSchema.parse({ id: 'invalid', name: 'Test' }),
       ).toThrow()
-      expect(() => keywordSchema.parse({ id: '1' })).toThrow() // name missing
+      expect(() => keywordSchema.parse({ id: MOCK_IDS.KEYWORD_1 })).toThrow() // name missing
     })
   })
 
   describe('keywordWithCountSchema', () => {
     it('bookmarkCount を含むオブジェクトを受け入れること', () => {
-      const validData = { id: '1', name: 'Test', bookmarkCount: 5 }
+      const validData = {
+        id: MOCK_IDS.KEYWORD_1,
+        name: 'Test',
+        bookmarkCount: 5,
+      }
       expect(keywordWithCountSchema.parse(validData)).toEqual(validData)
     })
 
     it('bookmarkCount が欠落している場合に拒否すること', () => {
       expect(() =>
-        keywordWithCountSchema.parse({ id: '1', name: 'Test' }),
+        keywordWithCountSchema.parse({ id: MOCK_IDS.KEYWORD_1, name: 'Test' }),
       ).toThrow()
     })
   })
@@ -53,8 +56,8 @@ describe('Keyword Schemas', () => {
     it('キーワードリストを含むレスポンスを受け入れること', () => {
       const validResponse = {
         keywords: [
-          { id: '1', name: 'Tag1', bookmarkCount: 10 },
-          { id: '2', name: 'Tag2', bookmarkCount: 0 },
+          { id: MOCK_IDS.KEYWORD_1, name: 'Tag1', bookmarkCount: 10 },
+          { id: MOCK_IDS.KEYWORD_2, name: 'Tag2', bookmarkCount: 0 },
         ],
       }
       expect(keywordsResponseSchema.parse(validResponse)).toEqual(validResponse)

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -2,10 +2,7 @@ import { z } from 'zod'
 
 import { VALIDATION_MESSAGES } from '@shared/constants'
 
-export const KeywordIdSchema = z
-  .string()
-  .regex(/^[1-9]\d*$/)
-  .brand<'KeywordId'>()
+export const KeywordIdSchema = z.string().uuid().brand<'KeywordId'>()
 export type KeywordId = z.infer<typeof KeywordIdSchema>
 
 export const keywordSchema = z.object({

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -6,14 +6,35 @@ import type { KeywordWithCount } from '../schemas/keyword'
 
 export const MOCK_BOOKMARK_TITLE_PREFIX = 'Test Bookmark'
 
+// UUID v7 形式のモック ID (時間順ソート可能性を維持)
+export const MOCK_IDS = {
+  KEYWORD_1: '018ed000-0001-7000-8000-000000000001',
+  KEYWORD_2: '018ed000-0002-7000-8000-000000000002',
+  KEYWORD_3: '018ed000-0003-7000-8000-000000000003',
+  BOOKMARK_1: '018ed000-0004-7000-8000-000000000004',
+  BOOKMARK_2: '018ed000-0005-7000-8000-000000000005',
+} as const
+
 export const MOCK_KEYWORDS: KeywordWithCount[] = [
-  { id: KeywordIdSchema.parse('1'), name: 'React', bookmarkCount: 0 },
-  { id: KeywordIdSchema.parse('2'), name: 'TypeScript', bookmarkCount: 0 },
-  { id: KeywordIdSchema.parse('3'), name: 'Vite', bookmarkCount: 0 },
+  {
+    id: KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1),
+    name: 'React',
+    bookmarkCount: 0,
+  },
+  {
+    id: KeywordIdSchema.parse(MOCK_IDS.KEYWORD_2),
+    name: 'TypeScript',
+    bookmarkCount: 0,
+  },
+  {
+    id: KeywordIdSchema.parse(MOCK_IDS.KEYWORD_3),
+    name: 'Vite',
+    bookmarkCount: 0,
+  },
 ]
 
 export const MOCK_BOOKMARK_1: Bookmark = {
-  id: BookmarkIdSchema.parse('1'),
+  id: BookmarkIdSchema.parse(MOCK_IDS.BOOKMARK_1),
   title: `${MOCK_BOOKMARK_TITLE_PREFIX} 1`,
   url: 'https://example.com/1',
   sortOrder: 0,
@@ -21,7 +42,7 @@ export const MOCK_BOOKMARK_1: Bookmark = {
 }
 
 export const MOCK_BOOKMARK_2: Bookmark = {
-  id: BookmarkIdSchema.parse('2'),
+  id: BookmarkIdSchema.parse(MOCK_IDS.BOOKMARK_2),
   title: `${MOCK_BOOKMARK_TITLE_PREFIX} 2`,
   url: 'https://example.com/2',
   sortOrder: 1,
@@ -38,6 +59,7 @@ export const VALID_URLS = {
   IPV6_LOOPBACK: 'http://[::1]:3030',
   FRONTEND: 'http://localhost:5173',
   TEST_API: 'http://localhost:4000',
+  FRONTEND_APP: 'http://localhost:5173',
 } as const
 
 /**

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -59,7 +59,6 @@ export const VALID_URLS = {
   IPV6_LOOPBACK: 'http://[::1]:3030',
   FRONTEND: 'http://localhost:5173',
   TEST_API: 'http://localhost:4000',
-  FRONTEND_APP: 'http://localhost:5173',
 } as const
 
 /**


### PR DESCRIPTION
Closes #392

UUID 移行マイルストーンの第一弾として、共有スキーマとモックデータを刷新しました。

### 変更内容
- BookmarkIdSchema / KeywordIdSchema: UUID 形式への移行
- shared/test/fixtures.ts: 全てのモック ID を UUID v7 文字列に刷新
- shared/schemas/*.test.ts: 新体系に合わせたテストの修正

### 検証
- npx vitest shared/ が全てパスすることを確認済み
- npm run type-check がパスすることを確認済み（型定義が string ベースのため、既存コードへの影響が最小限で済みました）