### PR TITLE
feat(src): Web アプリの UUID 移行とテストの修正

### DIFF
--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -18,6 +18,14 @@ export const MOCK_IDS = {
   UNKNOWN_ID: '018ed000-0008-7000-8000-000000000008',
 } as const
 
+/**
+ * 不正な入力（数値 ID 等）をテストするためのモック ID
+ */
+export const MOCK_NUMERIC_IDS = {
+  VALID: 1,
+  OVER: 2,
+} as const
+
 export const MOCK_KEYWORDS: KeywordWithCount[] = [
   {
     id: KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1),

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -13,6 +13,9 @@ export const MOCK_IDS = {
   KEYWORD_3: '018ed000-0003-7000-8000-000000000003',
   BOOKMARK_1: '018ed000-0004-7000-8000-000000000004',
   BOOKMARK_2: '018ed000-0005-7000-8000-000000000005',
+  BOOKMARK_3: '018ed000-0006-7000-8000-000000000006',
+  NEW_KEYWORD: '018ed000-0007-7000-8000-000000000007',
+  UNKNOWN_ID: '018ed000-0008-7000-8000-000000000008',
 } as const
 
 export const MOCK_KEYWORDS: KeywordWithCount[] = [
@@ -49,7 +52,15 @@ export const MOCK_BOOKMARK_2: Bookmark = {
   keywords: [],
 }
 
-export const MOCK_BOOKMARKS = [MOCK_BOOKMARK_1, MOCK_BOOKMARK_2]
+export const MOCK_BOOKMARK_3: Bookmark = {
+  id: BookmarkIdSchema.parse(MOCK_IDS.BOOKMARK_3),
+  title: `${MOCK_BOOKMARK_TITLE_PREFIX} 3`,
+  url: 'https://example.com/3',
+  sortOrder: 2,
+  keywords: [],
+}
+
+export const MOCK_BOOKMARKS = [MOCK_BOOKMARK_1, MOCK_BOOKMARK_2, MOCK_BOOKMARK_3]
 
 export const VALID_URLS = {
   HTTP: 'http://localhost:3030',

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -16,6 +16,7 @@ import {
   MOCK_BOOKMARK_2,
   MOCK_BOOKMARKS,
   MOCK_BOOKMARK_TITLE_PREFIX,
+  MOCK_IDS,
 } from '@shared/test/fixtures'
 
 import { BookmarkList } from './BookmarkList'
@@ -104,12 +105,12 @@ describe('BookmarkList', () => {
 
         // リスト項目の階層構造を確認 (list > listitem > button)
         const listItems = screen.getAllByRole(ARIA_ROLES.LISTITEM)
-        expect(listItems).toHaveLength(2)
+        expect(listItems).toHaveLength(3)
 
         const buttons = screen.getAllByRole(ARIA_ROLES.BUTTON, {
           name: new RegExp(MOCK_BOOKMARK_TITLE_PREFIX),
         })
-        expect(buttons).toHaveLength(2)
+        expect(buttons).toHaveLength(3)
 
         // 各リスト項目の中にボタンが含まれていることを確認
         listItems.forEach((item, index) => {
@@ -280,8 +281,8 @@ describe('BookmarkList', () => {
 
     const context = screen.getByTestId('mock-dnd-context')
     // ID に number をセットしてクリック
-    context.setAttribute('data-active-id', '1')
-    context.setAttribute('data-over-id', '2')
+    context.setAttribute('data-active-id', MOCK_IDS.BOOKMARK_1)
+    context.setAttribute('data-over-id', MOCK_IDS.BOOKMARK_2)
     context.setAttribute('data-id-type', 'number')
 
     await user.click(context)

--- a/src/components/BookmarkList.test.tsx
+++ b/src/components/BookmarkList.test.tsx
@@ -16,7 +16,7 @@ import {
   MOCK_BOOKMARK_2,
   MOCK_BOOKMARKS,
   MOCK_BOOKMARK_TITLE_PREFIX,
-  MOCK_IDS,
+  MOCK_NUMERIC_IDS,
 } from '@shared/test/fixtures'
 
 import { BookmarkList } from './BookmarkList'
@@ -42,19 +42,31 @@ vi.mock('@dnd-kit/core', async () => {
       <div
         data-testid="mock-dnd-context"
         onClick={(e) => {
+          const type = e.currentTarget.getAttribute('data-id-type')
+
+          // type が number の場合は、data-active-id-num 等から数値を取得する
+          if (type === 'number') {
+            const activeIdNum = Number(
+              e.currentTarget.getAttribute('data-active-id-num'),
+            )
+            const overIdNum = Number(
+              e.currentTarget.getAttribute('data-over-id-num'),
+            )
+            onDragEnd({
+              active: { id: activeIdNum },
+              over: { id: overIdNum },
+            })
+            return
+          }
+
           const activeId =
             e.currentTarget.getAttribute('data-active-id') || MOCK_BOOKMARK_1.id
           const overId =
             e.currentTarget.getAttribute('data-over-id') || MOCK_BOOKMARK_2.id
-          const type = e.currentTarget.getAttribute('data-id-type')
-
-          // 型ガードのテスト用に number を渡せるようにする
-          const finalActiveId = type === 'number' ? Number(activeId) : activeId
-          const finalOverId = type === 'number' ? Number(overId) : overId
 
           onDragEnd({
-            active: { id: finalActiveId },
-            over: { id: finalOverId },
+            active: { id: activeId },
+            over: { id: overId },
           })
         }}
       >
@@ -281,8 +293,8 @@ describe('BookmarkList', () => {
 
     const context = screen.getByTestId('mock-dnd-context')
     // ID に number をセットしてクリック
-    context.setAttribute('data-active-id', MOCK_IDS.BOOKMARK_1)
-    context.setAttribute('data-over-id', MOCK_IDS.BOOKMARK_2)
+    context.setAttribute('data-active-id-num', String(MOCK_NUMERIC_IDS.VALID))
+    context.setAttribute('data-over-id-num', String(MOCK_NUMERIC_IDS.OVER))
     context.setAttribute('data-id-type', 'number')
 
     await user.click(context)

--- a/src/components/DraggableList.test.tsx
+++ b/src/components/DraggableList.test.tsx
@@ -2,7 +2,7 @@ import * as sortable from '@dnd-kit/sortable'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { z } from 'zod'
 
-import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2 } from '@shared/test/fixtures'
+import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2, MOCK_IDS } from '@shared/test/fixtures'
 
 import { DraggableItem } from './DraggableItem'
 import { DraggableList } from './DraggableList'
@@ -49,8 +49,8 @@ vi.mock('@dnd-kit/sortable', async () => {
 
 describe('DraggableList', () => {
   const mockItems = [
-    { id: '1', name: 'Item 1' },
-    { id: '2', name: 'Item 2' },
+    { id: MOCK_IDS.BOOKMARK_1, name: 'Item 1' },
+    { id: MOCK_IDS.BOOKMARK_2, name: 'Item 2' },
   ]
 
   beforeEach(() => {
@@ -91,8 +91,8 @@ describe('DraggableList', () => {
       />,
     )
 
-    expect(screen.getByTestId('item-1')).toHaveTextContent('Item 1')
-    expect(screen.getByTestId('item-2')).toHaveTextContent('Item 2')
+    expect(screen.getByTestId(`item-${MOCK_IDS.BOOKMARK_1}`)).toHaveTextContent('Item 1')
+    expect(screen.getByTestId(`item-${MOCK_IDS.BOOKMARK_2}`)).toHaveTextContent('Item 2')
   })
 
   it('ドラッグ終了時に onReorder が正しい引数で呼び出されること', () => {
@@ -113,7 +113,7 @@ describe('DraggableList', () => {
     const context = screen.getByTestId('dnd-context')
     context.click()
 
-    expect(onReorder).toHaveBeenCalledWith('1', '2')
+    expect(onReorder).toHaveBeenCalledWith(MOCK_IDS.BOOKMARK_1, MOCK_IDS.BOOKMARK_2)
   })
 
   it('IDの検証に失敗した場合、onReorder が呼び出されないこと', () => {
@@ -137,7 +137,7 @@ describe('DraggableList', () => {
     )
 
     const context = screen.getByTestId('dnd-context')
-    context.click() // モックでは文字列 '1', '2' を渡すため、検証に失敗する
+    context.click() // モックでは文字列 UUID を渡すため、検証に失敗する
 
     expect(onReorder).not.toHaveBeenCalled()
     expect(consoleSpy).toHaveBeenCalled()
@@ -147,7 +147,7 @@ describe('DraggableList', () => {
   it('ドラッグ中のアイテムに適切なスタイルが適用されること (Branch Coverage用)', () => {
     const onReorder = vi.fn()
 
-    // ID '1' のアイテムだけドラッグ中とする
+    // MOCK_IDS.BOOKMARK_1 のアイテムだけドラッグ中とする
     vi.mocked(sortable.useSortable).mockImplementation(
       ({ id }: { id: string | number }) =>
         ({
@@ -156,7 +156,7 @@ describe('DraggableList', () => {
           setNodeRef: () => {},
           transform: null,
           transition: null,
-          isDragging: id === '1',
+          isDragging: id === MOCK_IDS.BOOKMARK_1,
         }) as unknown as ReturnType<typeof sortable.useSortable>,
     )
 
@@ -181,8 +181,8 @@ describe('DraggableList', () => {
       />,
     )
 
-    const item1 = screen.getByTestId('item-1')
-    const item2 = screen.getByTestId('item-2')
+    const item1 = screen.getByTestId(`item-${MOCK_IDS.BOOKMARK_1}`)
+    const item2 = screen.getByTestId(`item-${MOCK_IDS.BOOKMARK_2}`)
 
     // ドラッグ中のスタイルを確認
     expect(item1.style.opacity).toBe('0.5')

--- a/src/components/KeywordItem.test.tsx
+++ b/src/components/KeywordItem.test.tsx
@@ -2,6 +2,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ARIA_ROLES, KEY_VALUES } from '@shared/constants'
+import { MOCK_IDS } from '@shared/test/fixtures'
 import type { Keyword, KeywordId } from '@shared/schemas/keyword'
 
 import { KeywordItem } from './KeywordItem'
@@ -11,7 +12,7 @@ import type { DraggableAttributes } from '@dnd-kit/core'
 
 describe('KeywordItem', () => {
   const mockKeyword: Keyword = {
-    id: '1' as KeywordId,
+    id: MOCK_IDS.KEYWORD_1 as KeywordId,
     name: 'TestKeyword',
   }
   const defaultProps = {

--- a/src/components/KeywordItem.test.tsx
+++ b/src/components/KeywordItem.test.tsx
@@ -2,8 +2,8 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ARIA_ROLES, KEY_VALUES } from '@shared/constants'
-import { MOCK_IDS } from '@shared/test/fixtures'
-import type { Keyword, KeywordId } from '@shared/schemas/keyword'
+import type { Keyword } from '@shared/schemas/keyword'
+import { MOCK_KEYWORDS } from '@shared/test/fixtures'
 
 import { KeywordItem } from './KeywordItem'
 import { render, screen } from '../test/utils'
@@ -11,10 +11,7 @@ import { render, screen } from '../test/utils'
 import type { DraggableAttributes } from '@dnd-kit/core'
 
 describe('KeywordItem', () => {
-  const mockKeyword: Keyword = {
-    id: MOCK_IDS.KEYWORD_1 as KeywordId,
-    name: 'TestKeyword',
-  }
+  const mockKeyword: Keyword = MOCK_KEYWORDS[0]
   const defaultProps = {
     keyword: mockKeyword,
     isSelected: false,

--- a/src/hooks/useApp.test.tsx
+++ b/src/hooks/useApp.test.tsx
@@ -2,10 +2,10 @@ import { http, HttpResponse } from 'msw'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { TEST_MESSAGES } from '@shared/constants'
-import { BookmarkIdSchema } from '@shared/schemas/bookmark'
 import {
   MOCK_BOOKMARK_1,
   MOCK_BOOKMARK_2,
+  MOCK_BOOKMARK_3,
   VALID_URLS,
   MOCK_KEYWORDS,
 } from '@shared/test/fixtures'
@@ -170,7 +170,7 @@ describe('useApp Hook (Integration)', () => {
       }
       const b3 = {
         ...MOCK_BOOKMARK_1,
-        id: BookmarkIdSchema.parse('3'),
+        id: MOCK_BOOKMARK_3.id,
         title: 'B3',
         url: 'https://b3.com',
         keywords: [],
@@ -220,7 +220,7 @@ describe('useApp Hook (Integration)', () => {
       }
       const bookmarkWithoutKw1 = {
         ...MOCK_BOOKMARK_1,
-        id: '2',
+        id: MOCK_BOOKMARK_2.id,
         title: 'Other',
         keywords: [MOCK_KEYWORDS[1]],
       }
@@ -251,12 +251,12 @@ describe('useApp Hook (Integration)', () => {
     it('複数のキーワードが選択された場合、AND検索として機能すること', async () => {
       const bookmarkWithBoth = {
         ...MOCK_BOOKMARK_1,
-        id: '1',
+        id: MOCK_BOOKMARK_1.id,
         keywords: [MOCK_KEYWORDS[0], MOCK_KEYWORDS[1]],
       }
       const bookmarkWithOnly1 = {
         ...MOCK_BOOKMARK_1,
-        id: '2',
+        id: MOCK_BOOKMARK_2.id,
         keywords: [MOCK_KEYWORDS[0]],
       }
 

--- a/src/hooks/useBookmarkPage.test.ts
+++ b/src/hooks/useBookmarkPage.test.ts
@@ -9,7 +9,7 @@ import {
   DROPPABLE_IDS,
   KEY_VALUES,
 } from '@shared/constants'
-import { MOCK_BOOKMARK_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
+import { MOCK_BOOKMARK_1, MOCK_KEYWORDS, MOCK_IDS } from '@shared/test/fixtures'
 import * as urlUtils from '@shared/utils/url'
 
 import { useBookmarkPage } from './useBookmarkPage'
@@ -160,7 +160,7 @@ describe('useBookmarkPage Hook', () => {
         createCalled = true
         return HttpResponse.json({
           success: true,
-          data: { keyword: { id: '10', name: 'Enter' } },
+          data: { keyword: { id: MOCK_IDS.NEW_KEYWORD, name: 'Enter' } },
         })
       }),
       http.post('*/api/bookmarks/:id/keywords', () => {
@@ -293,14 +293,14 @@ describe('useBookmarkPage Hook', () => {
           createCalled = true
           return HttpResponse.json({
             success: true,
-            data: { keyword: { id: '10', name: NEW_TAG } },
+            data: { keyword: { id: MOCK_IDS.NEW_KEYWORD, name: NEW_TAG } },
           })
         }
         return new HttpResponse(null, { status: 400 })
       }),
       http.post('*/api/bookmarks/:id/keywords', async ({ request }) => {
         const body = (await request.json()) as { keywordId: string }
-        if (body.keywordId === '10') {
+        if (body.keywordId === MOCK_IDS.NEW_KEYWORD) {
           attachCalled = true
           return HttpResponse.json({ success: true, data: null })
         }
@@ -456,7 +456,7 @@ describe('useBookmarkPage Hook', () => {
         http.post('*/api/keywords', () => {
           return HttpResponse.json({
             success: true,
-            data: { keyword: { id: '10', name: 'Success' } },
+            data: { keyword: { id: MOCK_IDS.NEW_KEYWORD, name: 'Success' } },
           })
         }),
         http.post('*/api/bookmarks/:id/keywords', () => {

--- a/src/hooks/useBookmarks.test.tsx
+++ b/src/hooks/useBookmarks.test.tsx
@@ -2,8 +2,7 @@ import { http, HttpResponse } from 'msw'
 import { describe, expect, it, vi } from 'vitest'
 
 import { API_PATHS, LOG_MESSAGES } from '@shared/constants'
-import type { BookmarkId } from '@shared/schemas/bookmark'
-import { MOCK_BOOKMARK_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
+import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2, MOCK_KEYWORDS } from '@shared/test/fixtures'
 
 import {
   BookmarkApiError,
@@ -181,7 +180,7 @@ describe('useBookmarks Hook', () => {
 
       const { result } = renderHook(() => useReorderBookmarks())
 
-      result.current.mutate({ ids: ['2' as BookmarkId, '1' as BookmarkId] })
+      result.current.mutate({ ids: [MOCK_BOOKMARK_2.id, MOCK_BOOKMARK_1.id] })
 
       await waitFor(() => expect(result.current.isError).toBe(true))
       expect(consoleSpy).toHaveBeenCalledWith(

--- a/src/hooks/useKeywordListState.test.ts
+++ b/src/hooks/useKeywordListState.test.ts
@@ -3,6 +3,7 @@ import { useState, useCallback } from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { KeywordIdSchema } from '@shared/schemas/keyword'
+import { MOCK_IDS } from '@shared/test/fixtures'
 
 import { useKeywordListState } from './useKeywordListState'
 import { renderHook, act } from '../test/utils'
@@ -60,33 +61,33 @@ describe('useKeywordListState', () => {
   })
 
   it('URL に keywords パラメータがある場合、初期化時に復元されること', () => {
-    vi.stubGlobal('location', { search: '?keywords=1,2' })
+    vi.stubGlobal('location', { search: `?keywords=${MOCK_IDS.KEYWORD_1},${MOCK_IDS.KEYWORD_2}` })
     const { result } = renderHook(() => useKeywordListState())
 
     expect(result.current.selectedKeywordIds).toEqual([
-      KeywordIdSchema.parse('1'),
-      KeywordIdSchema.parse('2'),
+      KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1),
+      KeywordIdSchema.parse(MOCK_IDS.KEYWORD_2),
     ])
   })
 
   it('不正な形式の ID が URL に含まれている場合、無視して正常なものだけ復元されること', () => {
-    vi.stubGlobal('location', { search: '?keywords=1,, ,invalid!' })
+    vi.stubGlobal('location', { search: `?keywords=${MOCK_IDS.KEYWORD_1},, ,invalid!` })
     const { result } = renderHook(() => useKeywordListState())
 
     expect(result.current.selectedKeywordIds).toEqual([
-      KeywordIdSchema.parse('1'),
+      KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1),
     ])
   })
 
   it('クリックでキーワードが選択され、再度クリックで解除されること', async () => {
     const { result } = renderHook(() => useKeywordListState())
-    const keywordId = KeywordIdSchema.parse('1')
+    const keywordId = KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1)
 
     await act(async () => {
       result.current.toggleKeywordSelection(keywordId)
     })
     expect(result.current.selectedKeywordIds).toContain(keywordId)
-    expect(capturedParams.get('keywords')).toBe('1')
+    expect(capturedParams.get('keywords')).toBe(MOCK_IDS.KEYWORD_1)
 
     await act(async () => {
       result.current.toggleKeywordSelection(keywordId)
@@ -97,8 +98,8 @@ describe('useKeywordListState', () => {
 
   it('複数のキーワードを選択した際、カンマ区切りで URL パラメータに反映されること', async () => {
     const { result } = renderHook(() => useKeywordListState())
-    const id1 = KeywordIdSchema.parse('1')
-    const id2 = KeywordIdSchema.parse('2')
+    const id1 = KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1)
+    const id2 = KeywordIdSchema.parse(MOCK_IDS.KEYWORD_2)
 
     await act(async () => {
       result.current.toggleKeywordSelection(id1)
@@ -108,12 +109,12 @@ describe('useKeywordListState', () => {
     })
 
     expect(result.current.selectedKeywordIds).toEqual([id1, id2])
-    expect(capturedParams.get('keywords')).toBe('1,2')
+    expect(capturedParams.get('keywords')).toBe(`${MOCK_IDS.KEYWORD_1},${MOCK_IDS.KEYWORD_2}`)
   })
 
   it('clearKeywordSelection で全ての選択が解除され、URL からも削除されること', async () => {
     const { result } = renderHook(() => useKeywordListState())
-    const id1 = KeywordIdSchema.parse('1')
+    const id1 = KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1)
 
     await act(async () => {
       result.current.toggleKeywordSelection(id1)

--- a/src/hooks/useKeywordPage.test.ts
+++ b/src/hooks/useKeywordPage.test.ts
@@ -4,7 +4,7 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { APP_PATHS, UI_MESSAGES, UI_STATUS } from '@shared/constants'
-import { MOCK_KEYWORDS } from '@shared/test/fixtures'
+import { MOCK_KEYWORDS, MOCK_IDS } from '@shared/test/fixtures'
 
 import { useKeywordPage } from './useKeywordPage'
 import { server } from '../test/setup'
@@ -60,7 +60,7 @@ describe('useKeywordPage Hook', () => {
   })
 
   it('ID が存在しない場合、keyword が undefined になること', async () => {
-    vi.mocked(useParams).mockReturnValue({ id: '999' })
+    vi.mocked(useParams).mockReturnValue({ id: MOCK_IDS.UNKNOWN_ID })
 
     const { result } = renderHook(() => useKeywordPage())
 

--- a/src/lib/queryKeys.test.ts
+++ b/src/lib/queryKeys.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
+import { MOCK_IDS } from '@shared/test/fixtures'
+
 import { QUERY_KEYS } from './queryKeys'
 
 describe('QUERY_KEYS', () => {
@@ -17,12 +19,12 @@ describe('QUERY_KEYS', () => {
     })
 
     describe('DETAIL(id)', () => {
-      it('数値 ID を文字列に変換して正しいキーを返すこと', () => {
-        const id = 123
+      it('UUID を含めて正しいキーを返すこと', () => {
+        const id = MOCK_IDS.BOOKMARK_1
         expect(QUERY_KEYS.BOOKMARKS.DETAIL(id)).toEqual([
           'bookmarks',
           'detail',
-          '123',
+          id,
         ])
       })
 
@@ -34,21 +36,6 @@ describe('QUERY_KEYS', () => {
           'abc-789',
         ])
       })
-
-      it.each([
-        { id: 0, expected: '0' },
-        { id: '0', expected: '0' },
-        { id: -1, expected: '-1' },
-      ])(
-        'エッジケース ($id) でも正しく文字列化されること',
-        ({ id, expected }) => {
-          expect(QUERY_KEYS.BOOKMARKS.DETAIL(id)).toEqual([
-            'bookmarks',
-            'detail',
-            expected,
-          ])
-        },
-      )
     })
   })
 })

--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -12,7 +12,7 @@ import {
   UI_MESSAGES,
 } from '@shared/constants'
 import { updateBookmarkSchema } from '@shared/schemas/bookmark'
-import { MOCK_BOOKMARK_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
+import { MOCK_BOOKMARK_1, MOCK_KEYWORDS, MOCK_IDS } from '@shared/test/fixtures'
 import * as urlUtils from '@shared/utils/url'
 
 import { BookmarkPage } from './BookmarkPage'
@@ -244,7 +244,7 @@ describe('BookmarkPage Component', () => {
         createCalled = true
         return HttpResponse.json({
           success: true,
-          data: { keyword: { id: 'new-kw', name: 'NewTag' } },
+          data: { keyword: { id: MOCK_IDS.NEW_KEYWORD, name: 'NewTag' } },
         })
       }),
       http.post('*/api/bookmarks/:id/keywords', () => {
@@ -276,7 +276,7 @@ describe('BookmarkPage Component', () => {
         createCalled = true
         return HttpResponse.json({
           success: true,
-          data: { keyword: { id: 'new-kw', name: 'EnterTag' } },
+          data: { keyword: { id: MOCK_IDS.NEW_KEYWORD, name: 'EnterTag' } },
         })
       }),
       http.post('*/api/bookmarks/:id/keywords', () => {
@@ -395,7 +395,7 @@ describe('BookmarkPage Component', () => {
 
     renderWithRoutes(
       <BookmarkPage onBack={onBack} />,
-      APP_PATHS.BOOKMARK_DETAIL('999'),
+      APP_PATHS.BOOKMARK_DETAIL(MOCK_IDS.UNKNOWN_ID),
     )
 
     expect(await screen.findByText(/Bookmark not found/i)).toBeInTheDocument()


### PR DESCRIPTION
Web アプリ（src/）配下のテストとロジックを UUID v7 に適応させ、プロジェクト全体の型チェックとテストを正常化しました。

Closes #397