### PR TITLE
[Extension] キーワードの取得と追加の実装

### DIFF
--- a/extension/src/lib/idb.test.ts
+++ b/extension/src/lib/idb.test.ts
@@ -1,6 +1,7 @@
 import 'fake-indexeddb/auto'
 import { describe, it, expect, beforeEach } from 'vitest'
 
+import { DB_CONSTANTS } from '@shared/constants'
 import { KeywordIdSchema } from '@shared/schemas/keyword'
 import { MOCK_BOOKMARK_ENTITY_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
 
@@ -14,7 +15,7 @@ describe('BookmarkDatabase', () => {
   })
 
   it('データベースが正常に初期化され、ストアが存在すること', async () => {
-    expect(db.name).toBe('BookmarkDatabase')
+    expect(db.name).toBe(DB_CONSTANTS.DB_NAME)
     expect(db.bookmarks).toBeDefined()
     expect(db.keywords).toBeDefined()
 

--- a/extension/src/lib/idb.test.ts
+++ b/extension/src/lib/idb.test.ts
@@ -1,8 +1,8 @@
 import 'fake-indexeddb/auto'
 import { describe, it, expect, beforeEach } from 'vitest'
 
-import { DB_CONSTANTS } from '@shared/constants'
-import { MOCK_BOOKMARK_ENTITY_1 } from '@shared/test/fixtures'
+import { KeywordIdSchema } from '@shared/schemas/keyword'
+import { MOCK_BOOKMARK_ENTITY_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
 
 import { db } from './idb'
 
@@ -14,7 +14,7 @@ describe('BookmarkDatabase', () => {
   })
 
   it('データベースが正常に初期化され、ストアが存在すること', async () => {
-    expect(db.name).toBe(DB_CONSTANTS.DB_NAME)
+    expect(db.name).toBe('BookmarkDatabase')
     expect(db.bookmarks).toBeDefined()
     expect(db.keywords).toBeDefined()
 
@@ -24,11 +24,46 @@ describe('BookmarkDatabase', () => {
   })
 
   it('bookmarks ストアにデータを追加・取得できること (疎通確認)', async () => {
-    // shared/test/fixtures.ts のエンティティフィクスチャを使用
     const mockBookmark = MOCK_BOOKMARK_ENTITY_1
 
     await db.bookmarks.add(mockBookmark)
     const result = await db.bookmarks.get(mockBookmark.id)
     expect(result).toEqual(mockBookmark)
+  })
+
+  describe('Keyword Operations (Basic)', () => {
+    it('getAllKeywords が保存されている全キーワードを返すこと', async () => {
+      await db.keywords.bulkAdd(MOCK_KEYWORDS)
+      const result = await db.getAllKeywords()
+      expect(result).toHaveLength(MOCK_KEYWORDS.length)
+      expect(result).toEqual(expect.arrayContaining(MOCK_KEYWORDS))
+    })
+
+    it('addKeyword が新しいキーワードを保存し、その ID を返すこと', async () => {
+      const newKeyword = { name: 'New Tag' }
+      const id = await db.addKeyword(newKeyword)
+      
+      expect(KeywordIdSchema.safeParse(id).success).toBe(true)
+      
+      const saved = await db.keywords.get(id)
+      expect(saved?.name).toBe('New Tag')
+      expect(saved?.bookmarkCount).toBe(0)
+    })
+
+    it('既に存在する名前のキーワードを追加しようとした場合、既存の ID を返すこと (冪等性)', async () => {
+      const existing = MOCK_KEYWORDS[0]
+      await db.keywords.add(existing)
+
+      const id = await db.addKeyword({ name: existing.name })
+      
+      expect(id).toBe(existing.id)
+      const count = await db.keywords.count()
+      expect(count).toBe(1)
+    })
+
+    it('不正な名前（空文字等）のキーワード追加を拒否すること', async () => {
+      await expect(db.addKeyword({ name: '' })).rejects.toThrow()
+      await expect(db.addKeyword({ name: '   ' })).rejects.toThrow()
+    })
   })
 })

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -6,6 +6,7 @@ import {
   type KeywordId,
   type KeywordWithCount,
   keywordSchema,
+  KeywordIdSchema,
 } from '@shared/schemas/keyword'
 import { generateId } from '@shared/utils/id'
 
@@ -45,7 +46,7 @@ export class BookmarkDatabase extends Dexie {
       return existing.id
     }
 
-    const id = generateId() as KeywordId
+    const id = KeywordIdSchema.parse(generateId())
     await this.keywords.add({
       id,
       name,

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -2,7 +2,12 @@ import Dexie, { type Table } from 'dexie'
 
 import { DB_CONSTANTS } from '@shared/constants'
 import type { BookmarkEntity, BookmarkId } from '@shared/schemas/bookmark'
-import type { KeywordId, KeywordWithCount } from '@shared/schemas/keyword'
+import {
+  type KeywordId,
+  type KeywordWithCount,
+  keywordSchema,
+} from '@shared/schemas/keyword'
+import { generateId } from '@shared/utils/id'
 
 /**
  * 拡張機能内のデータを永続化するための IndexedDB クラス
@@ -16,6 +21,38 @@ export class BookmarkDatabase extends Dexie {
 
     // ストアの定義
     this.version(DB_CONSTANTS.IDB_VERSION).stores(DB_CONSTANTS.IDB_SCHEMA)
+  }
+
+  /**
+   * 全てのキーワードを取得する
+   */
+  async getAllKeywords(): Promise<KeywordWithCount[]> {
+    return await this.keywords.toArray()
+  }
+
+  /**
+   * キーワードを追加する。同名のキーワードが既に存在する場合は、その ID を返す。
+   * @param params 名前を含むキーワード情報（IDは任意）
+   */
+  async addKeyword(params: { name: string }): Promise<KeywordId> {
+    // バリデーション
+    const name = params.name.trim()
+    keywordSchema.shape.name.parse(name)
+
+    // 重複チェック
+    const existing = await this.keywords.where('name').equalsIgnoreCase(name).first()
+    if (existing) {
+      return existing.id
+    }
+
+    const id = generateId() as KeywordId
+    await this.keywords.add({
+      id,
+      name,
+      bookmarkCount: 0,
+    })
+
+    return id
   }
 }
 

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -7,7 +7,10 @@ export type KeywordId = z.infer<typeof KeywordIdSchema>
 
 export const keywordSchema = z.object({
   id: KeywordIdSchema,
-  name: z.string(),
+  name: z
+    .string()
+    .min(1, VALIDATION_MESSAGES.KEYWORD_MIN_LENGTH)
+    .max(50, VALIDATION_MESSAGES.KEYWORD_MAX_LENGTH),
 })
 export type Keyword = z.infer<typeof keywordSchema>
 


### PR DESCRIPTION
Issue #402 に対する実装です。

### 変更内容
- `extension/src/lib/idb.ts` に `getAllKeywords()` および `addKeyword()` を実装。
- `addKeyword` は同名のキーワードが存在する場合に既存の ID を返す冪等性を確保。
- `shared/schemas/keyword.ts` の `keywordSchema` に長さ制約を追加し、データの整合性を強化。
- `extension/src/lib/idb.test.ts` にて TDD による検証を完了。

Closes #402