### PR TITLE
[Extension] キーワードの更新実装

### DIFF
--- a/extension/src/lib/idb.test.ts
+++ b/extension/src/lib/idb.test.ts
@@ -3,7 +3,12 @@ import { describe, it, expect, beforeEach } from 'vitest'
 
 import { DB_CONSTANTS } from '@shared/constants'
 import { KeywordIdSchema } from '@shared/schemas/keyword'
-import { MOCK_BOOKMARK_ENTITY_1, MOCK_KEYWORDS } from '@shared/test/fixtures'
+import {
+  MOCK_BOOKMARK_ENTITY_1,
+  MOCK_KEYWORDS,
+  MOCK_IDS,
+  TEST_STRINGS,
+} from '@shared/test/fixtures'
 
 import { db } from './idb'
 
@@ -41,13 +46,13 @@ describe('BookmarkDatabase', () => {
     })
 
     it('addKeyword が新しいキーワードを保存し、その ID を返すこと', async () => {
-      const newKeyword = { name: 'New Tag' }
+      const newKeyword = { name: TEST_STRINGS.NEW_NAME }
       const id = await db.addKeyword(newKeyword)
       
       expect(KeywordIdSchema.safeParse(id).success).toBe(true)
       
       const saved = await db.keywords.get(id)
-      expect(saved?.name).toBe('New Tag')
+      expect(saved?.name).toBe(TEST_STRINGS.NEW_NAME)
       expect(saved?.bookmarkCount).toBe(0)
     })
 
@@ -65,6 +70,39 @@ describe('BookmarkDatabase', () => {
     it('不正な名前（空文字等）のキーワード追加を拒否すること', async () => {
       await expect(db.addKeyword({ name: '' })).rejects.toThrow()
       await expect(db.addKeyword({ name: '   ' })).rejects.toThrow()
+    })
+  })
+
+  describe('Keyword Operations (Update)', () => {
+    it('updateKeyword が正常に名前を更新すること', async () => {
+      const keyword = MOCK_KEYWORDS[0]
+      await db.keywords.add(keyword)
+
+      await db.updateKeyword(keyword.id, TEST_STRINGS.UPDATED_NAME)
+
+      const updated = await db.keywords.get(keyword.id)
+      expect(updated?.name).toBe(TEST_STRINGS.UPDATED_NAME)
+    })
+
+    it('存在しない ID の更新を試みた場合にエラーを投げること', async () => {
+      const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
+      await expect(
+        db.updateKeyword(unknownId, TEST_STRINGS.NEW_NAME),
+      ).rejects.toThrow()
+    })
+
+    it('他のキーワードと重複する名前への更新を拒否すること', async () => {
+      await db.keywords.bulkAdd([MOCK_KEYWORDS[0], MOCK_KEYWORDS[1]])
+
+      // React を TypeScript という名前に更新しようとする
+      await expect(
+        db.updateKeyword(MOCK_KEYWORDS[0].id, MOCK_KEYWORDS[1].name),
+      ).rejects.toThrow()
+    })
+
+    it('不正な形式の名前への更新を拒否すること', async () => {
+      await db.keywords.add(MOCK_KEYWORDS[0])
+      await expect(db.updateKeyword(MOCK_KEYWORDS[0].id, '')).rejects.toThrow()
     })
   })
 })

--- a/extension/src/lib/idb.test.ts
+++ b/extension/src/lib/idb.test.ts
@@ -84,6 +84,16 @@ describe('BookmarkDatabase', () => {
       expect(updated?.name).toBe(TEST_STRINGS.UPDATED_NAME)
     })
 
+    it('大文字小文字のみの変更（例: react -> React）が正常に行えること', async () => {
+      const keyword = { id: KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1), name: 'react', bookmarkCount: 0 }
+      await db.keywords.add(keyword)
+
+      await db.updateKeyword(keyword.id, 'React')
+
+      const updated = await db.keywords.get(keyword.id)
+      expect(updated?.name).toBe('React')
+    })
+
     it('存在しない ID の更新を試みた場合にエラーを投げること', async () => {
       const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
       await expect(

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -1,6 +1,6 @@
 import Dexie, { type Table } from 'dexie'
 
-import { DB_CONSTANTS } from '@shared/constants'
+import { DB_CONSTANTS, ERROR_MESSAGES } from '@shared/constants'
 import type { BookmarkEntity, BookmarkId } from '@shared/schemas/bookmark'
 import {
   type KeywordId,
@@ -54,6 +54,39 @@ export class BookmarkDatabase extends Dexie {
     })
 
     return id
+  }
+
+  /**
+   * キーワードの名前を更新する
+   */
+  async updateKeyword(id: KeywordId, name: string): Promise<void> {
+    const trimmedName = name.trim()
+    // バリデーション
+    keywordSchema.shape.name.parse(trimmedName)
+
+    return await this.transaction('rw', this.keywords, async () => {
+      // 存在確認
+      const existing = await this.keywords.get(id)
+      if (!existing) {
+        throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
+      }
+
+      // 名前が変わらない場合は何もしない
+      if (existing.name === trimmedName) {
+        return
+      }
+
+      // 他のキーワードとの重複チェック
+      const duplicate = await this.keywords
+        .where('name')
+        .equalsIgnoreCase(trimmedName)
+        .first()
+      if (duplicate) {
+        throw new Error(ERROR_MESSAGES.DUPLICATE_KEYWORD)
+      }
+
+      await this.keywords.update(id, { name: trimmedName })
+    })
   }
 }
 

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -81,7 +81,7 @@ export class BookmarkDatabase extends Dexie {
         .where('name')
         .equalsIgnoreCase(trimmedName)
         .first()
-      if (duplicate) {
+      if (duplicate && duplicate.id !== id) {
         throw new Error(ERROR_MESSAGES.DUPLICATE_KEYWORD)
       }
 

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -5,6 +5,12 @@ import type { Bookmark, BookmarkEntity } from '../schemas/bookmark'
 import type { KeywordWithCount } from '../schemas/keyword'
 
 export const MOCK_BOOKMARK_TITLE_PREFIX = 'Test Bookmark'
+export const MOCK_KEYWORD_NAME_PREFIX = 'Test Keyword'
+
+export const TEST_STRINGS = {
+  UPDATED_NAME: 'Updated Name',
+  NEW_NAME: 'New Name',
+} as const
 
 // UUID v7 形式のモック ID (時間順ソート可能性を維持)
 export const MOCK_IDS = {


### PR DESCRIPTION
Issue #404 に対する実装です。

### 変更内容
- `extension/src/lib/idb.ts` に `updateKeyword(id, name)` を実装。
- 重複チェック、存在確認、Zod によるバリデーションを組み合わせた堅牢な更新処理を構築。
- `shared/test/fixtures.ts` にテスト用共有定数 (`TEST_STRINGS`) を追加。
- `extension/src/lib/idb.test.ts` を更新し、型アサーションを排除して Zod スキーマによる型ガードと定数を利用するように改善。

Closes #404