### PR TITLE
[Extension] キーワードの削除実装

### DIFF
--- a/extension/src/lib/idb.test.ts
+++ b/extension/src/lib/idb.test.ts
@@ -1,7 +1,7 @@
 import 'fake-indexeddb/auto'
 import { describe, it, expect, beforeEach } from 'vitest'
 
-import { DB_CONSTANTS } from '@shared/constants'
+import { DB_CONSTANTS, ERROR_MESSAGES } from '@shared/constants'
 import { KeywordIdSchema } from '@shared/schemas/keyword'
 import {
   MOCK_BOOKMARK_ENTITY_1,
@@ -98,7 +98,7 @@ describe('BookmarkDatabase', () => {
       const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
       await expect(
         db.updateKeyword(unknownId, TEST_STRINGS.NEW_NAME),
-      ).rejects.toThrow()
+      ).rejects.toThrow(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
     })
 
     it('他のキーワードと重複する名前への更新を拒否すること', async () => {
@@ -107,7 +107,7 @@ describe('BookmarkDatabase', () => {
       // React を TypeScript という名前に更新しようとする
       await expect(
         db.updateKeyword(MOCK_KEYWORDS[0].id, MOCK_KEYWORDS[1].name),
-      ).rejects.toThrow()
+      ).rejects.toThrow(ERROR_MESSAGES.DUPLICATE_KEYWORD)
     })
 
     it('不正な形式の名前への更新を拒否すること', async () => {
@@ -127,9 +127,27 @@ describe('BookmarkDatabase', () => {
       expect(deleted).toBeUndefined()
     })
 
+    it('キーワード削除時に、関連するブックマークからの紐付けも解除されること', async () => {
+      const keyword = MOCK_KEYWORDS[0]
+      const bookmark = {
+        ...MOCK_BOOKMARK_ENTITY_1,
+        keywordIds: [keyword.id],
+      }
+      await db.keywords.add(keyword)
+      await db.bookmarks.add(bookmark)
+
+      // 削除実行
+      await db.deleteKeyword(keyword.id)
+
+      // ブックマークの keywordIds から削除されていることを確認
+      const updatedBookmark = await db.bookmarks.get(bookmark.id)
+      expect(updatedBookmark?.keywordIds).not.toContain(keyword.id)
+      expect(updatedBookmark?.keywordIds).toHaveLength(0)
+    })
+
     it('存在しない ID の削除を試みた場合にエラーを投げること', async () => {
       const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
-      await expect(db.deleteKeyword(unknownId)).rejects.toThrow()
+      await expect(db.deleteKeyword(unknownId)).rejects.toThrow(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
     })
   })
 })

--- a/extension/src/lib/idb.test.ts
+++ b/extension/src/lib/idb.test.ts
@@ -115,4 +115,21 @@ describe('BookmarkDatabase', () => {
       await expect(db.updateKeyword(MOCK_KEYWORDS[0].id, '')).rejects.toThrow()
     })
   })
+
+  describe('Keyword Operations (Delete)', () => {
+    it('deleteKeyword が正常にキーワードを削除すること', async () => {
+      const keyword = MOCK_KEYWORDS[0]
+      await db.keywords.add(keyword)
+
+      await db.deleteKeyword(keyword.id)
+
+      const deleted = await db.keywords.get(keyword.id)
+      expect(deleted).toBeUndefined()
+    })
+
+    it('存在しない ID の削除を試みた場合にエラーを投げること', async () => {
+      const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
+      await expect(db.deleteKeyword(unknownId)).rejects.toThrow()
+    })
+  })
 })

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -90,17 +90,27 @@ export class BookmarkDatabase extends Dexie {
   }
 
   /**
-   * キーワードを削除する
+   * キーワードを削除する。関連するブックマークからの紐付けも解除する。
    */
   async deleteKeyword(id: KeywordId): Promise<void> {
-    return await this.transaction('rw', this.keywords, async () => {
+    return await this.transaction('rw', [this.keywords, this.bookmarks], async () => {
       // 存在確認
       const existing = await this.keywords.get(id)
       if (!existing) {
         throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
       }
 
+      // キーワード自体を削除
       await this.keywords.delete(id)
+
+      // 関連するブックマークからキーワード ID を除去
+      // keywordIds はインデックスされているので高速にフィルタリング可能
+      await this.bookmarks
+        .where('keywordIds')
+        .equals(id)
+        .modify((bookmark) => {
+          bookmark.keywordIds = bookmark.keywordIds.filter((kId) => kId !== id)
+        })
     })
   }
 }

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -88,6 +88,21 @@ export class BookmarkDatabase extends Dexie {
       await this.keywords.update(id, { name: trimmedName })
     })
   }
+
+  /**
+   * キーワードを削除する
+   */
+  async deleteKeyword(id: KeywordId): Promise<void> {
+    return await this.transaction('rw', this.keywords, async () => {
+      // 存在確認
+      const existing = await this.keywords.get(id)
+      if (!existing) {
+        throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
+      }
+
+      await this.keywords.delete(id)
+    })
+  }
 }
 
 export const db = new BookmarkDatabase()


### PR DESCRIPTION
Issue #407 に対する実装です。

### 変更内容
- `extension/src/lib/idb.ts` に `deleteKeyword(id)` を実装。
- ID の存在確認と適切なエラーハンドリングを含む削除ロジックを構築。
- `extension/src/lib/idb.test.ts` にて TDD による検証（正常系・異常系）を完了。

Closes #407