### PR TITLE
[Extension] ブックマークの追加と取得の実装

### DIFF
--- a/extension/src/lib/bookmark-idb.test.ts
+++ b/extension/src/lib/bookmark-idb.test.ts
@@ -5,6 +5,7 @@ import {
   MOCK_BOOKMARK_ENTITY_1,
   MOCK_BOOKMARK_ENTITY_2,
   VALID_URLS,
+  MOCK_BOOKMARK_TITLE_PREFIX,
 } from '@shared/test/fixtures'
 
 import { db } from './idb'
@@ -30,25 +31,35 @@ describe('BookmarkDatabase - Bookmark Operations', () => {
     })
 
     it('addBookmark が最初のアイテムを追加する際、sortOrder 0 を割り当てること', async () => {
-      const params = { title: 'First', url: VALID_URLS.GOOGLE }
+      const params = { 
+        title: `${MOCK_BOOKMARK_TITLE_PREFIX} First`, 
+        url: VALID_URLS.GOOGLE 
+      }
       const id = await db.addBookmark(params)
 
       const saved = await db.bookmarks.get(id)
       expect(saved?.sortOrder).toBe(0)
+      expect(saved?.title).toBe(params.title)
     })
 
     it('addBookmark が既存アイテムがある場合、最小 sortOrder - 1 を割り当てること', async () => {
       // 既存データ (sortOrder: 0)
       await db.bookmarks.add({ ...MOCK_BOOKMARK_ENTITY_1, sortOrder: 0 })
 
-      const params = { title: 'New Top', url: VALID_URLS.HTTPS }
+      const params = { 
+        title: `${MOCK_BOOKMARK_TITLE_PREFIX} New Top`, 
+        url: VALID_URLS.HTTPS 
+      }
       const id = await db.addBookmark(params)
 
       const saved = await db.bookmarks.get(id)
       expect(saved?.sortOrder).toBe(-1)
 
       // さらに追加
-      const id2 = await db.addBookmark({ title: 'New Top 2', url: VALID_URLS.HTTP })
+      const id2 = await db.addBookmark({ 
+        title: `${MOCK_BOOKMARK_TITLE_PREFIX} New Top 2`, 
+        url: VALID_URLS.HTTP 
+      })
       const saved2 = await db.bookmarks.get(id2)
       expect(saved2?.sortOrder).toBe(-2)
     })

--- a/extension/src/lib/bookmark-idb.test.ts
+++ b/extension/src/lib/bookmark-idb.test.ts
@@ -1,0 +1,61 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import {
+  MOCK_BOOKMARK_ENTITY_1,
+  MOCK_BOOKMARK_ENTITY_2,
+  VALID_URLS,
+} from '@shared/test/fixtures'
+
+import { db } from './idb'
+
+describe('BookmarkDatabase - Bookmark Operations', () => {
+  beforeEach(async () => {
+    await db.bookmarks.clear()
+    await db.keywords.clear()
+  })
+
+  describe('Retrieval and Addition', () => {
+    it('getAllBookmarks が sortOrder 昇順で全ブックマークを返すこと', async () => {
+      // 順序をバラバラに追加
+      const b1 = { ...MOCK_BOOKMARK_ENTITY_1, sortOrder: 10 }
+      const b2 = { ...MOCK_BOOKMARK_ENTITY_2, sortOrder: 5 }
+      await db.bookmarks.bulkAdd([b1, b2])
+
+      const result = await db.getAllBookmarks()
+      
+      expect(result).toHaveLength(2)
+      expect(result[0].id).toBe(b2.id) // sortOrder: 5 が先頭
+      expect(result[1].id).toBe(b1.id) // sortOrder: 10 が次
+    })
+
+    it('addBookmark が最初のアイテムを追加する際、sortOrder 0 を割り当てること', async () => {
+      const params = { title: 'First', url: VALID_URLS.GOOGLE }
+      const id = await db.addBookmark(params)
+
+      const saved = await db.bookmarks.get(id)
+      expect(saved?.sortOrder).toBe(0)
+    })
+
+    it('addBookmark が既存アイテムがある場合、最小 sortOrder - 1 を割り当てること', async () => {
+      // 既存データ (sortOrder: 0)
+      await db.bookmarks.add({ ...MOCK_BOOKMARK_ENTITY_1, sortOrder: 0 })
+
+      const params = { title: 'New Top', url: VALID_URLS.HTTPS }
+      const id = await db.addBookmark(params)
+
+      const saved = await db.bookmarks.get(id)
+      expect(saved?.sortOrder).toBe(-1)
+
+      // さらに追加
+      const id2 = await db.addBookmark({ title: 'New Top 2', url: VALID_URLS.HTTP })
+      const saved2 = await db.bookmarks.get(id2)
+      expect(saved2?.sortOrder).toBe(-2)
+    })
+
+    it('addBookmark が不正な URL の場合、バリデーションエラーを投げること', async () => {
+      const params = { title: 'Invalid', url: 'not-a-url' }
+      await expect(db.addBookmark(params)).rejects.toThrow()
+    })
+  })
+})

--- a/extension/src/lib/idb.test.ts
+++ b/extension/src/lib/idb.test.ts
@@ -1,18 +1,12 @@
 import 'fake-indexeddb/auto'
 import { describe, it, expect, beforeEach } from 'vitest'
 
-import { DB_CONSTANTS, ERROR_MESSAGES } from '@shared/constants'
-import { KeywordIdSchema } from '@shared/schemas/keyword'
-import {
-  MOCK_BOOKMARK_ENTITY_1,
-  MOCK_KEYWORDS,
-  MOCK_IDS,
-  TEST_STRINGS,
-} from '@shared/test/fixtures'
+import { DB_CONSTANTS } from '@shared/constants'
+import { MOCK_BOOKMARK_ENTITY_1 } from '@shared/test/fixtures'
 
 import { db } from './idb'
 
-describe('BookmarkDatabase', () => {
+describe('BookmarkDatabase - Infrastructure', () => {
   beforeEach(async () => {
     // 各テストの前に DB をリセット
     await db.bookmarks.clear()
@@ -35,119 +29,5 @@ describe('BookmarkDatabase', () => {
     await db.bookmarks.add(mockBookmark)
     const result = await db.bookmarks.get(mockBookmark.id)
     expect(result).toEqual(mockBookmark)
-  })
-
-  describe('Keyword Operations (Basic)', () => {
-    it('getAllKeywords が保存されている全キーワードを返すこと', async () => {
-      await db.keywords.bulkAdd(MOCK_KEYWORDS)
-      const result = await db.getAllKeywords()
-      expect(result).toHaveLength(MOCK_KEYWORDS.length)
-      expect(result).toEqual(expect.arrayContaining(MOCK_KEYWORDS))
-    })
-
-    it('addKeyword が新しいキーワードを保存し、その ID を返すこと', async () => {
-      const newKeyword = { name: TEST_STRINGS.NEW_NAME }
-      const id = await db.addKeyword(newKeyword)
-      
-      expect(KeywordIdSchema.safeParse(id).success).toBe(true)
-      
-      const saved = await db.keywords.get(id)
-      expect(saved?.name).toBe(TEST_STRINGS.NEW_NAME)
-      expect(saved?.bookmarkCount).toBe(0)
-    })
-
-    it('既に存在する名前のキーワードを追加しようとした場合、既存の ID を返すこと (冪等性)', async () => {
-      const existing = MOCK_KEYWORDS[0]
-      await db.keywords.add(existing)
-
-      const id = await db.addKeyword({ name: existing.name })
-      
-      expect(id).toBe(existing.id)
-      const count = await db.keywords.count()
-      expect(count).toBe(1)
-    })
-
-    it('不正な名前（空文字等）のキーワード追加を拒否すること', async () => {
-      await expect(db.addKeyword({ name: '' })).rejects.toThrow()
-      await expect(db.addKeyword({ name: '   ' })).rejects.toThrow()
-    })
-  })
-
-  describe('Keyword Operations (Update)', () => {
-    it('updateKeyword が正常に名前を更新すること', async () => {
-      const keyword = MOCK_KEYWORDS[0]
-      await db.keywords.add(keyword)
-
-      await db.updateKeyword(keyword.id, TEST_STRINGS.UPDATED_NAME)
-
-      const updated = await db.keywords.get(keyword.id)
-      expect(updated?.name).toBe(TEST_STRINGS.UPDATED_NAME)
-    })
-
-    it('大文字小文字のみの変更（例: react -> React）が正常に行えること', async () => {
-      const keyword = { id: KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1), name: 'react', bookmarkCount: 0 }
-      await db.keywords.add(keyword)
-
-      await db.updateKeyword(keyword.id, 'React')
-
-      const updated = await db.keywords.get(keyword.id)
-      expect(updated?.name).toBe('React')
-    })
-
-    it('存在しない ID の更新を試みた場合にエラーを投げること', async () => {
-      const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
-      await expect(
-        db.updateKeyword(unknownId, TEST_STRINGS.NEW_NAME),
-      ).rejects.toThrow(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
-    })
-
-    it('他のキーワードと重複する名前への更新を拒否すること', async () => {
-      await db.keywords.bulkAdd([MOCK_KEYWORDS[0], MOCK_KEYWORDS[1]])
-
-      // React を TypeScript という名前に更新しようとする
-      await expect(
-        db.updateKeyword(MOCK_KEYWORDS[0].id, MOCK_KEYWORDS[1].name),
-      ).rejects.toThrow(ERROR_MESSAGES.DUPLICATE_KEYWORD)
-    })
-
-    it('不正な形式の名前への更新を拒否すること', async () => {
-      await db.keywords.add(MOCK_KEYWORDS[0])
-      await expect(db.updateKeyword(MOCK_KEYWORDS[0].id, '')).rejects.toThrow()
-    })
-  })
-
-  describe('Keyword Operations (Delete)', () => {
-    it('deleteKeyword が正常にキーワードを削除すること', async () => {
-      const keyword = MOCK_KEYWORDS[0]
-      await db.keywords.add(keyword)
-
-      await db.deleteKeyword(keyword.id)
-
-      const deleted = await db.keywords.get(keyword.id)
-      expect(deleted).toBeUndefined()
-    })
-
-    it('キーワード削除時に、関連するブックマークからの紐付けも解除されること', async () => {
-      const keyword = MOCK_KEYWORDS[0]
-      const bookmark = {
-        ...MOCK_BOOKMARK_ENTITY_1,
-        keywordIds: [keyword.id],
-      }
-      await db.keywords.add(keyword)
-      await db.bookmarks.add(bookmark)
-
-      // 削除実行
-      await db.deleteKeyword(keyword.id)
-
-      // ブックマークの keywordIds から削除されていることを確認
-      const updatedBookmark = await db.bookmarks.get(bookmark.id)
-      expect(updatedBookmark?.keywordIds).not.toContain(keyword.id)
-      expect(updatedBookmark?.keywordIds).toHaveLength(0)
-    })
-
-    it('存在しない ID の削除を試みた場合にエラーを投げること', async () => {
-      const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
-      await expect(db.deleteKeyword(unknownId)).rejects.toThrow(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
-    })
   })
 })

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -42,7 +42,7 @@ export class BookmarkDatabase extends Dexie {
    */
   async addBookmark(params: CreateBookmarkRequest): Promise<BookmarkId> {
     // バリデーションにプロジェクト標準のスキーマを使用
-    createBookmarkSchema.parse(params)
+    const validated = createBookmarkSchema.parse(params)
 
     return await this.transaction('rw', this.bookmarks, async () => {
       // 現在の最小 sortOrder を取得
@@ -52,8 +52,8 @@ export class BookmarkDatabase extends Dexie {
       const id = BookmarkIdSchema.parse(generateId())
       const newBookmark: BookmarkEntity = {
         id,
-        title: params.title,
-        url: params.url,
+        title: validated.title,
+        url: validated.url,
         sortOrder: minSortOrder - 1,
         keywordIds: [],
       }

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -1,7 +1,12 @@
 import Dexie, { type Table } from 'dexie'
 
 import { DB_CONSTANTS, ERROR_MESSAGES } from '@shared/constants'
-import type { BookmarkEntity, BookmarkId } from '@shared/schemas/bookmark'
+import {
+  type BookmarkEntity,
+  type BookmarkId,
+  bookmarkSchema,
+  BookmarkIdSchema,
+} from '@shared/schemas/bookmark'
 import {
   type KeywordId,
   type KeywordWithCount,
@@ -22,6 +27,39 @@ export class BookmarkDatabase extends Dexie {
 
     // ストアの定義
     this.version(DB_CONSTANTS.IDB_VERSION).stores(DB_CONSTANTS.IDB_SCHEMA)
+  }
+
+  /**
+   * 全てのブックマークを取得する（ソート順）
+   */
+  async getAllBookmarks(): Promise<BookmarkEntity[]> {
+    return await this.bookmarks.orderBy('sortOrder').toArray()
+  }
+
+  /**
+   * ブックマークを追加する
+   */
+  async addBookmark(params: { title: string; url: string }): Promise<BookmarkId> {
+    // バリデーション
+    bookmarkSchema.pick({ title: true, url: true }).parse(params)
+
+    return await this.transaction('rw', this.bookmarks, async () => {
+      // 現在の最小 sortOrder を取得
+      const firstBookmark = await this.bookmarks.orderBy('sortOrder').first()
+      const minSortOrder = firstBookmark ? firstBookmark.sortOrder : 1
+
+      const id = BookmarkIdSchema.parse(generateId())
+      const newBookmark: BookmarkEntity = {
+        id,
+        title: params.title,
+        url: params.url,
+        sortOrder: minSortOrder - 1,
+        keywordIds: [],
+      }
+
+      await this.bookmarks.add(newBookmark)
+      return id
+    })
   }
 
   /**
@@ -104,7 +142,6 @@ export class BookmarkDatabase extends Dexie {
       await this.keywords.delete(id)
 
       // 関連するブックマークからキーワード ID を除去
-      // keywordIds はインデックスされているので高速にフィルタリング可能
       await this.bookmarks
         .where('keywordIds')
         .equals(id)

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -4,8 +4,9 @@ import { DB_CONSTANTS, ERROR_MESSAGES } from '@shared/constants'
 import {
   type BookmarkEntity,
   type BookmarkId,
-  bookmarkSchema,
   BookmarkIdSchema,
+  createBookmarkSchema,
+  type CreateBookmarkRequest,
 } from '@shared/schemas/bookmark'
 import {
   type KeywordId,
@@ -39,9 +40,9 @@ export class BookmarkDatabase extends Dexie {
   /**
    * ブックマークを追加する
    */
-  async addBookmark(params: { title: string; url: string }): Promise<BookmarkId> {
-    // バリデーション
-    bookmarkSchema.pick({ title: true, url: true }).parse(params)
+  async addBookmark(params: CreateBookmarkRequest): Promise<BookmarkId> {
+    // バリデーションにプロジェクト標準のスキーマを使用
+    createBookmarkSchema.parse(params)
 
     return await this.transaction('rw', this.bookmarks, async () => {
       // 現在の最小 sortOrder を取得

--- a/extension/src/lib/keyword-idb.test.ts
+++ b/extension/src/lib/keyword-idb.test.ts
@@ -7,6 +7,7 @@ import {
   MOCK_KEYWORDS,
   MOCK_IDS,
   TEST_STRINGS,
+  MOCK_BOOKMARK_ENTITY_1,
 } from '@shared/test/fixtures'
 
 import { db } from './idb'
@@ -99,6 +100,24 @@ describe('BookmarkDatabase - Keyword Operations', () => {
 
       const deleted = await db.keywords.get(keyword.id)
       expect(deleted).toBeUndefined()
+    })
+
+    it('キーワード削除時に、関連するブックマークからの紐付けも解除されること', async () => {
+      const keyword = MOCK_KEYWORDS[0]
+      const bookmark = {
+        ...MOCK_BOOKMARK_ENTITY_1,
+        keywordIds: [keyword.id],
+      }
+      await db.keywords.add(keyword)
+      await db.bookmarks.add(bookmark)
+
+      // 削除実行
+      await db.deleteKeyword(keyword.id)
+
+      // ブックマークの keywordIds から削除されていることを確認
+      const updatedBookmark = await db.bookmarks.get(bookmark.id)
+      expect(updatedBookmark?.keywordIds).not.toContain(keyword.id)
+      expect(updatedBookmark?.keywordIds).toHaveLength(0)
     })
 
     it('存在しない ID の削除を試みた場合にエラーを投げること', async () => {

--- a/extension/src/lib/keyword-idb.test.ts
+++ b/extension/src/lib/keyword-idb.test.ts
@@ -1,0 +1,109 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { ERROR_MESSAGES } from '@shared/constants'
+import { KeywordIdSchema } from '@shared/schemas/keyword'
+import {
+  MOCK_KEYWORDS,
+  MOCK_IDS,
+  TEST_STRINGS,
+} from '@shared/test/fixtures'
+
+import { db } from './idb'
+
+describe('BookmarkDatabase - Keyword Operations', () => {
+  beforeEach(async () => {
+    await db.keywords.clear()
+    await db.bookmarks.clear()
+  })
+
+  describe('Basic CRUD', () => {
+    it('getAllKeywords が保存されている全キーワードを返すこと', async () => {
+      await db.keywords.bulkAdd(MOCK_KEYWORDS)
+      const result = await db.getAllKeywords()
+      expect(result).toHaveLength(MOCK_KEYWORDS.length)
+      expect(result).toEqual(expect.arrayContaining(MOCK_KEYWORDS))
+    })
+
+    it('addKeyword が新しいキーワードを保存し、その ID を返すこと', async () => {
+      const newKeyword = { name: TEST_STRINGS.NEW_NAME }
+      const id = await db.addKeyword(newKeyword)
+      
+      expect(KeywordIdSchema.safeParse(id).success).toBe(true)
+      
+      const saved = await db.keywords.get(id)
+      expect(saved?.name).toBe(TEST_STRINGS.NEW_NAME)
+      expect(saved?.bookmarkCount).toBe(0)
+    })
+
+    it('既に存在する名前のキーワードを追加しようとした場合、既存の ID を返すこと (冪等性)', async () => {
+      const existing = MOCK_KEYWORDS[0]
+      await db.keywords.add(existing)
+
+      const id = await db.addKeyword({ name: existing.name })
+      
+      expect(id).toBe(existing.id)
+      const count = await db.keywords.count()
+      expect(count).toBe(1)
+    })
+
+    it('不正な名前（空文字等）のキーワード追加を拒否すること', async () => {
+      await expect(db.addKeyword({ name: '' })).rejects.toThrow()
+      await expect(db.addKeyword({ name: '   ' })).rejects.toThrow()
+    })
+  })
+
+  describe('Update', () => {
+    it('updateKeyword が正常に名前を更新すること', async () => {
+      const keyword = MOCK_KEYWORDS[0]
+      await db.keywords.add(keyword)
+
+      await db.updateKeyword(keyword.id, TEST_STRINGS.UPDATED_NAME)
+
+      const updated = await db.keywords.get(keyword.id)
+      expect(updated?.name).toBe(TEST_STRINGS.UPDATED_NAME)
+    })
+
+    it('大文字小文字のみの変更（例: react -> React）が正常に行えること', async () => {
+      const keyword = { id: KeywordIdSchema.parse(MOCK_IDS.KEYWORD_1), name: 'react', bookmarkCount: 0 }
+      await db.keywords.add(keyword)
+
+      await db.updateKeyword(keyword.id, 'React')
+
+      const updated = await db.keywords.get(keyword.id)
+      expect(updated?.name).toBe('React')
+    })
+
+    it('存在しない ID の更新を試みた場合にエラーを投げること', async () => {
+      const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
+      await expect(
+        db.updateKeyword(unknownId, TEST_STRINGS.NEW_NAME),
+      ).rejects.toThrow(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
+    })
+
+    it('他のキーワードと重複する名前への更新を拒否すること', async () => {
+      await db.keywords.bulkAdd([MOCK_KEYWORDS[0], MOCK_KEYWORDS[1]])
+
+      await expect(
+        db.updateKeyword(MOCK_KEYWORDS[0].id, MOCK_KEYWORDS[1].name),
+      ).rejects.toThrow(ERROR_MESSAGES.DUPLICATE_KEYWORD)
+    })
+  })
+
+  describe('Delete', () => {
+    it('deleteKeyword が正常にキーワードを削除すること', async () => {
+      const keyword = MOCK_KEYWORDS[0]
+      await db.keywords.add(keyword)
+
+      await db.deleteKeyword(keyword.id)
+
+      const deleted = await db.keywords.get(keyword.id)
+      expect(deleted).toBeUndefined()
+    })
+
+    it('存在しない ID の削除を試みた場合にエラーを投げること', async () => {
+      const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
+      await expect(db.deleteKeyword(unknownId)).rejects.toThrow(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
+    })
+  })
+})


### PR DESCRIPTION
Issue #409 に対する実装です。

### 変更内容
- `extension/src/lib/idb.ts` に `getAllBookmarks()` および `addBookmark()` を実装。
- 新規追加時に `min(sortOrder) - 1` を割り当てることで、常に先頭に表示されるロジックを導入。
- 肥大化した `idb.test.ts` を `bookmark-idb.test.ts` と `keyword-idb.test.ts` に分割し、視認性とメンテナンス性を向上。
- `extension/src/lib/bookmark-idb.test.ts` にて TDD による検証を完了。

Closes #409