### PR TITLE
[Extension] ブックマークの削除実装

### DIFF
--- a/extension/src/lib/bookmark-idb.test.ts
+++ b/extension/src/lib/bookmark-idb.test.ts
@@ -131,4 +131,28 @@ describe('BookmarkDatabase - Bookmark Operations', () => {
       },
     )
   })
+
+  describe('Delete', () => {
+    it('deleteBookmark が正常にブックマークを削除すること', async () => {
+      const bookmark = MOCK_BOOKMARK_ENTITY_1
+      await db.bookmarks.add(bookmark)
+
+      await db.deleteBookmark(bookmark.id)
+
+      const deleted = await db.bookmarks.get(bookmark.id)
+      expect(deleted).toBeUndefined()
+    })
+
+    it('存在しない ID の削除を試みた場合にエラーを投げること', async () => {
+      const unknownId = BookmarkIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
+      await expect(db.deleteBookmark(unknownId)).rejects.toThrow(
+        ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+      )
+    })
+
+    it('不正な形式の ID での削除を試みた場合にバリデーションエラーを投げること', async () => {
+      const invalidId = TEST_STRINGS.INVALID_ID as unknown as import('@shared/schemas/bookmark').BookmarkId
+      await expect(db.deleteBookmark(invalidId)).rejects.toThrow()
+    })
+  })
 })

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -82,6 +82,17 @@ export class BookmarkDatabase extends Dexie {
   }
 
   /**
+   * ブックマークを削除する
+   */
+  async deleteBookmark(id: BookmarkId): Promise<void> {
+    const validatedId = BookmarkIdSchema.parse(id)
+    const deletedCount = await this.bookmarks.where('id').equals(validatedId).delete()
+    if (deletedCount === 0) {
+      throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+    }
+  }
+
+  /**
    * 全てのキーワードを取得する
    */
   async getAllKeywords(): Promise<KeywordWithCount[]> {

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -12,6 +12,7 @@ export const TEST_STRINGS = {
   NEW_NAME: 'New Name',
   PRE_TRIMMED_NAME: '   TRIMMED NAME    ',
   TRIMMED_NAME: 'TRIMMED NAME',
+  INVALID_ID: 'not-a-uuid',
 } as const
 
 // UUID v7 形式のモック ID (時間順ソート可能性を維持)


### PR DESCRIPTION
Issue #416 に対する実装です。

### 変更内容
- `extension/src/lib/idb.ts` に `deleteBookmark(id)` を実装。
- ID の存在確認と適切なエラーハンドリングを含む削除ロジックを構築。
- `extension/src/lib/bookmark-idb.test.ts` にて TDD による検証（正常系・異常系）を完了。

Closes #416