### PR TITLE
[Extension] キーワードの紐付け (attachKeyword) の実装

### DIFF
--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -95,6 +95,38 @@ export class BookmarkDatabase extends Dexie {
   }
 
   /**
+   * ブックマークにキーワードを紐付ける
+   */
+  async attachKeyword(bookmarkId: BookmarkId, keywordId: KeywordId): Promise<void> {
+    // ID のバリデーション
+    const vBookmarkId = BookmarkIdSchema.parse(bookmarkId)
+    const vKeywordId = KeywordIdSchema.parse(keywordId)
+
+    return await this.transaction('rw', [this.bookmarks, this.keywords], async () => {
+      // 存在確認
+      const bookmark = await this.bookmarks.get(vBookmarkId)
+      if (!bookmark) {
+        throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+      }
+
+      const keyword = await this.keywords.get(vKeywordId)
+      if (!keyword) {
+        throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
+      }
+
+      // 既に紐付けられているか確認
+      if (bookmark.keywordIds.includes(vKeywordId)) {
+        return
+      }
+
+      // 紐付け追加
+      await this.bookmarks.update(vBookmarkId, {
+        keywordIds: [...bookmark.keywordIds, vKeywordId],
+      })
+    })
+  }
+
+  /**
    * 全てのキーワードを取得する
    */
   async getAllKeywords(): Promise<KeywordWithCount[]> {

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -123,6 +123,11 @@ export class BookmarkDatabase extends Dexie {
       await this.bookmarks.update(vBookmarkId, {
         keywordIds: [...bookmark.keywordIds, vKeywordId],
       })
+
+      // キーワード側の統計情報を更新 (カウントアップ)
+      await this.keywords.update(vKeywordId, {
+        bookmarkCount: keyword.bookmarkCount + 1,
+      })
     })
   }
 

--- a/extension/src/lib/relation-idb.test.ts
+++ b/extension/src/lib/relation-idb.test.ts
@@ -1,0 +1,74 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { ERROR_MESSAGES } from '@shared/constants'
+import { type BookmarkId, BookmarkIdSchema } from '@shared/schemas/bookmark'
+import { type KeywordId, KeywordIdSchema } from '@shared/schemas/keyword'
+import {
+  MOCK_BOOKMARK_ENTITY_1,
+  MOCK_KEYWORDS,
+  MOCK_IDS,
+  TEST_STRINGS,
+} from '@shared/test/fixtures'
+
+import { db } from './idb'
+
+describe('BookmarkDatabase - Relation Operations', () => {
+  beforeEach(async () => {
+    await db.bookmarks.clear()
+    await db.keywords.clear()
+  })
+
+  describe('attachKeyword', () => {
+    it('ブックマークにキーワードを正しく紐付けられること', async () => {
+      const bookmark = MOCK_BOOKMARK_ENTITY_1
+      const keyword = MOCK_KEYWORDS[0]
+      await db.bookmarks.add(bookmark)
+      await db.keywords.add(keyword)
+
+      await db.attachKeyword(bookmark.id, keyword.id)
+
+      const updated = await db.bookmarks.get(bookmark.id)
+      expect(updated?.keywordIds).toContain(keyword.id)
+    })
+
+    it('既に紐付けられているキーワードを再度追加しても重複しないこと (冪等性)', async () => {
+      const bookmark = MOCK_BOOKMARK_ENTITY_1
+      const keyword = MOCK_KEYWORDS[0]
+      await db.bookmarks.add({ ...bookmark, keywordIds: [keyword.id] })
+      await db.keywords.add(keyword)
+
+      await db.attachKeyword(bookmark.id, keyword.id)
+
+      const updated = await db.bookmarks.get(bookmark.id)
+      expect(updated?.keywordIds).toHaveLength(1)
+      expect(updated?.keywordIds).toContain(keyword.id)
+    })
+
+    it('存在しないブックマーク ID を指定した場合にエラーを投げること', async () => {
+      const keyword = MOCK_KEYWORDS[0]
+      await db.keywords.add(keyword)
+
+      const unknownId = BookmarkIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
+      await expect(db.attachKeyword(unknownId, keyword.id)).rejects.toThrow(
+        ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+      )
+    })
+
+    it('存在しないキーワード ID を指定した場合にエラーを投げること', async () => {
+      const bookmark = MOCK_BOOKMARK_ENTITY_1
+      await db.bookmarks.add(bookmark)
+
+      const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
+      await expect(db.attachKeyword(bookmark.id, unknownId)).rejects.toThrow(
+        ERROR_MESSAGES.KEYWORD_NOT_FOUND,
+      )
+    })
+
+    it('不正な形式の ID での紐付けを試みた場合にバリデーションエラーを投げること', async () => {
+      const invalidId = TEST_STRINGS.INVALID_ID as unknown as KeywordId
+      const validBookmarkId = MOCK_IDS.BOOKMARK_1 as BookmarkId
+      await expect(db.attachKeyword(validBookmarkId, invalidId)).rejects.toThrow()
+    })
+  })
+})

--- a/extension/src/lib/relation-idb.test.ts
+++ b/extension/src/lib/relation-idb.test.ts
@@ -2,7 +2,7 @@ import 'fake-indexeddb/auto'
 import { describe, it, expect, beforeEach } from 'vitest'
 
 import { ERROR_MESSAGES } from '@shared/constants'
-import { type BookmarkId, BookmarkIdSchema } from '@shared/schemas/bookmark'
+import { BookmarkIdSchema } from '@shared/schemas/bookmark'
 import { type KeywordId, KeywordIdSchema } from '@shared/schemas/keyword'
 import {
   MOCK_BOOKMARK_ENTITY_1,
@@ -20,7 +20,7 @@ describe('BookmarkDatabase - Relation Operations', () => {
   })
 
   describe('attachKeyword', () => {
-    it('ブックマークにキーワードを正しく紐付けられること', async () => {
+    it('ブックマークにキーワードを正しく紐付け、カウントを増やすこと', async () => {
       const bookmark = MOCK_BOOKMARK_ENTITY_1
       const keyword = MOCK_KEYWORDS[0]
       await db.bookmarks.add(bookmark)
@@ -28,21 +28,29 @@ describe('BookmarkDatabase - Relation Operations', () => {
 
       await db.attachKeyword(bookmark.id, keyword.id)
 
-      const updated = await db.bookmarks.get(bookmark.id)
-      expect(updated?.keywordIds).toContain(keyword.id)
+      // ブックマーク側の検証
+      const updatedBookmark = await db.bookmarks.get(bookmark.id)
+      expect(updatedBookmark?.keywordIds).toContain(keyword.id)
+
+      // キーワード側の検証 (カウントアップ)
+      const updatedKeyword = await db.keywords.get(keyword.id)
+      expect(updatedKeyword?.bookmarkCount).toBe(keyword.bookmarkCount + 1)
     })
 
-    it('既に紐付けられているキーワードを再度追加しても重複しないこと (冪等性)', async () => {
+    it('既に紐付けられているキーワードを再度追加しても重複せず、カウントも増えないこと (冪等性)', async () => {
       const bookmark = MOCK_BOOKMARK_ENTITY_1
       const keyword = MOCK_KEYWORDS[0]
+      // 初期状態で紐付け済み（カウントも1に設定）
       await db.bookmarks.add({ ...bookmark, keywordIds: [keyword.id] })
-      await db.keywords.add(keyword)
+      await db.keywords.add({ ...keyword, bookmarkCount: 1 })
 
       await db.attachKeyword(bookmark.id, keyword.id)
 
-      const updated = await db.bookmarks.get(bookmark.id)
-      expect(updated?.keywordIds).toHaveLength(1)
-      expect(updated?.keywordIds).toContain(keyword.id)
+      const updatedBookmark = await db.bookmarks.get(bookmark.id)
+      expect(updatedBookmark?.keywordIds).toHaveLength(1)
+
+      const updatedKeyword = await db.keywords.get(keyword.id)
+      expect(updatedKeyword?.bookmarkCount).toBe(1) // 増えていないこと
     })
 
     it('存在しないブックマーク ID を指定した場合にエラーを投げること', async () => {
@@ -67,7 +75,7 @@ describe('BookmarkDatabase - Relation Operations', () => {
 
     it('不正な形式の ID での紐付けを試みた場合にバリデーションエラーを投げること', async () => {
       const invalidId = TEST_STRINGS.INVALID_ID as unknown as KeywordId
-      const validBookmarkId = MOCK_IDS.BOOKMARK_1 as BookmarkId
+      const validBookmarkId = BookmarkIdSchema.parse(MOCK_IDS.BOOKMARK_1)
       await expect(db.attachKeyword(validBookmarkId, invalidId)).rejects.toThrow()
     })
   })


### PR DESCRIPTION
Issue #420 に対する実装です。

### 変更内容
- `extension/src/lib/idb.ts` に `attachKeyword(bookmarkId, keywordId)` を実装。
- ブックマークとキーワード双方の存在確認、および ID バリデーションを含む安全な紐付け処理を構築。
- 新しく `extension/src/lib/relation-idb.test.ts` を作成し、リレーション関連のテストを独立。
- TDD により、正常な紐付け、冪等性（重複追加の防止）、および存在しない ID 指定時のエラーハンドリングを検証済み。

Closes #420