### PR TITLE
[Extension] キーワードの紐付け解除 (detachKeyword) の実装

### DIFF
--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -132,6 +132,43 @@ export class BookmarkDatabase extends Dexie {
   }
 
   /**
+   * ブックマークからキーワードを解除する
+   */
+  async detachKeyword(bookmarkId: BookmarkId, keywordId: KeywordId): Promise<void> {
+    // ID のバリデーション
+    const vBookmarkId = BookmarkIdSchema.parse(bookmarkId)
+    const vKeywordId = KeywordIdSchema.parse(keywordId)
+
+    return await this.transaction('rw', [this.bookmarks, this.keywords], async () => {
+      // 存在確認
+      const bookmark = await this.bookmarks.get(vBookmarkId)
+      if (!bookmark) {
+        throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+      }
+
+      const keyword = await this.keywords.get(vKeywordId)
+      if (!keyword) {
+        throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
+      }
+
+      // 紐付けられていない場合は何もしない
+      if (!bookmark.keywordIds.includes(vKeywordId)) {
+        return
+      }
+
+      // 紐付け解除
+      await this.bookmarks.update(vBookmarkId, {
+        keywordIds: bookmark.keywordIds.filter((id) => id !== vKeywordId),
+      })
+
+      // キーワード側の統計情報を更新 (カウントダウン)
+      await this.keywords.update(vKeywordId, {
+        bookmarkCount: Math.max(0, keyword.bookmarkCount - 1),
+      })
+    })
+  }
+
+  /**
    * 全てのキーワードを取得する
    */
   async getAllKeywords(): Promise<KeywordWithCount[]> {

--- a/extension/src/lib/relation-idb.test.ts
+++ b/extension/src/lib/relation-idb.test.ts
@@ -1,8 +1,9 @@
 import 'fake-indexeddb/auto'
 import { describe, it, expect, beforeEach } from 'vitest'
+import { ZodError } from 'zod'
 
 import { ERROR_MESSAGES } from '@shared/constants'
-import { BookmarkIdSchema } from '@shared/schemas/bookmark'
+import { BookmarkIdSchema, type BookmarkId } from '@shared/schemas/bookmark'
 import { type KeywordId, KeywordIdSchema } from '@shared/schemas/keyword'
 import {
   MOCK_BOOKMARK_ENTITY_1,
@@ -76,7 +77,80 @@ describe('BookmarkDatabase - Relation Operations', () => {
     it('不正な形式の ID での紐付けを試みた場合にバリデーションエラーを投げること', async () => {
       const invalidId = TEST_STRINGS.INVALID_ID as unknown as KeywordId
       const validBookmarkId = BookmarkIdSchema.parse(MOCK_IDS.BOOKMARK_1)
-      await expect(db.attachKeyword(validBookmarkId, invalidId)).rejects.toThrow()
+      await expect(
+        db.attachKeyword(validBookmarkId, invalidId),
+      ).rejects.toThrow(ZodError)
+    })
+  })
+
+  describe('detachKeyword', () => {
+    it('ブックマークからキーワードを解除し、カウントを減らすこと', async () => {
+      const keyword = MOCK_KEYWORDS[0]
+      const bookmark = { ...MOCK_BOOKMARK_ENTITY_1, keywordIds: [keyword.id] }
+      await db.bookmarks.add(bookmark)
+      await db.keywords.add({ ...keyword, bookmarkCount: 1 })
+
+      await db.detachKeyword(bookmark.id, keyword.id)
+
+      // ブックマーク側の検証
+      const updatedBookmark = await db.bookmarks.get(bookmark.id)
+      expect(updatedBookmark?.keywordIds).not.toContain(keyword.id)
+
+      // キーワード側の検証 (カウントダウン)
+      const updatedKeyword = await db.keywords.get(keyword.id)
+      expect(updatedKeyword?.bookmarkCount).toBe(0)
+    })
+
+    it('紐付けられていないキーワードを解除してもエラーにならず、カウントも変わらないこと (冪等性)', async () => {
+      const bookmark = MOCK_BOOKMARK_ENTITY_1
+      const keyword = MOCK_KEYWORDS[0]
+      await db.bookmarks.add(bookmark)
+      await db.keywords.add({ ...keyword, bookmarkCount: 0 })
+
+      await db.detachKeyword(bookmark.id, keyword.id)
+
+      const updatedBookmark = await db.bookmarks.get(bookmark.id)
+      expect(updatedBookmark?.keywordIds).toHaveLength(0)
+
+      const updatedKeyword = await db.keywords.get(keyword.id)
+      expect(updatedKeyword?.bookmarkCount).toBe(0)
+    })
+
+    it('存在しないブックマーク ID を指定した場合にエラーを投げること', async () => {
+      const keyword = MOCK_KEYWORDS[0]
+      await db.keywords.add(keyword)
+
+      const unknownId = BookmarkIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
+      await expect(db.detachKeyword(unknownId, keyword.id)).rejects.toThrow(
+        ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+      )
+    })
+
+    it('存在しないキーワード ID を指定した場合にエラーを投げること', async () => {
+      const bookmark = MOCK_BOOKMARK_ENTITY_1
+      await db.bookmarks.add(bookmark)
+
+      const unknownId = KeywordIdSchema.parse(MOCK_IDS.UNKNOWN_ID)
+      await expect(db.detachKeyword(bookmark.id, unknownId)).rejects.toThrow(
+        ERROR_MESSAGES.KEYWORD_NOT_FOUND,
+      )
+    })
+
+    it('不正な形式の ブックマークID での解除を試みた場合にバリデーションエラーを投げること', async () => {
+      const keyword = MOCK_KEYWORDS[0]
+      const invalidId = TEST_STRINGS.INVALID_ID as unknown as BookmarkId
+
+      await expect(db.detachKeyword(invalidId, keyword.id)).rejects.toThrow(
+        ZodError,
+      )
+    })
+
+    it('不正な形式の キーワードID での解除を試みた場合にバリデーションエラーを投げること', async () => {
+      const invalidId = TEST_STRINGS.INVALID_ID as unknown as KeywordId
+      const validBookmarkId = BookmarkIdSchema.parse(MOCK_IDS.BOOKMARK_1)
+      await expect(
+        db.detachKeyword(validBookmarkId, invalidId),
+      ).rejects.toThrow(ZodError)
     })
   })
 })


### PR DESCRIPTION
Issue #422 に対する実装です。

### 変更内容
- `extension/src/lib/idb.ts` に `detachKeyword(bookmarkId, keywordId)` を実装。
- キーワード解除時に、該当キーワードの `bookmarkCount` をデクリメント（減算）してデータ整合性を維持。
- `relation-idb.test.ts` を更新し、`ZodError` を用いた厳密なバリデーションエラーの検証を含む、正常・異常系のテストケースを追加。

Closes #422