### PR TITLE
[Extension] ブックマーク削除時のキーワード統計更新の実装

### DIFF
--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -114,14 +114,37 @@ export class BookmarkDatabase extends Dexie {
   }
 
   /**
-   * ブックマークを削除する
+   * ブックマークを削除する。関連するキーワードの統計情報も更新する。
    */
   async deleteBookmark(id: BookmarkId): Promise<void> {
     const validatedId = BookmarkIdSchema.parse(id)
-    const deletedCount = await this.bookmarks.where('id').equals(validatedId).delete()
-    if (deletedCount === 0) {
-      throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
-    }
+
+    return await this.transaction('rw', [this.bookmarks, this.keywords], async () => {
+      // 存在確認
+      const bookmark = await this.bookmarks.get(validatedId)
+      if (!bookmark) {
+        throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+      }
+
+      // ブックマークを削除
+      await this.bookmarks.delete(validatedId)
+
+      // 紐付いていた各キーワードの統計情報を更新 (カウントダウン)
+      if (bookmark.keywordIds.length > 0) {
+        // キーワードを一括取得
+        const associatedKeywords = await this.keywords.bulkGet(bookmark.keywordIds)
+        
+        await Promise.all(
+          associatedKeywords.map(async (kw) => {
+            if (kw) {
+              await this.keywords.update(kw.id, {
+                bookmarkCount: Math.max(0, kw.bookmarkCount - 1),
+              })
+            }
+          })
+        )
+      }
+    })
   }
 
   /**

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -131,18 +131,12 @@ export class BookmarkDatabase extends Dexie {
 
       // 紐付いていた各キーワードの統計情報を更新 (カウントダウン)
       if (bookmark.keywordIds.length > 0) {
-        // キーワードを一括取得
-        const associatedKeywords = await this.keywords.bulkGet(bookmark.keywordIds)
-        
-        await Promise.all(
-          associatedKeywords.map(async (kw) => {
-            if (kw) {
-              await this.keywords.update(kw.id, {
-                bookmarkCount: Math.max(0, kw.bookmarkCount - 1),
-              })
-            }
+        await this.keywords
+          .where('id')
+          .anyOf(bookmark.keywordIds)
+          .modify((kw) => {
+            kw.bookmarkCount = Math.max(0, kw.bookmarkCount - 1)
           })
-        )
       }
     })
   }

--- a/extension/src/lib/relation-idb.test.ts
+++ b/extension/src/lib/relation-idb.test.ts
@@ -209,4 +209,31 @@ describe('BookmarkDatabase - Relation Operations', () => {
       expect(result[0].keywords).toEqual([])
     })
   })
+
+  describe('Cascade Counter Updates', () => {
+    it('ブックマークを削除した際、紐付いていた全キーワードのカウントが減ること', async () => {
+      const kw1 = MOCK_KEYWORDS[0]
+      const kw2 = MOCK_KEYWORDS[1]
+      // 初期状態でカウント1ずつ
+      await db.keywords.bulkAdd([
+        { ...kw1, bookmarkCount: 1 },
+        { ...kw2, bookmarkCount: 1 },
+      ])
+
+      const bookmark = {
+        ...MOCK_BOOKMARK_ENTITY_1,
+        keywordIds: [kw1.id, kw2.id],
+      }
+      await db.bookmarks.add(bookmark)
+
+      // 削除実行
+      await db.deleteBookmark(bookmark.id)
+
+      // キーワードのカウントが減っていることを検証
+      const updatedKw1 = await db.keywords.get(kw1.id)
+      const updatedKw2 = await db.keywords.get(kw2.id)
+      expect(updatedKw1?.bookmarkCount).toBe(0)
+      expect(updatedKw2?.bookmarkCount).toBe(0)
+    })
+  })
 })


### PR DESCRIPTION
Issue #427 に対する実装です。

### 変更内容
- `extension/src/lib/idb.ts` の `deleteBookmark` を修正し、削除されるブックマークに紐付いていた全キーワードの `bookmarkCount` をデクリメント（減算）するロジックを追加。
- トランザクションを使用して、ブックマークの削除と統計情報の更新が原子的に行われることを保証。
- `relation-idb.test.ts` に `Cascade Counter Updates` テストを追加し、削除後にカウントが正しく減っていることを検証。

Closes #427