### PR TITLE
[Extension] ブックマークの並び替え (sortOrder) 実装

### DIFF
--- a/extension/src/lib/bookmark-reorder-idb.test.ts
+++ b/extension/src/lib/bookmark-reorder-idb.test.ts
@@ -1,0 +1,61 @@
+import 'fake-indexeddb/auto'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ZodError } from 'zod'
+
+import { ERROR_MESSAGES } from '@shared/constants'
+import { type BookmarkId, BookmarkIdSchema } from '@shared/schemas/bookmark'
+import {
+  MOCK_BOOKMARK_ENTITY_1,
+  MOCK_BOOKMARK_ENTITY_2,
+  MOCK_BOOKMARK_ENTITY_3,
+  MOCK_IDS,
+} from '@shared/test/fixtures'
+
+import { db } from './idb'
+
+describe('BookmarkDatabase - Bookmark Reorder Operations', () => {
+  beforeEach(async () => {
+    await db.bookmarks.clear()
+    await db.keywords.clear()
+  })
+
+  describe('reorderBookmarks', () => {
+    it('渡された ID リストの順序に従って sortOrder が更新されること', async () => {
+      // 3つのブックマークを用意（初期順序: b1, b2, b3）
+      const b1 = { ...MOCK_BOOKMARK_ENTITY_1, sortOrder: 10 }
+      const b2 = { ...MOCK_BOOKMARK_ENTITY_2, sortOrder: 20 }
+      const b3 = { ...MOCK_BOOKMARK_ENTITY_3, sortOrder: 30 }
+      await db.bookmarks.bulkAdd([b1, b2, b3])
+
+      // 順序を入れ替える (b3, b1, b2)
+      const newOrder = [b3.id, b1.id, b2.id]
+      
+      await db.reorderBookmarks(newOrder)
+
+      const result = await db.getAllBookmarks()
+      expect(result).toHaveLength(3)
+      expect(result[0].id).toBe(b3.id)
+      expect(result[1].id).toBe(b1.id)
+      expect(result[2].id).toBe(b2.id)
+      
+      // sortOrder が連続した値 (0, 1, 2) に更新されていることを確認
+      expect(result[0].sortOrder).toBe(0)
+      expect(result[1].sortOrder).toBe(1)
+      expect(result[2].sortOrder).toBe(2)
+    })
+
+    it('重複した ID を含むリストを拒否すること (ZodError)', async () => {
+      const ids = [MOCK_IDS.BOOKMARK_1, MOCK_IDS.BOOKMARK_1] as unknown as BookmarkId[]
+      await expect(db.reorderBookmarks(ids)).rejects.toThrow(ZodError)
+    })
+
+    it('存在しない ID を含むリストを渡した場合にエラーを投げること', async () => {
+      await db.bookmarks.add(MOCK_BOOKMARK_ENTITY_1)
+      const ids = [MOCK_BOOKMARK_ENTITY_1.id, BookmarkIdSchema.parse(MOCK_IDS.UNKNOWN_ID)]
+      
+      await expect(db.reorderBookmarks(ids)).rejects.toThrow(
+        ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+      )
+    })
+  })
+})

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -150,22 +150,29 @@ export class BookmarkDatabase extends Dexie {
     const validatedIds = reorderBookmarksSchema.parse({ ids }).ids
 
     return await this.transaction('rw', this.bookmarks, async () => {
-      // 全ての ID が存在するか、より効率的に確認するために件数をチェック
+      // 全ての ID が存在するか、件数をチェック
       const existingCount = await this.bookmarks
         .where('id')
         .anyOf(validatedIds)
         .count()
-      
+
       if (existingCount !== validatedIds.length) {
         throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
       }
 
-      // 順序を更新
-      await Promise.all(
-        validatedIds.map((id, index) =>
-          this.bookmarks.update(id, { sortOrder: index })
-        )
-      )
+      // ID と新しい順序のマッピングを作成
+      const orderMap = new Map(validatedIds.map((id, index) => [id, index]))
+
+      // 順序を一括更新 (modify を使用して効率化)
+      await this.bookmarks
+        .where('id')
+        .anyOf(validatedIds)
+        .modify((bookmark) => {
+          const newOrder = orderMap.get(bookmark.id)
+          if (newOrder !== undefined) {
+            bookmark.sortOrder = newOrder
+          }
+        })
     })
   }
 

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -10,6 +10,7 @@ import {
   type CreateBookmarkRequest,
   updateBookmarkSchema,
   type UpdateBookmarkRequest,
+  reorderBookmarksSchema,
 } from '@shared/schemas/bookmark'
 import {
   type KeywordId,
@@ -138,6 +139,33 @@ export class BookmarkDatabase extends Dexie {
             kw.bookmarkCount = Math.max(0, kw.bookmarkCount - 1)
           })
       }
+    })
+  }
+
+  /**
+   * ブックマークの順序を一括更新する
+   */
+  async reorderBookmarks(ids: BookmarkId[]): Promise<void> {
+    // バリデーション
+    const validatedIds = reorderBookmarksSchema.parse({ ids }).ids
+
+    return await this.transaction('rw', this.bookmarks, async () => {
+      // 全ての ID が存在するか、より効率的に確認するために件数をチェック
+      const existingCount = await this.bookmarks
+        .where('id')
+        .anyOf(validatedIds)
+        .count()
+      
+      if (existingCount !== validatedIds.length) {
+        throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+      }
+
+      // 順序を更新
+      await Promise.all(
+        validatedIds.map((id, index) =>
+          this.bookmarks.update(id, { sortOrder: index })
+        )
+      )
     })
   }
 


### PR DESCRIPTION
Issue #429 に対する実装です。

### 変更内容
- `extension/src/lib/idb.ts` に `reorderBookmarks(ids)` を実装。渡された ID リストの順序に基づいて `sortOrder` を一括更新します。
- トランザクションを使用して、順序更新の原子性を保証。
- 引数の ID リストに対して `reorderBookmarksSchema` を用いた厳格なバリデーション（重複チェック等）を適用。
- `extension/src/lib/bookmark-reorder-idb.test.ts` を新設し、正常な並び替えと異常系（重複、存在しない ID）を TDD で検証済み。

Closes #429