### PR TITLE
[Shared] キーワード一覧取得 (GET_KEYWORDS) のスキーマ定義

### DIFF
--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { z } from 'zod'
+import { z, ZodError } from 'zod'
 
 import { API_ACTIONS } from '../constants'
 import {
@@ -7,7 +7,10 @@ import {
   ApiErrorSchema,
   ApiActionSchema,
   baseMessageRequestSchema,
+  getKeywordsRequestSchema,
+  getKeywordsResponseSchema,
 } from './api'
+import { MOCK_KEYWORDS } from '../test/fixtures'
 
 describe('API Schemas', () => {
   describe('createApiSuccessSchema', () => {
@@ -37,7 +40,7 @@ describe('API Schemas', () => {
     })
 
     it('未定義のアクションを拒否すること', () => {
-      expect(() => ApiActionSchema.parse('INVALID_ACTION')).toThrow()
+      expect(() => ApiActionSchema.parse('INVALID_ACTION')).toThrow(ZodError)
     })
   })
 
@@ -49,15 +52,35 @@ describe('API Schemas', () => {
       }
       expect(baseMessageRequestSchema.parse(validRequest)).toEqual(validRequest)
     })
+  })
 
-    it('payload がなくても受け入れること', () => {
+  describe('getKeywordsRequestSchema', () => {
+    it('正しい GET_KEYWORDS リクエストを受け入れること', () => {
       const validRequest = { action: API_ACTIONS.GET_KEYWORDS }
-      expect(baseMessageRequestSchema.parse(validRequest)).toEqual(validRequest)
+      expect(getKeywordsRequestSchema.parse(validRequest)).toEqual(validRequest)
     })
 
-    it('不正なアクションを含む構造を拒否すること', () => {
-      const invalidRequest = { action: 'UNKNOWN' }
-      expect(() => baseMessageRequestSchema.parse(invalidRequest)).toThrow()
+    it('不正なアクションを持つリクエストを拒否すること', () => {
+      const invalidRequest = { action: API_ACTIONS.GET_BOOKMARKS }
+      expect(() => getKeywordsRequestSchema.parse(invalidRequest)).toThrow(ZodError)
+    })
+  })
+
+  describe('getKeywordsResponseSchema', () => {
+    it('キーワード一覧を含むレスポンスを検証できること', () => {
+      const validResponse = {
+        success: true,
+        data: { keywords: MOCK_KEYWORDS },
+      }
+      expect(getKeywordsResponseSchema.parse(validResponse)).toEqual(validResponse)
+    })
+
+    it('不正なデータ（キーワード欠落など）を拒否すること', () => {
+      const invalidResponse = {
+        success: true,
+        data: { keywords: [{ id: 'invalid' }] },
+      }
+      expect(() => getKeywordsResponseSchema.parse(invalidResponse)).toThrow(ZodError)
     })
   })
 })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { API_ACTIONS } from '../constants'
+import { keywordsResponseSchema } from './keyword'
 
 /**
  * API 成功時の共通レスポンス形式
@@ -49,3 +50,19 @@ export const baseMessageRequestSchema = z.object({
 })
 
 export type BaseMessageRequest = z.infer<typeof baseMessageRequestSchema>
+
+/**
+ * キーワード一覧取得 (GET_KEYWORDS)
+ */
+export const getKeywordsRequestSchema = baseMessageRequestSchema.extend({
+  action: z.literal(API_ACTIONS.GET_KEYWORDS),
+  payload: z.undefined().optional(),
+})
+
+export type GetKeywordsRequest = z.infer<typeof getKeywordsRequestSchema>
+
+export const getKeywordsResponseSchema = createApiResponseSchema(
+  keywordsResponseSchema,
+)
+
+export type GetKeywordsResponse = z.infer<typeof getKeywordsResponseSchema>


### PR DESCRIPTION
Issue #433 に対する実装です。

### 変更内容
- `shared/schemas/api.ts` に `getKeywordsRequestSchema` および `getKeywordsResponseSchema` を追加。
- `shared/schemas/api.test.ts` を更新し、`ZodError` を用いた厳密な例外検証を含むバリデーションテストを実装。

Closes #433