### PR TITLE
[Shared] キーワード追加 (ADD_KEYWORD) のスキーマ定義

### DIFF
--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -9,8 +9,10 @@ import {
   baseMessageRequestSchema,
   getKeywordsRequestSchema,
   getKeywordsResponseSchema,
+  addKeywordRequestSchema,
+  addKeywordResponseSchema,
 } from './api'
-import { MOCK_KEYWORDS } from '../test/fixtures'
+import { MOCK_KEYWORDS, TEST_STRINGS } from '../test/fixtures'
 
 describe('API Schemas', () => {
   describe('createApiSuccessSchema', () => {
@@ -62,7 +64,9 @@ describe('API Schemas', () => {
 
     it('不正なアクションを持つリクエストを拒否すること', () => {
       const invalidRequest = { action: API_ACTIONS.GET_BOOKMARKS }
-      expect(() => getKeywordsRequestSchema.parse(invalidRequest)).toThrow(ZodError)
+      expect(() => getKeywordsRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
     })
   })
 
@@ -72,15 +76,42 @@ describe('API Schemas', () => {
         success: true,
         data: { keywords: MOCK_KEYWORDS },
       }
-      expect(getKeywordsResponseSchema.parse(validResponse)).toEqual(validResponse)
+      expect(getKeywordsResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+  })
+
+  describe('addKeywordRequestSchema', () => {
+    it('正しい ADD_KEYWORD リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.ADD_KEYWORD,
+        payload: { name: TEST_STRINGS.NEW_NAME },
+      }
+      expect(addKeywordRequestSchema.parse(validRequest)).toEqual(validRequest)
     })
 
-    it('不正なデータ（キーワード欠落など）を拒否すること', () => {
-      const invalidResponse = {
-        success: true,
-        data: { keywords: [{ id: 'invalid' }] },
+    it('payload が不正（名前が空）なリクエストを拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.ADD_KEYWORD,
+        payload: { name: '' },
       }
-      expect(() => getKeywordsResponseSchema.parse(invalidResponse)).toThrow(ZodError)
+      expect(() => addKeywordRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+  })
+
+  describe('addKeywordResponseSchema', () => {
+    it('追加されたキーワードを含むレスポンスを検証できること', () => {
+      const keyword = { id: MOCK_KEYWORDS[0].id, name: MOCK_KEYWORDS[0].name }
+      const validResponse = {
+        success: true,
+        data: { keyword },
+      }
+      expect(addKeywordResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
     })
   })
 })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod'
 
 import { API_ACTIONS } from '../constants'
-import { keywordsResponseSchema } from './keyword'
+import {
+  createKeywordRequestSchema,
+  keywordResponseSchema,
+  keywordsResponseSchema,
+} from './keyword'
 
 /**
  * API 成功時の共通レスポンス形式
@@ -66,3 +70,19 @@ export const getKeywordsResponseSchema = createApiResponseSchema(
 )
 
 export type GetKeywordsResponse = z.infer<typeof getKeywordsResponseSchema>
+
+/**
+ * キーワード追加 (ADD_KEYWORD)
+ */
+export const addKeywordRequestSchema = baseMessageRequestSchema.extend({
+  action: z.literal(API_ACTIONS.ADD_KEYWORD),
+  payload: createKeywordRequestSchema,
+})
+
+export type AddKeywordRequest = z.infer<typeof addKeywordRequestSchema>
+
+export const addKeywordResponseSchema = createApiResponseSchema(
+  keywordResponseSchema,
+)
+
+export type AddKeywordResponse = z.infer<typeof addKeywordResponseSchema>


### PR DESCRIPTION
Issue #435 に対する実装です。

### 変更内容
- `shared/schemas/api.ts` に `addKeywordRequestSchema` および `addKeywordResponseSchema` を追加。
- 既存の `createKeywordRequestSchema` および `keywordResponseSchema` を活用。
- `shared/schemas/api.test.ts` を更新し、正常なリクエスト/レスポンス構造のバリデーション、および不正なペイロード（空文字など）の拒否を TDD で検証済み。

Closes #435