### PR TITLE
[Shared] キーワード更新 (UPDATE_KEYWORD) のスキーマ定義

### DIFF
--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { z, ZodError } from 'zod'
 
-import { API_ACTIONS } from '../constants'
+import { API_ACTIONS, ERROR_MESSAGES } from '../constants'
 import {
   createApiSuccessSchema,
   ApiErrorSchema,
@@ -30,7 +30,10 @@ describe('API Schemas', () => {
     it('エラー構造を検証できること', () => {
       const errorData = {
         success: false,
-        error: { message: 'error', code: 'ERR_001' },
+        error: {
+          message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+          code: TEST_STRINGS.ERROR_CODE,
+        },
       }
       expect(ApiErrorSchema.parse(errorData)).toEqual(errorData)
     })
@@ -131,7 +134,7 @@ describe('API Schemas', () => {
     it('不正な形式の ID を拒否すること', () => {
       const invalidRequest = {
         action: API_ACTIONS.UPDATE_KEYWORD,
-        payload: { id: 'invalid-id', name: 'Valid Name' },
+        payload: { id: TEST_STRINGS.INVALID_ID, name: TEST_STRINGS.NEW_NAME },
       }
       expect(() =>
         updateKeywordMessageRequestSchema.parse(invalidRequest),
@@ -151,9 +154,26 @@ describe('API Schemas', () => {
 
   describe('updateKeywordMessageResponseSchema', () => {
     it('成功時のレスポンスを検証できること', () => {
-      const validResponse = { success: true, data: null }
+      const keyword = { id: MOCK_IDS.KEYWORD_1, name: TEST_STRINGS.UPDATED_NAME }
+      const validResponse = {
+        success: true,
+        data: { keyword },
+      }
       expect(updateKeywordMessageResponseSchema.parse(validResponse)).toEqual(
         validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.KEYWORD_NOT_FOUND,
+          code: TEST_STRINGS.ERROR_CODE,
+        },
+      }
+      expect(updateKeywordMessageResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
       )
     })
   })

--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -11,8 +11,10 @@ import {
   getKeywordsResponseSchema,
   addKeywordRequestSchema,
   addKeywordResponseSchema,
+  updateKeywordMessageRequestSchema,
+  updateKeywordMessageResponseSchema,
 } from './api'
-import { MOCK_KEYWORDS, TEST_STRINGS } from '../test/fixtures'
+import { MOCK_KEYWORDS, MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
 
 describe('API Schemas', () => {
   describe('createApiSuccessSchema', () => {
@@ -110,6 +112,47 @@ describe('API Schemas', () => {
         data: { keyword },
       }
       expect(addKeywordResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+  })
+
+  describe('updateKeywordMessageRequestSchema', () => {
+    it('正しい UPDATE_KEYWORD リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.UPDATE_KEYWORD,
+        payload: { id: MOCK_IDS.KEYWORD_1, name: TEST_STRINGS.UPDATED_NAME },
+      }
+      expect(updateKeywordMessageRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('不正な形式の ID を拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.UPDATE_KEYWORD,
+        payload: { id: 'invalid-id', name: 'Valid Name' },
+      }
+      expect(() =>
+        updateKeywordMessageRequestSchema.parse(invalidRequest),
+      ).toThrow(ZodError)
+    })
+
+    it('名前が空のリクエストを拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.UPDATE_KEYWORD,
+        payload: { id: MOCK_IDS.KEYWORD_1, name: '' },
+      }
+      expect(() =>
+        updateKeywordMessageRequestSchema.parse(invalidRequest),
+      ).toThrow(ZodError)
+    })
+  })
+
+  describe('updateKeywordMessageResponseSchema', () => {
+    it('成功時のレスポンスを検証できること', () => {
+      const validResponse = { success: true, data: null }
+      expect(updateKeywordMessageResponseSchema.parse(validResponse)).toEqual(
         validResponse,
       )
     })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -3,8 +3,10 @@ import { z } from 'zod'
 import { API_ACTIONS } from '../constants'
 import {
   createKeywordRequestSchema,
+  KeywordIdSchema,
   keywordResponseSchema,
   keywordsResponseSchema,
+  updateKeywordRequestSchema,
 } from './keyword'
 
 /**
@@ -86,3 +88,25 @@ export const addKeywordResponseSchema = createApiResponseSchema(
 )
 
 export type AddKeywordResponse = z.infer<typeof addKeywordResponseSchema>
+
+/**
+ * キーワード更新 (UPDATE_KEYWORD)
+ */
+export const updateKeywordMessageRequestSchema = baseMessageRequestSchema.extend({
+  action: z.literal(API_ACTIONS.UPDATE_KEYWORD),
+  payload: updateKeywordRequestSchema.extend({
+    id: KeywordIdSchema,
+  }),
+})
+
+export type UpdateKeywordMessageRequest = z.infer<
+  typeof updateKeywordMessageRequestSchema
+>
+
+export const updateKeywordMessageResponseSchema = createApiResponseSchema(
+  z.null(), // 更新時はデータなし（成功フラグのみ）
+)
+
+export type UpdateKeywordMessageResponse = z.infer<
+  typeof updateKeywordMessageResponseSchema
+>

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -104,7 +104,7 @@ export type UpdateKeywordMessageRequest = z.infer<
 >
 
 export const updateKeywordMessageResponseSchema = createApiResponseSchema(
-  z.null(), // 更新時はデータなし（成功フラグのみ）
+  keywordResponseSchema,
 )
 
 export type UpdateKeywordMessageResponse = z.infer<

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -13,6 +13,7 @@ export const TEST_STRINGS = {
   PRE_TRIMMED_NAME: '   TRIMMED NAME    ',
   TRIMMED_NAME: 'TRIMMED NAME',
   INVALID_ID: 'not-a-uuid',
+  ERROR_CODE: 'TEST_ERROR_CODE',
 } as const
 
 // UUID v7 形式のモック ID (時間順ソート可能性を維持)


### PR DESCRIPTION
Issue #437 に対する実装です。

### 変更内容
- `shared/schemas/api.ts` に `updateKeywordMessageRequestSchema` および `updateKeywordMessageResponseSchema` を追加。
- 既存の `updateKeywordRequestSchema` および `KeywordIdSchema` を活用し、メッセージング基盤に適合する形で統合。
- `shared/schemas/api.test.ts` を更新し、正常系・異常系（不正な ID/名前、エラーレスポンス構造）のバリデーションを TDD で検証済み。
- テストコードにおいて `ERROR_MESSAGES` 定数を使用し、マジックストリングを排除。

なお、エラーコードについては暫定的にリテラル文字列を使用していますが、別途 **Issue #438（API エラーコードの定義と標準化）** にて一括対応する予定です。

Closes #437