### PR TITLE
[Shared] API エラーコードの定義と標準化

### DIFF
--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -121,6 +121,17 @@ export const COMMON_MESSAGES = {
 } as const
 
 /**
+ * API エラーコード
+ */
+export const ERROR_CODES = {
+  INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
+  NOT_FOUND: 'NOT_FOUND',
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  CONFLICT: 'CONFLICT',
+  BAD_REQUEST: 'BAD_REQUEST',
+} as const
+
+/**
  * API サーバーが返す共通のエラーメッセージ
  */
 export const ERROR_MESSAGES = {

--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { z, ZodError } from 'zod'
 
-import { API_ACTIONS, ERROR_MESSAGES } from '../constants'
+import { API_ACTIONS, ERROR_MESSAGES, ERROR_CODES } from '../constants'
 import {
   createApiSuccessSchema,
   ApiErrorSchema,
@@ -32,7 +32,7 @@ describe('API Schemas', () => {
         success: false,
         error: {
           message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
-          code: TEST_STRINGS.ERROR_CODE,
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
         },
       }
       expect(ApiErrorSchema.parse(errorData)).toEqual(errorData)
@@ -169,7 +169,7 @@ describe('API Schemas', () => {
         success: false,
         error: {
           message: ERROR_MESSAGES.KEYWORD_NOT_FOUND,
-          code: TEST_STRINGS.ERROR_CODE,
+          code: ERROR_CODES.NOT_FOUND,
         },
       }
       expect(updateKeywordMessageResponseSchema.parse(errorResponse)).toEqual(

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { API_ACTIONS } from '../constants'
+import { API_ACTIONS, ERROR_CODES } from '../constants'
 import {
   createKeywordRequestSchema,
   KeywordIdSchema,
@@ -8,6 +8,14 @@ import {
   keywordsResponseSchema,
   updateKeywordRequestSchema,
 } from './keyword'
+
+/**
+ * エラーコードのスキーマ
+ */
+export const ErrorCodeSchema = z.enum(
+  Object.values(ERROR_CODES) as [string, ...string[]],
+)
+export type ErrorCode = z.infer<typeof ErrorCodeSchema>
 
 /**
  * API 成功時の共通レスポンス形式
@@ -25,7 +33,7 @@ export const ApiErrorSchema = z.object({
   success: z.literal(false),
   error: z.object({
     message: z.string(),
-    code: z.string(),
+    code: ErrorCodeSchema,
     details: z.unknown().optional(),
   }),
 })


### PR DESCRIPTION
Issue #438 に対する実装です。

### 変更内容
- `shared/constants.ts` に `ERROR_CODES` 定数を定義（INTERNAL_SERVER_ERROR, NOT_FOUND, VALIDATION_ERROR, CONFLICT, BAD_REQUEST）。
- `shared/schemas/api.ts` の `ApiErrorSchema` を更新し、エラーコードを `ERROR_CODES` の列挙型に制限するように強化。
- `shared/schemas/api.test.ts` を更新し、定数を使用したエラーレスポンスのバリデーションを検証済み。

これにより、システム全体で一貫したエラーハンドリングと、型安全なエラーコードの利用が可能になりました。

Closes #438