### PR TITLE
[Shared] キーワード削除 (DELETE_KEYWORD) のスキーマ定義

### DIFF
--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -13,6 +13,8 @@ import {
   addKeywordResponseSchema,
   updateKeywordMessageRequestSchema,
   updateKeywordMessageResponseSchema,
+  deleteKeywordMessageRequestSchema,
+  deleteKeywordMessageResponseSchema,
 } from './api'
 import { MOCK_KEYWORDS, MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
 
@@ -154,7 +156,10 @@ describe('API Schemas', () => {
 
   describe('updateKeywordMessageResponseSchema', () => {
     it('成功時のレスポンスを検証できること', () => {
-      const keyword = { id: MOCK_IDS.KEYWORD_1, name: TEST_STRINGS.UPDATED_NAME }
+      const keyword = {
+        id: MOCK_IDS.KEYWORD_1,
+        name: TEST_STRINGS.UPDATED_NAME,
+      }
       const validResponse = {
         success: true,
         data: { keyword },
@@ -173,6 +178,50 @@ describe('API Schemas', () => {
         },
       }
       expect(updateKeywordMessageResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
+      )
+    })
+  })
+
+  describe('deleteKeywordMessageRequestSchema', () => {
+    it('正しい DELETE_KEYWORD リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.DELETE_KEYWORD,
+        payload: { id: MOCK_IDS.KEYWORD_1 },
+      }
+      expect(deleteKeywordMessageRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('不正な形式の ID を拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.DELETE_KEYWORD,
+        payload: { id: TEST_STRINGS.INVALID_ID },
+      }
+      expect(() =>
+        deleteKeywordMessageRequestSchema.parse(invalidRequest),
+      ).toThrow(ZodError)
+    })
+  })
+
+  describe('deleteKeywordMessageResponseSchema', () => {
+    it('成功時のレスポンスを検証できること', () => {
+      const validResponse = { success: true, data: null }
+      expect(deleteKeywordMessageResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.KEYWORD_NOT_FOUND,
+          code: ERROR_CODES.NOT_FOUND,
+        },
+      }
+      expect(deleteKeywordMessageResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -118,3 +118,25 @@ export const updateKeywordMessageResponseSchema = createApiResponseSchema(
 export type UpdateKeywordMessageResponse = z.infer<
   typeof updateKeywordMessageResponseSchema
 >
+
+/**
+ * キーワード削除 (DELETE_KEYWORD)
+ */
+export const deleteKeywordMessageRequestSchema = baseMessageRequestSchema.extend({
+  action: z.literal(API_ACTIONS.DELETE_KEYWORD),
+  payload: z.object({
+    id: KeywordIdSchema,
+  }),
+})
+
+export type DeleteKeywordMessageRequest = z.infer<
+  typeof deleteKeywordMessageRequestSchema
+>
+
+export const deleteKeywordMessageResponseSchema = createApiResponseSchema(
+  z.null(), // 削除時はデータなし
+)
+
+export type DeleteKeywordMessageResponse = z.infer<
+  typeof deleteKeywordMessageResponseSchema
+>


### PR DESCRIPTION
Issue #441 に対する実装です。

### 変更内容
- `shared/schemas/api.ts` に `deleteKeywordMessageRequestSchema` および `deleteKeywordMessageResponseSchema` を追加。
- 既存の `KeywordIdSchema` を活用し、メッセージング基盤に適合する形で統合。
- `shared/schemas/api.test.ts` を更新し、正常系・異常系（不正な ID 形式、エラーレスポンス構造）のバリデーションを TDD で検証済み。
- ユーザー様の修正により、`UPDATE_KEYWORD` のバリデーションテスト補完およびテストコードのフォーマット改善を反映。

Closes #441