### PR TITLE
[Shared] ブックマーク一覧取得 (GET_BOOKMARKS) のスキーマ定義

### DIFF
--- a/shared/schemas/api-bookmark.test.ts
+++ b/shared/schemas/api-bookmark.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { ZodError } from 'zod'
+
+import { API_ACTIONS, ERROR_MESSAGES, ERROR_CODES } from '../constants'
+import { getBookmarksRequestSchema, getBookmarksResponseSchema } from './api'
+import { MOCK_BOOKMARKS } from '../test/fixtures'
+
+describe('API Schemas - Bookmark Operations', () => {
+  describe('getBookmarksRequestSchema', () => {
+    it('正しい GET_BOOKMARKS リクエストを受け入れること', () => {
+      const validRequest = { action: API_ACTIONS.GET_BOOKMARKS }
+      expect(getBookmarksRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('不正なアクションを持つリクエストを拒否すること', () => {
+      const invalidRequest = { action: API_ACTIONS.GET_KEYWORDS }
+      expect(() => getBookmarksRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+  })
+
+  describe('getBookmarksResponseSchema', () => {
+    it('ブックマーク一覧を含むレスポンスを検証できること', () => {
+      const validResponse = {
+        success: true,
+        data: { bookmarks: MOCK_BOOKMARKS },
+      }
+      expect(getBookmarksResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        },
+      }
+      expect(getBookmarksResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
+      )
+    })
+  })
+})

--- a/shared/schemas/api-keyword.test.ts
+++ b/shared/schemas/api-keyword.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest'
+import { ZodError } from 'zod'
+
+import { API_ACTIONS, ERROR_MESSAGES, ERROR_CODES } from '../constants'
+import {
+  getKeywordsRequestSchema,
+  getKeywordsResponseSchema,
+  addKeywordRequestSchema,
+  addKeywordResponseSchema,
+  updateKeywordMessageRequestSchema,
+  updateKeywordMessageResponseSchema,
+  deleteKeywordMessageRequestSchema,
+  deleteKeywordMessageResponseSchema,
+} from './api'
+import { MOCK_KEYWORDS, MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
+
+describe('API Schemas - Keyword Operations', () => {
+  describe('getKeywordsRequestSchema', () => {
+    it('正しい GET_KEYWORDS リクエストを受け入れること', () => {
+      const validRequest = { action: API_ACTIONS.GET_KEYWORDS }
+      expect(getKeywordsRequestSchema.parse(validRequest)).toEqual(validRequest)
+    })
+
+    it('不正なアクションを持つリクエストを拒否すること', () => {
+      const invalidRequest = { action: API_ACTIONS.GET_BOOKMARKS }
+      expect(() => getKeywordsRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+  })
+
+  describe('getKeywordsResponseSchema', () => {
+    it('キーワード一覧を含むレスポンスを検証できること', () => {
+      const validResponse = {
+        success: true,
+        data: { keywords: MOCK_KEYWORDS },
+      }
+      expect(getKeywordsResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+  })
+
+  describe('addKeywordRequestSchema', () => {
+    it('正しい ADD_KEYWORD リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.ADD_KEYWORD,
+        payload: { name: TEST_STRINGS.NEW_NAME },
+      }
+      expect(addKeywordRequestSchema.parse(validRequest)).toEqual(validRequest)
+    })
+
+    it('payload が不正（名前が空）なリクエストを拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.ADD_KEYWORD,
+        payload: { name: '' },
+      }
+      expect(() => addKeywordRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+  })
+
+  describe('addKeywordResponseSchema', () => {
+    it('追加されたキーワードを含むレスポンスを検証できること', () => {
+      const mock = MOCK_KEYWORDS[0]
+      const keyword = { id: mock.id, name: mock.name }
+      const validResponse = {
+        success: true,
+        data: { keyword },
+      }
+      expect(addKeywordResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+  })
+
+  describe('updateKeywordMessageRequestSchema', () => {
+    it('正しい UPDATE_KEYWORD リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.UPDATE_KEYWORD,
+        payload: { id: MOCK_IDS.KEYWORD_1, name: TEST_STRINGS.UPDATED_NAME },
+      }
+      expect(updateKeywordMessageRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('不正な形式の ID を拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.UPDATE_KEYWORD,
+        payload: { id: TEST_STRINGS.INVALID_ID, name: TEST_STRINGS.NEW_NAME },
+      }
+      expect(() =>
+        updateKeywordMessageRequestSchema.parse(invalidRequest),
+      ).toThrow(ZodError)
+    })
+
+    it('名前が空のリクエストを拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.UPDATE_KEYWORD,
+        payload: { id: MOCK_IDS.KEYWORD_1, name: '' },
+      }
+      expect(() =>
+        updateKeywordMessageRequestSchema.parse(invalidRequest),
+      ).toThrow(ZodError)
+    })
+  })
+
+  describe('updateKeywordMessageResponseSchema', () => {
+    it('成功時のレスポンスを検証できること', () => {
+      const keyword = {
+        id: MOCK_IDS.KEYWORD_1,
+        name: TEST_STRINGS.UPDATED_NAME,
+      }
+      const validResponse = {
+        success: true,
+        data: { keyword },
+      }
+      expect(updateKeywordMessageResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.KEYWORD_NOT_FOUND,
+          code: ERROR_CODES.NOT_FOUND,
+        },
+      }
+      expect(updateKeywordMessageResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
+      )
+    })
+  })
+
+  describe('deleteKeywordMessageRequestSchema', () => {
+    it('正しい DELETE_KEYWORD リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.DELETE_KEYWORD,
+        payload: { id: MOCK_IDS.KEYWORD_1 },
+      }
+      expect(deleteKeywordMessageRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('不正な形式の ID を拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.DELETE_KEYWORD,
+        payload: { id: TEST_STRINGS.INVALID_ID },
+      }
+      expect(() =>
+        deleteKeywordMessageRequestSchema.parse(invalidRequest),
+      ).toThrow(ZodError)
+    })
+  })
+
+  describe('deleteKeywordMessageResponseSchema', () => {
+    it('成功時のレスポンスを検証できること', () => {
+      const validResponse = { success: true, data: null }
+      expect(deleteKeywordMessageResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.KEYWORD_NOT_FOUND,
+          code: ERROR_CODES.NOT_FOUND,
+        },
+      }
+      expect(deleteKeywordMessageResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
+      )
+    })
+  })
+})

--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -7,23 +7,15 @@ import {
   ApiErrorSchema,
   ApiActionSchema,
   baseMessageRequestSchema,
-  getKeywordsRequestSchema,
-  getKeywordsResponseSchema,
-  addKeywordRequestSchema,
-  addKeywordResponseSchema,
-  updateKeywordMessageRequestSchema,
-  updateKeywordMessageResponseSchema,
-  deleteKeywordMessageRequestSchema,
-  deleteKeywordMessageResponseSchema,
 } from './api'
-import { MOCK_KEYWORDS, MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
+import { MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
 
-describe('API Schemas', () => {
+describe('API Schemas - Messaging Foundation', () => {
   describe('createApiSuccessSchema', () => {
     it('正常なデータ構造を検証できること', () => {
       const dataSchema = z.object({ id: z.string() })
       const schema = createApiSuccessSchema(dataSchema)
-      const validData = { success: true, data: { id: 'test' } }
+      const validData = { success: true, data: { id: MOCK_IDS.BOOKMARK_1 } }
       expect(schema.parse(validData)).toEqual(validData)
     })
   })
@@ -49,7 +41,9 @@ describe('API Schemas', () => {
     })
 
     it('未定義のアクションを拒否すること', () => {
-      expect(() => ApiActionSchema.parse('INVALID_ACTION')).toThrow(ZodError)
+      expect(() => ApiActionSchema.parse(TEST_STRINGS.INVALID_ACTION)).toThrow(
+        ZodError,
+      )
     })
   })
 
@@ -57,172 +51,15 @@ describe('API Schemas', () => {
     it('正しいメッセージ構造を受け入れること', () => {
       const validRequest = {
         action: API_ACTIONS.GET_BOOKMARKS,
-        payload: { some: 'data' },
+        payload: { some: TEST_STRINGS.NEW_NAME },
       }
       expect(baseMessageRequestSchema.parse(validRequest)).toEqual(validRequest)
     })
-  })
 
-  describe('getKeywordsRequestSchema', () => {
-    it('正しい GET_KEYWORDS リクエストを受け入れること', () => {
-      const validRequest = { action: API_ACTIONS.GET_KEYWORDS }
-      expect(getKeywordsRequestSchema.parse(validRequest)).toEqual(validRequest)
-    })
-
-    it('不正なアクションを持つリクエストを拒否すること', () => {
-      const invalidRequest = { action: API_ACTIONS.GET_BOOKMARKS }
-      expect(() => getKeywordsRequestSchema.parse(invalidRequest)).toThrow(
+    it('不正な形式のリクエストを拒否すること', () => {
+      const invalidRequest = { action: TEST_STRINGS.INVALID_ACTION }
+      expect(() => baseMessageRequestSchema.parse(invalidRequest)).toThrow(
         ZodError,
-      )
-    })
-  })
-
-  describe('getKeywordsResponseSchema', () => {
-    it('キーワード一覧を含むレスポンスを検証できること', () => {
-      const validResponse = {
-        success: true,
-        data: { keywords: MOCK_KEYWORDS },
-      }
-      expect(getKeywordsResponseSchema.parse(validResponse)).toEqual(
-        validResponse,
-      )
-    })
-  })
-
-  describe('addKeywordRequestSchema', () => {
-    it('正しい ADD_KEYWORD リクエストを受け入れること', () => {
-      const validRequest = {
-        action: API_ACTIONS.ADD_KEYWORD,
-        payload: { name: TEST_STRINGS.NEW_NAME },
-      }
-      expect(addKeywordRequestSchema.parse(validRequest)).toEqual(validRequest)
-    })
-
-    it('payload が不正（名前が空）なリクエストを拒否すること', () => {
-      const invalidRequest = {
-        action: API_ACTIONS.ADD_KEYWORD,
-        payload: { name: '' },
-      }
-      expect(() => addKeywordRequestSchema.parse(invalidRequest)).toThrow(
-        ZodError,
-      )
-    })
-  })
-
-  describe('addKeywordResponseSchema', () => {
-    it('追加されたキーワードを含むレスポンスを検証できること', () => {
-      const keyword = { id: MOCK_KEYWORDS[0].id, name: MOCK_KEYWORDS[0].name }
-      const validResponse = {
-        success: true,
-        data: { keyword },
-      }
-      expect(addKeywordResponseSchema.parse(validResponse)).toEqual(
-        validResponse,
-      )
-    })
-  })
-
-  describe('updateKeywordMessageRequestSchema', () => {
-    it('正しい UPDATE_KEYWORD リクエストを受け入れること', () => {
-      const validRequest = {
-        action: API_ACTIONS.UPDATE_KEYWORD,
-        payload: { id: MOCK_IDS.KEYWORD_1, name: TEST_STRINGS.UPDATED_NAME },
-      }
-      expect(updateKeywordMessageRequestSchema.parse(validRequest)).toEqual(
-        validRequest,
-      )
-    })
-
-    it('不正な形式の ID を拒否すること', () => {
-      const invalidRequest = {
-        action: API_ACTIONS.UPDATE_KEYWORD,
-        payload: { id: TEST_STRINGS.INVALID_ID, name: TEST_STRINGS.NEW_NAME },
-      }
-      expect(() =>
-        updateKeywordMessageRequestSchema.parse(invalidRequest),
-      ).toThrow(ZodError)
-    })
-
-    it('名前が空のリクエストを拒否すること', () => {
-      const invalidRequest = {
-        action: API_ACTIONS.UPDATE_KEYWORD,
-        payload: { id: MOCK_IDS.KEYWORD_1, name: '' },
-      }
-      expect(() =>
-        updateKeywordMessageRequestSchema.parse(invalidRequest),
-      ).toThrow(ZodError)
-    })
-  })
-
-  describe('updateKeywordMessageResponseSchema', () => {
-    it('成功時のレスポンスを検証できること', () => {
-      const keyword = {
-        id: MOCK_IDS.KEYWORD_1,
-        name: TEST_STRINGS.UPDATED_NAME,
-      }
-      const validResponse = {
-        success: true,
-        data: { keyword },
-      }
-      expect(updateKeywordMessageResponseSchema.parse(validResponse)).toEqual(
-        validResponse,
-      )
-    })
-
-    it('エラー時のレスポンスを検証できること', () => {
-      const errorResponse = {
-        success: false,
-        error: {
-          message: ERROR_MESSAGES.KEYWORD_NOT_FOUND,
-          code: ERROR_CODES.NOT_FOUND,
-        },
-      }
-      expect(updateKeywordMessageResponseSchema.parse(errorResponse)).toEqual(
-        errorResponse,
-      )
-    })
-  })
-
-  describe('deleteKeywordMessageRequestSchema', () => {
-    it('正しい DELETE_KEYWORD リクエストを受け入れること', () => {
-      const validRequest = {
-        action: API_ACTIONS.DELETE_KEYWORD,
-        payload: { id: MOCK_IDS.KEYWORD_1 },
-      }
-      expect(deleteKeywordMessageRequestSchema.parse(validRequest)).toEqual(
-        validRequest,
-      )
-    })
-
-    it('不正な形式の ID を拒否すること', () => {
-      const invalidRequest = {
-        action: API_ACTIONS.DELETE_KEYWORD,
-        payload: { id: TEST_STRINGS.INVALID_ID },
-      }
-      expect(() =>
-        deleteKeywordMessageRequestSchema.parse(invalidRequest),
-      ).toThrow(ZodError)
-    })
-  })
-
-  describe('deleteKeywordMessageResponseSchema', () => {
-    it('成功時のレスポンスを検証できること', () => {
-      const validResponse = { success: true, data: null }
-      expect(deleteKeywordMessageResponseSchema.parse(validResponse)).toEqual(
-        validResponse,
-      )
-    })
-
-    it('エラー時のレスポンスを検証できること', () => {
-      const errorResponse = {
-        success: false,
-        error: {
-          message: ERROR_MESSAGES.KEYWORD_NOT_FOUND,
-          code: ERROR_CODES.NOT_FOUND,
-        },
-      }
-      expect(deleteKeywordMessageResponseSchema.parse(errorResponse)).toEqual(
-        errorResponse,
       )
     })
   })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 
 import { API_ACTIONS, ERROR_CODES } from '../constants'
+import { bookmarksResponseSchema } from './bookmark'
 import {
   createKeywordRequestSchema,
   KeywordIdSchema,
@@ -140,3 +141,19 @@ export const deleteKeywordMessageResponseSchema = createApiResponseSchema(
 export type DeleteKeywordMessageResponse = z.infer<
   typeof deleteKeywordMessageResponseSchema
 >
+
+/**
+ * ブックマーク一覧取得 (GET_BOOKMARKS)
+ */
+export const getBookmarksRequestSchema = baseMessageRequestSchema.extend({
+  action: z.literal(API_ACTIONS.GET_BOOKMARKS),
+  payload: z.undefined().optional(),
+})
+
+export type GetBookmarksRequest = z.infer<typeof getBookmarksRequestSchema>
+
+export const getBookmarksResponseSchema = createApiResponseSchema(
+  bookmarksResponseSchema,
+)
+
+export type GetBookmarksResponse = z.infer<typeof getBookmarksResponseSchema>

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -12,6 +12,7 @@ export const TEST_STRINGS = {
   NEW_NAME: 'New Name',
   PRE_TRIMMED_NAME: '   TRIMMED NAME    ',
   TRIMMED_NAME: 'TRIMMED NAME',
+  INVALID_ACTION: 'INVALID ACTION',
   INVALID_ID: 'not-a-uuid',
   ERROR_CODE: 'TEST_ERROR_CODE',
 } as const


### PR DESCRIPTION
Issue #443 に対する実装です。

### 変更内容
- `shared/schemas/api.ts` に `getBookmarksRequestSchema` および `getBookmarksResponseSchema` を追加。
- 既存の `bookmarksResponseSchema` を活用し、キーワード詳細を含むブックマーク一覧を返却する構造を定義。
- `shared/schemas/api.test.ts` をリファクタリングし、ドメインごとにテストファイルを分割 (`api-keyword.test.ts`, `api-bookmark.test.ts`)。
- 新設された `shared/schemas/api-bookmark.test.ts` にて、正常系・異常系（エラーレスポンス構造）のバリデーションを TDD で検証済み。

Closes #443