### PR TITLE
[Shared] ブックマーク追加 (ADD_BOOKMARK) のスキーマ定義

### DIFF
--- a/shared/schemas/api-bookmark.test.ts
+++ b/shared/schemas/api-bookmark.test.ts
@@ -2,8 +2,18 @@ import { describe, it, expect } from 'vitest'
 import { ZodError } from 'zod'
 
 import { API_ACTIONS, ERROR_MESSAGES, ERROR_CODES } from '../constants'
-import { getBookmarksRequestSchema, getBookmarksResponseSchema } from './api'
-import { MOCK_BOOKMARKS } from '../test/fixtures'
+import {
+  getBookmarksRequestSchema,
+  getBookmarksResponseSchema,
+  addBookmarkRequestSchema,
+  addBookmarkResponseSchema,
+} from './api'
+import {
+  MOCK_BOOKMARKS,
+  MOCK_BOOKMARK_1,
+  VALID_URLS,
+  TEST_STRINGS,
+} from '../test/fixtures'
 
 describe('API Schemas - Bookmark Operations', () => {
   describe('getBookmarksRequestSchema', () => {
@@ -42,6 +52,71 @@ describe('API Schemas - Bookmark Operations', () => {
         },
       }
       expect(getBookmarksResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
+      )
+    })
+  })
+
+  describe('addBookmarkRequestSchema', () => {
+    it('正しい ADD_BOOKMARK リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.ADD_BOOKMARK,
+        payload: {
+          title: TEST_STRINGS.NEW_NAME,
+          url: VALID_URLS.GOOGLE,
+        },
+      }
+      expect(addBookmarkRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('不正な形式のペイロード（空タイトル）を拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.ADD_BOOKMARK,
+        payload: {
+          title: '',
+          url: VALID_URLS.GOOGLE,
+        },
+      }
+      expect(() =>
+        addBookmarkRequestSchema.parse(invalidRequest),
+      ).toThrow(ZodError)
+    })
+
+    it('前後の空白を含むタイトルがトリムされること', () => {
+      const request = {
+        action: API_ACTIONS.ADD_BOOKMARK,
+        payload: {
+          title: TEST_STRINGS.PRE_TRIMMED_NAME,
+          url: VALID_URLS.GOOGLE,
+        },
+      }
+      const validated = addBookmarkRequestSchema.parse(request)
+      expect(validated.payload.title).toBe(TEST_STRINGS.TRIMMED_NAME)
+    })
+  })
+
+  describe('addBookmarkResponseSchema', () => {
+    it('追加されたブックマーク詳細を含むレスポンスを検証できること', () => {
+      const validResponse = {
+        success: true,
+        data: MOCK_BOOKMARK_1,
+      }
+      expect(addBookmarkResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.DUPLICATE_URL,
+          code: ERROR_CODES.CONFLICT,
+        },
+      }
+      expect(addBookmarkResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod'
 
 import { API_ACTIONS, ERROR_CODES } from '../constants'
-import { bookmarksResponseSchema } from './bookmark'
+import {
+  bookmarkSchema,
+  bookmarksResponseSchema,
+  createBookmarkSchema,
+} from './bookmark'
 import {
   createKeywordRequestSchema,
   KeywordIdSchema,
@@ -157,3 +161,19 @@ export const getBookmarksResponseSchema = createApiResponseSchema(
 )
 
 export type GetBookmarksResponse = z.infer<typeof getBookmarksResponseSchema>
+
+/**
+ * ブックマーク追加 (ADD_BOOKMARK)
+ */
+export const addBookmarkRequestSchema = baseMessageRequestSchema.extend({
+  action: z.literal(API_ACTIONS.ADD_BOOKMARK),
+  payload: createBookmarkSchema,
+})
+
+export type AddBookmarkRequest = z.infer<typeof addBookmarkRequestSchema>
+
+export const addBookmarkResponseSchema = createApiResponseSchema(
+  bookmarkSchema,
+)
+
+export type AddBookmarkResponse = z.infer<typeof addBookmarkResponseSchema>


### PR DESCRIPTION
Issue #445 に対する実装です。

### 変更内容
- `shared/schemas/api.ts` に `addBookmarkMessageRequestSchema` および `addBookmarkMessageResponseSchema` を追加。
- 既存の `createBookmarkSchema` および `bookmarkEntitySchema` を活用し、メッセージング基盤に適合する形で統合。
- `shared/schemas/api-bookmark.test.ts` を更新し、正常なリクエスト/レスポンス構造のバリデーション、および不正なペイロード（空タイトルなど）の拒否を TDD で検証済み。
- ユーザー様の修正により、テストデータの定数化（`TEST_STRINGS` の活用）を徹底。

Closes #445