### PR TITLE
[Shared] メッセージングスキーマの命名規則の統一と基盤強化

### DIFF
--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -5,11 +5,11 @@ import { z } from 'zod'
 
 import { ERROR_MESSAGES, HTTP_STATUS, LOG_MESSAGES } from '@shared/constants'
 import {
-  createKeywordRequestSchema,
+  createKeywordSchema,
   KeywordIdSchema,
   keywordResponseSchema,
   keywordsResponseSchema,
-  updateKeywordRequestSchema,
+  updateKeywordSchema,
 } from '@shared/schemas/keyword'
 
 import { db } from '../db'
@@ -51,7 +51,7 @@ const keywordsRoute = new Hono()
       throw error
     }
   })
-  .post('/', zValidator('json', createKeywordRequestSchema), async (c) => {
+  .post('/', zValidator('json', createKeywordSchema), async (c) => {
     const { name } = c.req.valid('json')
 
     try {
@@ -106,7 +106,7 @@ const keywordsRoute = new Hono()
   .patch(
     '/:id',
     zValidator('param', z.object({ id: KeywordIdSchema })),
-    zValidator('json', updateKeywordRequestSchema),
+    zValidator('json', updateKeywordSchema),
     async (c) => {
       const { id } = c.req.valid('param')
       const { name } = c.req.valid('json')
@@ -116,7 +116,7 @@ const keywordsRoute = new Hono()
         const existing = await db
           .select()
           .from(keywordsTable)
-          .where(eq(keywordsTable.keywordId, Number(id)))
+          .where(eq(keywordsTable.keywordId, Number(id as string)))
           .get()
 
         if (!existing) {
@@ -139,7 +139,7 @@ const keywordsRoute = new Hono()
           .where(eq(keywordsTable.keywordName, name))
           .get()
 
-        if (duplicate && duplicate.keywordId !== Number(id)) {
+        if (duplicate && duplicate.keywordId !== Number(id as string)) {
           return c.json(
             {
               success: false,
@@ -156,7 +156,7 @@ const keywordsRoute = new Hono()
         const result = await db
           .update(keywordsTable)
           .set({ keywordName: name })
-          .where(eq(keywordsTable.keywordId, Number(id)))
+          .where(eq(keywordsTable.keywordId, Number(id as string)))
           .returning()
           .get()
 
@@ -187,10 +187,9 @@ const keywordsRoute = new Hono()
 
       try {
         // 削除実行と結果の取得を同時に行う
-        // 中間テーブル (bookmarkKeywords) は外部キー制約 (ON DELETE CASCADE) により自動的に削除される
         const result = await db
           .delete(keywordsTable)
-          .where(eq(keywordsTable.keywordId, Number(id)))
+          .where(eq(keywordsTable.keywordId, Number(id as string)))
           .returning()
           .get()
 

--- a/shared/schemas/api-keyword.test.ts
+++ b/shared/schemas/api-keyword.test.ts
@@ -7,10 +7,10 @@ import {
   getKeywordsResponseSchema,
   addKeywordRequestSchema,
   addKeywordResponseSchema,
-  updateKeywordMessageRequestSchema,
-  updateKeywordMessageResponseSchema,
-  deleteKeywordMessageRequestSchema,
-  deleteKeywordMessageResponseSchema,
+  updateKeywordRequestSchema,
+  updateKeywordResponseSchema,
+  deleteKeywordRequestSchema,
+  deleteKeywordResponseSchema,
 } from './api'
 import { MOCK_KEYWORDS, MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
 
@@ -63,8 +63,7 @@ describe('API Schemas - Keyword Operations', () => {
 
   describe('addKeywordResponseSchema', () => {
     it('追加されたキーワードを含むレスポンスを検証できること', () => {
-      const mock = MOCK_KEYWORDS[0]
-      const keyword = { id: mock.id, name: mock.name }
+      const keyword = { id: MOCK_KEYWORDS[0].id, name: MOCK_KEYWORDS[0].name }
       const validResponse = {
         success: true,
         data: { keyword },
@@ -75,13 +74,13 @@ describe('API Schemas - Keyword Operations', () => {
     })
   })
 
-  describe('updateKeywordMessageRequestSchema', () => {
+  describe('updateKeywordRequestSchema', () => {
     it('正しい UPDATE_KEYWORD リクエストを受け入れること', () => {
       const validRequest = {
         action: API_ACTIONS.UPDATE_KEYWORD,
         payload: { id: MOCK_IDS.KEYWORD_1, name: TEST_STRINGS.UPDATED_NAME },
       }
-      expect(updateKeywordMessageRequestSchema.parse(validRequest)).toEqual(
+      expect(updateKeywordRequestSchema.parse(validRequest)).toEqual(
         validRequest,
       )
     })
@@ -92,7 +91,7 @@ describe('API Schemas - Keyword Operations', () => {
         payload: { id: TEST_STRINGS.INVALID_ID, name: TEST_STRINGS.NEW_NAME },
       }
       expect(() =>
-        updateKeywordMessageRequestSchema.parse(invalidRequest),
+        updateKeywordRequestSchema.parse(invalidRequest),
       ).toThrow(ZodError)
     })
 
@@ -102,12 +101,12 @@ describe('API Schemas - Keyword Operations', () => {
         payload: { id: MOCK_IDS.KEYWORD_1, name: '' },
       }
       expect(() =>
-        updateKeywordMessageRequestSchema.parse(invalidRequest),
+        updateKeywordRequestSchema.parse(invalidRequest),
       ).toThrow(ZodError)
     })
   })
 
-  describe('updateKeywordMessageResponseSchema', () => {
+  describe('updateKeywordResponseSchema', () => {
     it('成功時のレスポンスを検証できること', () => {
       const keyword = {
         id: MOCK_IDS.KEYWORD_1,
@@ -117,7 +116,7 @@ describe('API Schemas - Keyword Operations', () => {
         success: true,
         data: { keyword },
       }
-      expect(updateKeywordMessageResponseSchema.parse(validResponse)).toEqual(
+      expect(updateKeywordResponseSchema.parse(validResponse)).toEqual(
         validResponse,
       )
     })
@@ -130,19 +129,19 @@ describe('API Schemas - Keyword Operations', () => {
           code: ERROR_CODES.NOT_FOUND,
         },
       }
-      expect(updateKeywordMessageResponseSchema.parse(errorResponse)).toEqual(
+      expect(updateKeywordResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })
   })
 
-  describe('deleteKeywordMessageRequestSchema', () => {
+  describe('deleteKeywordRequestSchema', () => {
     it('正しい DELETE_KEYWORD リクエストを受け入れること', () => {
       const validRequest = {
         action: API_ACTIONS.DELETE_KEYWORD,
         payload: { id: MOCK_IDS.KEYWORD_1 },
       }
-      expect(deleteKeywordMessageRequestSchema.parse(validRequest)).toEqual(
+      expect(deleteKeywordRequestSchema.parse(validRequest)).toEqual(
         validRequest,
       )
     })
@@ -153,15 +152,15 @@ describe('API Schemas - Keyword Operations', () => {
         payload: { id: TEST_STRINGS.INVALID_ID },
       }
       expect(() =>
-        deleteKeywordMessageRequestSchema.parse(invalidRequest),
+        deleteKeywordRequestSchema.parse(invalidRequest),
       ).toThrow(ZodError)
     })
   })
 
-  describe('deleteKeywordMessageResponseSchema', () => {
+  describe('deleteKeywordResponseSchema', () => {
     it('成功時のレスポンスを検証できること', () => {
       const validResponse = { success: true, data: null }
-      expect(deleteKeywordMessageResponseSchema.parse(validResponse)).toEqual(
+      expect(deleteKeywordResponseSchema.parse(validResponse)).toEqual(
         validResponse,
       )
     })
@@ -174,7 +173,7 @@ describe('API Schemas - Keyword Operations', () => {
           code: ERROR_CODES.NOT_FOUND,
         },
       }
-      expect(deleteKeywordMessageResponseSchema.parse(errorResponse)).toEqual(
+      expect(deleteKeywordResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })

--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -6,7 +6,7 @@ import {
   createApiSuccessSchema,
   ApiErrorSchema,
   ApiActionSchema,
-  baseMessageRequestSchema,
+  baseApiRequestSchema,
 } from './api'
 import { MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
 
@@ -47,18 +47,18 @@ describe('API Schemas - Messaging Foundation', () => {
     })
   })
 
-  describe('baseMessageRequestSchema', () => {
+  describe('baseApiRequestSchema', () => {
     it('正しいメッセージ構造を受け入れること', () => {
       const validRequest = {
         action: API_ACTIONS.GET_BOOKMARKS,
         payload: { some: TEST_STRINGS.NEW_NAME },
       }
-      expect(baseMessageRequestSchema.parse(validRequest)).toEqual(validRequest)
+      expect(baseApiRequestSchema.parse(validRequest)).toEqual(validRequest)
     })
 
     it('不正な形式のリクエストを拒否すること', () => {
       const invalidRequest = { action: TEST_STRINGS.INVALID_ACTION }
-      expect(() => baseMessageRequestSchema.parse(invalidRequest)).toThrow(
+      expect(() => baseApiRequestSchema.parse(invalidRequest)).toThrow(
         ZodError,
       )
     })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -7,11 +7,11 @@ import {
   createBookmarkSchema,
 } from './bookmark'
 import {
-  createKeywordRequestSchema,
+  createKeywordSchema,
   KeywordIdSchema,
   keywordResponseSchema,
   keywordsResponseSchema,
-  updateKeywordRequestSchema,
+  updateKeywordSchema,
 } from './keyword'
 
 /**
@@ -63,17 +63,15 @@ export type ApiAction = z.infer<typeof ApiActionSchema>
  * 共通のメッセージリクエスト構造
  * 個別のアクションごとのスキーマはこれらを拡張して定義する
  */
-export const baseMessageRequestSchema = z.object({
+export const baseApiRequestSchema = z.object({
   action: ApiActionSchema,
   payload: z.unknown().optional(),
 })
 
-export type BaseMessageRequest = z.infer<typeof baseMessageRequestSchema>
-
 /**
  * キーワード一覧取得 (GET_KEYWORDS)
  */
-export const getKeywordsRequestSchema = baseMessageRequestSchema.extend({
+export const getKeywordsRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.GET_KEYWORDS),
   payload: z.undefined().optional(),
 })
@@ -89,9 +87,9 @@ export type GetKeywordsResponse = z.infer<typeof getKeywordsResponseSchema>
 /**
  * キーワード追加 (ADD_KEYWORD)
  */
-export const addKeywordRequestSchema = baseMessageRequestSchema.extend({
+export const addKeywordRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.ADD_KEYWORD),
-  payload: createKeywordRequestSchema,
+  payload: createKeywordSchema,
 })
 
 export type AddKeywordRequest = z.infer<typeof addKeywordRequestSchema>
@@ -105,51 +103,43 @@ export type AddKeywordResponse = z.infer<typeof addKeywordResponseSchema>
 /**
  * キーワード更新 (UPDATE_KEYWORD)
  */
-export const updateKeywordMessageRequestSchema = baseMessageRequestSchema.extend({
+export const updateKeywordRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.UPDATE_KEYWORD),
-  payload: updateKeywordRequestSchema.extend({
+  payload: updateKeywordSchema.extend({
     id: KeywordIdSchema,
   }),
 })
 
-export type UpdateKeywordMessageRequest = z.infer<
-  typeof updateKeywordMessageRequestSchema
->
+export type UpdateKeywordRequest = z.infer<typeof updateKeywordRequestSchema>
 
-export const updateKeywordMessageResponseSchema = createApiResponseSchema(
+export const updateKeywordResponseSchema = createApiResponseSchema(
   keywordResponseSchema,
 )
 
-export type UpdateKeywordMessageResponse = z.infer<
-  typeof updateKeywordMessageResponseSchema
->
+export type UpdateKeywordResponse = z.infer<typeof updateKeywordResponseSchema>
 
 /**
  * キーワード削除 (DELETE_KEYWORD)
  */
-export const deleteKeywordMessageRequestSchema = baseMessageRequestSchema.extend({
+export const deleteKeywordRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.DELETE_KEYWORD),
   payload: z.object({
     id: KeywordIdSchema,
   }),
 })
 
-export type DeleteKeywordMessageRequest = z.infer<
-  typeof deleteKeywordMessageRequestSchema
->
+export type DeleteKeywordRequest = z.infer<typeof deleteKeywordRequestSchema>
 
-export const deleteKeywordMessageResponseSchema = createApiResponseSchema(
+export const deleteKeywordResponseSchema = createApiResponseSchema(
   z.null(), // 削除時はデータなし
 )
 
-export type DeleteKeywordMessageResponse = z.infer<
-  typeof deleteKeywordMessageResponseSchema
->
+export type DeleteKeywordResponse = z.infer<typeof deleteKeywordResponseSchema>
 
 /**
  * ブックマーク一覧取得 (GET_BOOKMARKS)
  */
-export const getBookmarksRequestSchema = baseMessageRequestSchema.extend({
+export const getBookmarksRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.GET_BOOKMARKS),
   payload: z.undefined().optional(),
 })
@@ -165,7 +155,7 @@ export type GetBookmarksResponse = z.infer<typeof getBookmarksResponseSchema>
 /**
  * ブックマーク追加 (ADD_BOOKMARK)
  */
-export const addBookmarkRequestSchema = baseMessageRequestSchema.extend({
+export const addBookmarkRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.ADD_BOOKMARK),
   payload: createBookmarkSchema,
 })
@@ -177,3 +167,24 @@ export const addBookmarkResponseSchema = createApiResponseSchema(
 )
 
 export type AddBookmarkResponse = z.infer<typeof addBookmarkResponseSchema>
+
+/**
+ * 全てのメッセージリクエストを統合したディスクリミネイテッドユニオン型
+ * action フィールドを識別子として使用し、パースの効率とエラーメッセージを改善
+ */
+export const ApiRequestSchema = z.discriminatedUnion('action', [
+  getKeywordsRequestSchema,
+  addKeywordRequestSchema,
+  updateKeywordRequestSchema,
+  deleteKeywordRequestSchema,
+  getBookmarksRequestSchema,
+  addBookmarkRequestSchema,
+])
+
+export type ApiRequest = z.infer<typeof ApiRequestSchema>
+
+/**
+ * 任意の API リクエストを表す基底型
+ * メッセージハンドラの汎用的な引数型などに使用する
+ */
+export type BaseApiRequest = z.infer<typeof baseApiRequestSchema>

--- a/shared/schemas/keyword.test.ts
+++ b/shared/schemas/keyword.test.ts
@@ -5,7 +5,8 @@ import {
   keywordSchema,
   keywordWithCountSchema,
   keywordsResponseSchema,
-  updateKeywordRequestSchema,
+  updateKeywordSchema,
+  createKeywordSchema,
 } from './keyword'
 import {
   MOCK_BOOKMARK_TITLE_PREFIX,
@@ -37,7 +38,7 @@ describe('Keyword Schemas', () => {
     it('不正なデータを拒否すること', () => {
       expect(() =>
         keywordSchema.parse({
-          id: 'invalid',
+          id: TEST_STRINGS.INVALID_ID,
           name: MOCK_BOOKMARK_TITLE_PREFIX,
         }),
       ).toThrow()
@@ -77,20 +78,27 @@ describe('Keyword Schemas', () => {
     })
   })
 
-  describe('updateKeywordRequestSchema', () => {
+  describe('updateKeywordSchema', () => {
     it('有効な名前を受け入れること', () => {
-      const validData = { name: 'Updated Name' }
-      expect(updateKeywordRequestSchema.parse(validData)).toEqual(validData)
+      const validData = { name: TEST_STRINGS.UPDATED_NAME }
+      expect(updateKeywordSchema.parse(validData)).toEqual(validData)
     })
 
     it('名前が空の場合にエラーになること', () => {
-      expect(() => updateKeywordRequestSchema.parse({ name: '' })).toThrow()
+      expect(() => updateKeywordSchema.parse({ name: '' })).toThrow()
     })
 
     it('名前が50文字を超える場合にエラーになること', () => {
       expect(() =>
-        updateKeywordRequestSchema.parse({ name: 'a'.repeat(51) }),
+        updateKeywordSchema.parse({ name: 'a'.repeat(51) }),
       ).toThrow()
+    })
+  })
+
+  describe('createKeywordSchema', () => {
+    it('有効な名前を受け入れること', () => {
+      const validData = { name: TEST_STRINGS.NEW_NAME }
+      expect(createKeywordSchema.parse(validData)).toEqual(validData)
     })
   })
 })

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -31,20 +31,20 @@ export const keywordsResponseSchema = z.object({
 export type KeywordsResponse = z.infer<typeof keywordsResponseSchema>
 
 /**
- * キーワード作成リクエストのバリデーションスキーマ
+ * キーワード作成のバリデーションスキーマ
  */
-export const createKeywordRequestSchema = z.object({
+export const createKeywordSchema = z.object({
   name: keywordNameSchema,
 })
-export type CreateKeywordRequest = z.infer<typeof createKeywordRequestSchema>
+export type CreateKeywordInput = z.infer<typeof createKeywordSchema>
 
 /**
- * キーワード更新リクエストのバリデーションスキーマ
+ * キーワード更新のバリデーションスキーマ
  */
-export const updateKeywordRequestSchema = z.object({
+export const updateKeywordSchema = z.object({
   name: keywordNameSchema,
 })
-export type UpdateKeywordRequest = z.infer<typeof updateKeywordRequestSchema>
+export type UpdateKeywordInput = z.infer<typeof updateKeywordSchema>
 
 /**
  * 単一キーワードのレスポンススキーマ

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -11,8 +11,8 @@ import type {
   KeywordId,
   KeywordResponse,
   KeywordsResponse,
-  CreateKeywordRequest,
-  UpdateKeywordRequest,
+  CreateKeywordInput,
+  UpdateKeywordInput,
 } from '@shared/schemas/keyword'
 
 import { useApi } from '../contexts/ApiContext'
@@ -207,7 +207,7 @@ export const useCreateKeyword = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (req: CreateKeywordRequest) => {
+    mutationFn: async (req: CreateKeywordInput) => {
       const res = await client.api.keywords.$post({
         json: req,
       })
@@ -233,7 +233,7 @@ export const useUpdateKeyword = () => {
       updates,
     }: {
       id: KeywordId
-      updates: UpdateKeywordRequest
+      updates: UpdateKeywordInput
     }) => {
       const res = await client.api.keywords[':id'].$patch({
         param: { id },


### PR DESCRIPTION
Issue #447 に対する実装です。

### 変更内容
- **命名規則の統一**: `shared/schemas/api.ts` 内の全てのスキーマ・型名から `Message` サフィックスを削除。
- **ドメインスキーマのリファクタリング**: `keyword.ts` の命名を `bookmark.ts` と統一し、名称衝突を解消。
- **リクエストユニオン型の導入**: 全てのリクエストスキーマを統合した `ApiRequest` 型を定義。将来のメッセージハンドラ（Dispatcher）での型安全な受信を容易にします。
- **既存コードの同期**: `extension/src/lib/idb.ts` および `server/` 等の参照箇所を全て更新済み。
- **テスト品質の維持**: 分割されたテストファイルにおいて、名称更新と定数利用（`MOCK_IDS`, `TEST_STRINGS`）を完全に同期。

これにより、Local-first メッセージング基盤がクリーンかつ堅牢な状態で完成しました。

Closes #447