### PR TITLE
[Shared] ブックマーク更新 (UPDATE_BOOKMARK) のスキーマ定義

### DIFF
--- a/shared/schemas/api-bookmark.test.ts
+++ b/shared/schemas/api-bookmark.test.ts
@@ -7,12 +7,15 @@ import {
   readBookmarksResponseSchema,
   createBookmarkRequestSchema,
   createBookmarkResponseSchema,
+  updateBookmarkRequestSchema,
+  updateBookmarkResponseSchema,
 } from './api'
 import {
   MOCK_BOOKMARKS,
   MOCK_BOOKMARK_1,
   VALID_URLS,
   TEST_STRINGS,
+  MOCK_IDS,
 } from '../test/fixtures'
 
 describe('API Schemas - Bookmark Operations', () => {
@@ -117,6 +120,98 @@ describe('API Schemas - Bookmark Operations', () => {
         },
       }
       expect(createBookmarkResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
+      )
+    })
+  })
+
+  describe('updateBookmarkRequestSchema', () => {
+    it('正しい UPDATE_BOOKMARK リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.UPDATE_BOOKMARK,
+        payload: {
+          id: MOCK_IDS.BOOKMARK_1,
+          title: TEST_STRINGS.UPDATED_NAME,
+          url: VALID_URLS.HTTPS,
+        },
+      }
+      expect(updateBookmarkRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('一部のフィールドのみの更新を受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.UPDATE_BOOKMARK,
+        payload: {
+          id: MOCK_IDS.BOOKMARK_1,
+          title: TEST_STRINGS.UPDATED_NAME,
+        },
+      }
+      expect(updateBookmarkRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('不正な形式の ID を拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.UPDATE_BOOKMARK,
+        payload: {
+          id: TEST_STRINGS.INVALID_ID,
+          title: TEST_STRINGS.UPDATED_NAME,
+        },
+      }
+      expect(() => updateBookmarkRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+
+    it('タイトルとURLが両方欠落している場合に拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.UPDATE_BOOKMARK,
+        payload: {
+          id: MOCK_IDS.BOOKMARK_1,
+        },
+      }
+      expect(() => updateBookmarkRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+
+    it('不正な URL 形式を拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.UPDATE_BOOKMARK,
+        payload: {
+          id: MOCK_IDS.BOOKMARK_1,
+          url: TEST_STRINGS.INVALID_ID,
+        },
+      }
+      expect(() => updateBookmarkRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+  })
+
+  describe('updateBookmarkResponseSchema', () => {
+    it('更新後のブックマーク詳細を含むレスポンスを検証できること', () => {
+      const validResponse = {
+        success: true,
+        data: MOCK_BOOKMARK_1,
+      }
+      expect(updateBookmarkResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+          code: ERROR_CODES.NOT_FOUND,
+        },
+      }
+      expect(updateBookmarkResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -2,9 +2,11 @@ import { z } from 'zod'
 
 import { API_ACTIONS, ERROR_CODES } from '../constants'
 import {
+  BookmarkIdSchema,
   bookmarkSchema,
   bookmarksSchema,
   createBookmarkInputSchema,
+  updateBookmarkInputSchema,
 } from './bookmark'
 import {
   createKeywordInputSchema,
@@ -167,6 +169,25 @@ export type CreateBookmarkResponse = z.infer<
 >
 
 /**
+ * ブックマーク更新 (UPDATE_BOOKMARK)
+ */
+export const updateBookmarkRequestSchema = baseApiRequestSchema.extend({
+  action: z.literal(API_ACTIONS.UPDATE_BOOKMARK),
+  payload: updateBookmarkInputSchema.extend({
+    id: BookmarkIdSchema,
+  }),
+})
+
+export type UpdateBookmarkRequest = z.infer<typeof updateBookmarkRequestSchema>
+
+export const updateBookmarkResponseSchema =
+  baseApiResponseSchema(bookmarkSchema)
+
+export type UpdateBookmarkResponse = z.infer<
+  typeof updateBookmarkResponseSchema
+>
+
+/**
  * 全てのメッセージリクエストを統合したディスクリミネイテッドユニオン型
  * action フィールドを識別子として使用し、パースの効率とエラーメッセージを改善
  */
@@ -177,6 +198,7 @@ export const ApiRequestSchema = z.discriminatedUnion('action', [
   deleteKeywordRequestSchema,
   readBookmarksRequestSchema,
   createBookmarkRequestSchema,
+  updateBookmarkRequestSchema,
 ])
 
 export type ApiRequest = z.infer<typeof ApiRequestSchema>

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -173,9 +173,7 @@ export type CreateBookmarkResponse = z.infer<
  */
 export const updateBookmarkRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.UPDATE_BOOKMARK),
-  payload: updateBookmarkInputSchema.extend({
-    id: BookmarkIdSchema,
-  }),
+  payload: z.object({ id: BookmarkIdSchema }).and(updateBookmarkInputSchema),
 })
 
 export type UpdateBookmarkRequest = z.infer<typeof updateBookmarkRequestSchema>


### PR DESCRIPTION
Issue #449 に対する実装です。

### 変更内容
- `shared/schemas/api.ts` に `updateBookmarkRequestSchema` および `updateBookmarkResponseSchema` を追加。
- 既存の `updateBookmarkSchema` および `BookmarkIdSchema` を活用し、メッセージング基盤（ディスクリミネイテッドユニオン）に統合。
- `shared/schemas/api-bookmark.test.ts` を更新し、正常系、部分更新、ID/URL不正などの異常系バリデーションを TDD で検証済み。
- ユーザー様の修正により、テストデータの定数化（`TEST_STRINGS` の活用）を徹底。

Closes #449