### PR TITLE
[Shared] 命名規則の体系的な統一 (Input/Requestの分離)

### DIFF
--- a/docs/design/naming-conventions.md
+++ b/docs/design/naming-conventions.md
@@ -23,34 +23,58 @@
 | **Entity** | DB保存形式（正規化済み） | `bookmarkEntitySchema` | `BookmarkEntity` | `shared/schemas/[domain].ts` |
 | **Object** | アプリ内形式（単体または集合） | `bookmarkSchema`<br>`bookmarksSchema` | `Bookmark`<br>`Bookmarks` | `shared/schemas/[domain].ts` |
 | **Input** | 処理の引数（データ部のみ） | `updateBookmarkInputSchema` | `UpdateBookmarkInput` | `shared/schemas/[domain].ts` |
-| **Request** | 通信の封筒（action付） | `readBookmarksRequestSchema` | `ReadBookmarksRequest` | `shared/schemas/api.ts` |
+| **Request** | 通信の封筒（action付） | `updateBookmarkRequestSchema` | `UpdateBookmarkRequest` | `shared/schemas/api.ts` |
 | **Response** | 通信の結果（共通形式） | `readBookmarksResponseSchema` | `ReadBookmarksResponse` | `shared/schemas/api.ts` |
 
-## 3. 具体的な適用例
+## 3. 共通基盤の構造 (`api.ts`)
 
-### ブックマーク取得 (READ_BOOKMARKS)
+全てのリクエスト・レスポンスは以下の基本構造に基づいています。
 
-1. **ドメイン層 (`bookmark.ts`)**
-   - データの集合としての形状を定義します。
-   - `bookmarksSchema` / `Bookmarks` (内容: `{ bookmarks: Bookmark[] }`)
+### BaseApiRequest
+通信の「封筒」の最小構造です。
+- `action`: `ApiAction` (操作を識別する定数)
+- `payload`: `unknown` (アクションごとの入力データ。オプション)
 
-2. **通信層 (`api.ts`)**
-   - ドメインの Object をレスポンスに包みます。
-   - `readBookmarksRequestSchema` / `ReadBookmarksRequest`
-   - `readBookmarksResponseSchema` / `ReadBookmarksResponse` (内容: `ApiResponse<Bookmarks>`)
-
-### ブックマーク更新 (UPDATE_BOOKMARK)
-
-1. **ドメイン層 (`bookmark.ts`)**
-   - 処理に必要なデータ（ペイロード）を定義します。
-   - `updateBookmarkInputSchema` / `UpdateBookmarkInput`
-
-2. **通信層 (`api.ts`)**
-   - ドメインの Input を封筒（Envelope）に包みます。
-   - `updateBookmarkRequestSchema` / `UpdateBookmarkRequest`
+### BaseApiResponse
+通信の「結果」を返す共通形式です。
+- `success`: `boolean` (成功か失敗か)
+- `data`: `T` (成功時のデータ。アクションごとに定義)
+- `error`: `{ message: string, code: string, details?: any }` (失敗時の詳細)
 
 ## 4. 運用ルール
 
 - **Response 名の独占**: `...ResponseSchema` という名称は **`shared/schemas/api.ts` でのみ使用** します。ドメイン層では `...Schema` (Object) を使用することで、インポート時の名称衝突を回避します。
 - **インポート**: `idb.ts` などの内部ロジックは `Input` / `Entity` を、メッセージ送信側は `Request` / `Response` を使用します。
 - **DRY原則**: `Request` や `Response` の定義には、必ずドメイン層のスキーマを再利用（`.extend()` や型引数への適用）します。
+
+## 5. ドメイン層名称マトリクス (`shared/schemas/[domain].ts`)
+
+| アクション | カテゴリ | ドメイン層スキーマ名 | データ構造 (主なプロパティ) |
+| :--- | :--- | :--- | :--- |
+| **キーワード取得** | Object | `keywordsSchema` | `{ keywords: KeywordWithCount[] }` |
+| **キーワード作成** | Input | `createKeywordInputSchema` | `{ name: string }` |
+| **キーワード更新** | Input | `updateKeywordInputSchema` | `{ name: string }` |
+| **キーワード削除** | Input | `deleteKeywordInputSchema` | `{ id: KeywordId }` |
+| **キーワード紐付け**| Input | `attachKeywordInputSchema` | `{ bookmarkId: BookmarkId, keywordId: KeywordId }` |
+| **キーワード解除** | Input | `detachKeywordInputSchema` | `{ bookmarkId: BookmarkId, keywordId: KeywordId }` |
+| **ブックマーク取得**| Object | `bookmarksSchema` | `{ bookmarks: Bookmark[] }` |
+| **ブックマーク追加**| Input | `createBookmarkInputSchema` | `{ title: string, url: string }` |
+| **ブックマーク更新**| Input | `updateBookmarkInputSchema` | `{ title?: string, url?: string }` |
+| **ブックマーク削除**| Input | `deleteBookmarkInputSchema` | `{ id: BookmarkId }` |
+| **ブックマーク並替**| Input | `reorderBookmarksInputSchema` | `{ ids: BookmarkId[] }` |
+
+## 6. 通信層名称マトリクス (`shared/schemas/api.ts`)
+
+| アクション | Request スキーマ名 | Request 構造 (BaseApiRequest + α) | Response (data 部) |
+| :--- | :--- | :--- | :--- |
+| **キーワード取得** | `readKeywordsRequestSchema` | `action: READ_KEYWORDS`, `payload: undefined` | `Keywords` |
+| **キーワード作成** | `createKeywordRequestSchema` | `action: CREATE_KEYWORD`, `payload: CreateKeywordInput` | `Keyword` |
+| **キーワード更新** | `updateKeywordRequestSchema` | `action: UPDATE_KEYWORD`, `payload: UpdateKeywordInput & { id: KeywordId }` | `Keyword` |
+| **キーワード削除** | `deleteKeywordRequestSchema` | `action: DELETE_KEYWORD`, `payload: DeleteKeywordInput` | `null` |
+| **キーワード紐付け**| `attachKeywordRequestSchema` | `action: ATTACH_KEYWORD`, `payload: AttachKeywordInput` | `null` |
+| **キーワード解除** | `detachKeywordRequestSchema` | `action: DETACH_KEYWORD`, `payload: DetachKeywordInput` | `null` |
+| **ブックマーク取得**| `readBookmarksRequestSchema` | `action: READ_BOOKMARKS`, `payload: undefined` | `Bookmarks` |
+| **ブックマーク追加**| `createBookmarkRequestSchema` | `action: CREATE_BOOKMARK`, `payload: CreateBookmarkInput` | `Bookmark` |
+| **ブックマーク更新**| `updateBookmarkRequestSchema` | `action: UPDATE_BOOKMARK`, `payload: UpdateBookmarkInput & { id: BookmarkId }` | `Bookmark` |
+| **ブックマーク削除**| `deleteBookmarkRequestSchema` | `action: DELETE_BOOKMARK`, `payload: DeleteBookmarkInput` | `null` |
+| **ブックマーク並替**| `reorderBookmarksRequestSchema` | `action: REORDER_BOOKMARKS`, `payload: ReorderBookmarksInput` | `null` |

--- a/docs/design/naming-conventions.md
+++ b/docs/design/naming-conventions.md
@@ -21,22 +21,23 @@
 | カテゴリ | 役割 | Zod スキーマ例 | TypeScript 型例 | 定義ファイル |
 | :--- | :--- | :--- | :--- | :--- |
 | **Entity** | DB保存形式（正規化済み） | `bookmarkEntitySchema` | `BookmarkEntity` | `shared/schemas/[domain].ts` |
-| **Object** | アプリ内形式（結合済み） | `bookmarkSchema` | `Bookmark` | `shared/schemas/[domain].ts` |
+| **Object** | アプリ内形式（単体または集合） | `bookmarkSchema`<br>`bookmarksSchema` | `Bookmark`<br>`Bookmarks` | `shared/schemas/[domain].ts` |
 | **Input** | 処理の引数（データ部のみ） | `updateBookmarkInputSchema` | `UpdateBookmarkInput` | `shared/schemas/[domain].ts` |
-| **Request** | 通信の封筒（action付） | `updateBookmarkRequestSchema` | `UpdateBookmarkRequest` | `shared/schemas/api.ts` |
-| **Response** | 通信の結果（共通形式） | `updateBookmarkResponseSchema` | `UpdateBookmarkResponse` | `shared/schemas/api.ts` |
+| **Request** | 通信の封筒（action付） | `readBookmarksRequestSchema` | `ReadBookmarksRequest` | `shared/schemas/api.ts` |
+| **Response** | 通信の結果（共通形式） | `readBookmarksResponseSchema` | `ReadBookmarksResponse` | `shared/schemas/api.ts` |
 
 ## 3. 具体的な適用例
 
 ### ブックマーク取得 (READ_BOOKMARKS)
 
 1. **ドメイン層 (`bookmark.ts`)**
-   - 取得結果の形状を定義します。
-   - `bookmarksResponseSchema` / `BookmarksResponse`
+   - データの集合としての形状を定義します。
+   - `bookmarksSchema` / `Bookmarks` (内容: `{ bookmarks: Bookmark[] }`)
 
 2. **通信層 (`api.ts`)**
-   - 取得要求（リクエスト）を定義します。
+   - ドメインの Object をレスポンスに包みます。
    - `readBookmarksRequestSchema` / `ReadBookmarksRequest`
+   - `readBookmarksResponseSchema` / `ReadBookmarksResponse` (内容: `ApiResponse<Bookmarks>`)
 
 ### ブックマーク更新 (UPDATE_BOOKMARK)
 
@@ -50,6 +51,6 @@
 
 ## 4. 運用ルール
 
-- **名称の重複禁止**: `api.ts` で定義する型は、ドメイン層の型と必ずサフィックス（`Input` vs `Request`）で区別できるようにします。
-- **インポート**: `idb.ts` などの内部ロジックは `Input` を、メッセージ送信側は `Request` を使用します。
-- **DRY原則**: `Request` の `payload` 定義には、必ずドメイン層の `Input` スキーマを `.extend()` または組み合わせる形で再利用します。
+- **Response 名の独占**: `...ResponseSchema` という名称は **`shared/schemas/api.ts` でのみ使用** します。ドメイン層では `...Schema` (Object) を使用することで、インポート時の名称衝突を回避します。
+- **インポート**: `idb.ts` などの内部ロジックは `Input` / `Entity` を、メッセージ送信側は `Request` / `Response` を使用します。
+- **DRY原則**: `Request` や `Response` の定義には、必ずドメイン層のスキーマを再利用（`.extend()` や型引数への適用）します。

--- a/docs/design/naming-conventions.md
+++ b/docs/design/naming-conventions.md
@@ -1,0 +1,55 @@
+# 命名規則ガイドライン (Schema & Types)
+
+本プロジェクトにおける Zod スキーマおよび TypeScript 型の命名規則を定義します。
+この規則は、ドメイン層（データ構造）と通信層（メッセージング）の分離を明確にし、名称の衝突を防ぐことを目的としています。
+
+## 1. 基本構成
+
+名称は以下のプレースホルダーを組み合わせて構成されます。
+
+`[Action][Name][Category][Suffix]`
+
+| プレースホルダー | 対象 | 具体的な値（CRUD準拠） |
+| :--- | :--- | :--- |
+| **`[Action]`** | 操作の動詞 | `read`, `create`, `update`, `delete`, `reorder`, `attach`, `detach` |
+| **`[Name]`** | ドメイン名 | `Bookmark`, `Keyword`, または共通基盤としての `BaseApi` |
+| **`[Category]`** | 役割カテゴリ | `Entity`, `Input`, `Request`, `Response` (後述) |
+| **`[Suffix]`** | 技術スタック | `Schema` (Zod スキーマの場合のみ付与) |
+
+## 2. 役割カテゴリと定義ファイル
+
+| カテゴリ | 役割 | Zod スキーマ例 | TypeScript 型例 | 定義ファイル |
+| :--- | :--- | :--- | :--- | :--- |
+| **Entity** | DB保存形式（正規化済み） | `bookmarkEntitySchema` | `BookmarkEntity` | `shared/schemas/[domain].ts` |
+| **Object** | アプリ内形式（結合済み） | `bookmarkSchema` | `Bookmark` | `shared/schemas/[domain].ts` |
+| **Input** | 処理の引数（データ部のみ） | `updateBookmarkInputSchema` | `UpdateBookmarkInput` | `shared/schemas/[domain].ts` |
+| **Request** | 通信の封筒（action付） | `updateBookmarkRequestSchema` | `UpdateBookmarkRequest` | `shared/schemas/api.ts` |
+| **Response** | 通信の結果（共通形式） | `updateBookmarkResponseSchema` | `UpdateBookmarkResponse` | `shared/schemas/api.ts` |
+
+## 3. 具体的な適用例
+
+### ブックマーク取得 (READ_BOOKMARKS)
+
+1. **ドメイン層 (`bookmark.ts`)**
+   - 取得結果の形状を定義します。
+   - `bookmarksResponseSchema` / `BookmarksResponse`
+
+2. **通信層 (`api.ts`)**
+   - 取得要求（リクエスト）を定義します。
+   - `readBookmarksRequestSchema` / `ReadBookmarksRequest`
+
+### ブックマーク更新 (UPDATE_BOOKMARK)
+
+1. **ドメイン層 (`bookmark.ts`)**
+   - 処理に必要なデータ（ペイロード）を定義します。
+   - `updateBookmarkInputSchema` / `UpdateBookmarkInput`
+
+2. **通信層 (`api.ts`)**
+   - ドメインの Input を封筒（Envelope）に包みます。
+   - `updateBookmarkRequestSchema` / `UpdateBookmarkRequest`
+
+## 4. 運用ルール
+
+- **名称の重複禁止**: `api.ts` で定義する型は、ドメイン層の型と必ずサフィックス（`Input` vs `Request`）で区別できるようにします。
+- **インポート**: `idb.ts` などの内部ロジックは `Input` を、メッセージ送信側は `Request` を使用します。
+- **DRY原則**: `Request` の `payload` 定義には、必ずドメイン層の `Input` スキーマを `.extend()` または組み合わせる形で再利用します。

--- a/docs/design/naming-conventions.md
+++ b/docs/design/naming-conventions.md
@@ -9,34 +9,38 @@
 
 `[Action][Name][Category][Suffix]`
 
-| プレースホルダー | 対象 | 具体的な値（CRUD準拠） |
-| :--- | :--- | :--- |
-| **`[Action]`** | 操作の動詞 | `read`, `create`, `update`, `delete`, `reorder`, `attach`, `detach` |
-| **`[Name]`** | ドメイン名 | `Bookmark`, `Keyword`, または共通基盤としての `BaseApi` |
-| **`[Category]`** | 役割カテゴリ | `Entity`, `Input`, `Request`, `Response` (後述) |
-| **`[Suffix]`** | 技術スタック | `Schema` (Zod スキーマの場合のみ付与) |
+| プレースホルダー | 対象         | 具体的な値（CRUD準拠）                                              |
+| :--------------- | :----------- | :------------------------------------------------------------------ |
+| **`[Action]`**   | 操作の動詞   | `read`, `create`, `update`, `delete`, `reorder`, `attach`, `detach` |
+| **`[Name]`**     | ドメイン名   | `Bookmark`, `Keyword`, または共通基盤としての `BaseApi`             |
+| **`[Category]`** | 役割カテゴリ | `Entity`, `Object`, `Input`, `Request`, `Response`                  |
+| **`[Suffix]`**   | 技術スタック | `Schema` (Zod スキーマの場合のみ付与)                               |
 
 ## 2. 役割カテゴリと定義ファイル
 
-| カテゴリ | 役割 | Zod スキーマ例 | TypeScript 型例 | 定義ファイル |
-| :--- | :--- | :--- | :--- | :--- |
-| **Entity** | DB保存形式（正規化済み） | `bookmarkEntitySchema` | `BookmarkEntity` | `shared/schemas/[domain].ts` |
-| **Object** | アプリ内形式（単体または集合） | `bookmarkSchema`<br>`bookmarksSchema` | `Bookmark`<br>`Bookmarks` | `shared/schemas/[domain].ts` |
-| **Input** | 処理の引数（データ部のみ） | `updateBookmarkInputSchema` | `UpdateBookmarkInput` | `shared/schemas/[domain].ts` |
-| **Request** | 通信の封筒（action付） | `updateBookmarkRequestSchema` | `UpdateBookmarkRequest` | `shared/schemas/api.ts` |
-| **Response** | 通信の結果（共通形式） | `readBookmarksResponseSchema` | `ReadBookmarksResponse` | `shared/schemas/api.ts` |
+| カテゴリ     | 役割                           | Zod スキーマ例                        | TypeScript 型例           | 定義ファイル                 |
+| :----------- | :----------------------------- | :------------------------------------ | :------------------------ | :--------------------------- |
+| **Entity**   | DB保存形式（正規化済み）       | `bookmarkEntitySchema`                | `BookmarkEntity`          | `shared/schemas/[domain].ts` |
+| **Object**   | アプリ内形式（単体または集合） | `bookmarkSchema`<br>`bookmarksSchema` | `Bookmark`<br>`Bookmarks` | `shared/schemas/[domain].ts` |
+| **Input**    | 処理の引数（データ部のみ）     | `updateBookmarkInputSchema`           | `UpdateBookmarkInput`     | `shared/schemas/[domain].ts` |
+| **Request**  | 通信の封筒（action付）         | `updateBookmarkRequestSchema`         | `UpdateBookmarkRequest`   | `shared/schemas/api.ts`      |
+| **Response** | 通信の結果（共通形式）         | `readBookmarksResponseSchema`         | `ReadBookmarksResponse`   | `shared/schemas/api.ts`      |
 
 ## 3. 共通基盤の構造 (`api.ts`)
 
 全てのリクエスト・レスポンスは以下の基本構造に基づいています。
 
 ### BaseApiRequest
+
 通信の「封筒」の最小構造です。
+
 - `action`: `ApiAction` (操作を識別する定数)
 - `payload`: `unknown` (アクションごとの入力データ。オプション)
 
 ### BaseApiResponse
+
 通信の「結果」を返す共通形式です。
+
 - `success`: `boolean` (成功か失敗か)
 - `data`: `T` (成功時のデータ。アクションごとに定義)
 - `error`: `{ message: string, code: string, details?: any }` (失敗時の詳細)
@@ -49,32 +53,34 @@
 
 ## 5. ドメイン層名称マトリクス (`shared/schemas/[domain].ts`)
 
-| アクション | カテゴリ | ドメイン層スキーマ名 | データ構造 (主なプロパティ) |
-| :--- | :--- | :--- | :--- |
-| **キーワード取得** | Object | `keywordsSchema` | `{ keywords: KeywordWithCount[] }` |
-| **キーワード作成** | Input | `createKeywordInputSchema` | `{ name: string }` |
-| **キーワード更新** | Input | `updateKeywordInputSchema` | `{ name: string }` |
-| **キーワード削除** | Input | `deleteKeywordInputSchema` | `{ id: KeywordId }` |
-| **キーワード紐付け**| Input | `attachKeywordInputSchema` | `{ bookmarkId: BookmarkId, keywordId: KeywordId }` |
-| **キーワード解除** | Input | `detachKeywordInputSchema` | `{ bookmarkId: BookmarkId, keywordId: KeywordId }` |
-| **ブックマーク取得**| Object | `bookmarksSchema` | `{ bookmarks: Bookmark[] }` |
-| **ブックマーク追加**| Input | `createBookmarkInputSchema` | `{ title: string, url: string }` |
-| **ブックマーク更新**| Input | `updateBookmarkInputSchema` | `{ title?: string, url?: string }` |
-| **ブックマーク削除**| Input | `deleteBookmarkInputSchema` | `{ id: BookmarkId }` |
-| **ブックマーク並替**| Input | `reorderBookmarksInputSchema` | `{ ids: BookmarkId[] }` |
+| アクション           | カテゴリ | ドメイン層スキーマ名          | データ構造 (主なプロパティ)                        |
+| :------------------- | :------- | :---------------------------- | :------------------------------------------------- |
+| **キーワード取得**   | Object   | `keywordsSchema`              | `{ keywords: KeywordWithCount[] }`                 |
+| **キーワード作成**   | Input    | `createKeywordInputSchema`    | `{ name: string }`                                 |
+| **キーワード更新**   | Input    | `updateKeywordInputSchema`    | `{ name: string }`                                 |
+| **キーワード削除**   | Input    | `deleteKeywordInputSchema`    | `{ id: KeywordId }`                                |
+| **キーワード紐付け** | Input    | `attachKeywordInputSchema`    | `{ bookmarkId: BookmarkId, keywordId: KeywordId }` |
+| **キーワード解除**   | Input    | `detachKeywordInputSchema`    | `{ bookmarkId: BookmarkId, keywordId: KeywordId }` |
+| **ブックマーク取得** | Object   | `bookmarksSchema`             | `{ bookmarks: Bookmark[] }`                        |
+| **ブックマーク追加** | Input    | `createBookmarkInputSchema`   | `{ title: string, url: string }`                   |
+| **ブックマーク更新** | Input    | `updateBookmarkInputSchema`   | `{ title?: string, url?: string }`                 |
+| **ブックマーク削除** | Input    | `deleteBookmarkInputSchema`   | `{ id: BookmarkId }`                               |
+| **ブックマーク並替** | Input    | `reorderBookmarksInputSchema` | `{ ids: BookmarkId[] }`                            |
 
 ## 6. 通信層名称マトリクス (`shared/schemas/api.ts`)
 
-| アクション | Request スキーマ名 | Request 構造 (BaseApiRequest + α) | Response (data 部) |
-| :--- | :--- | :--- | :--- |
-| **キーワード取得** | `readKeywordsRequestSchema` | `action: READ_KEYWORDS`, `payload: undefined` | `Keywords` |
-| **キーワード作成** | `createKeywordRequestSchema` | `action: CREATE_KEYWORD`, `payload: CreateKeywordInput` | `Keyword` |
-| **キーワード更新** | `updateKeywordRequestSchema` | `action: UPDATE_KEYWORD`, `payload: UpdateKeywordInput & { id: KeywordId }` | `Keyword` |
-| **キーワード削除** | `deleteKeywordRequestSchema` | `action: DELETE_KEYWORD`, `payload: DeleteKeywordInput` | `null` |
-| **キーワード紐付け**| `attachKeywordRequestSchema` | `action: ATTACH_KEYWORD`, `payload: AttachKeywordInput` | `null` |
-| **キーワード解除** | `detachKeywordRequestSchema` | `action: DETACH_KEYWORD`, `payload: DetachKeywordInput` | `null` |
-| **ブックマーク取得**| `readBookmarksRequestSchema` | `action: READ_BOOKMARKS`, `payload: undefined` | `Bookmarks` |
-| **ブックマーク追加**| `createBookmarkRequestSchema` | `action: CREATE_BOOKMARK`, `payload: CreateBookmarkInput` | `Bookmark` |
-| **ブックマーク更新**| `updateBookmarkRequestSchema` | `action: UPDATE_BOOKMARK`, `payload: UpdateBookmarkInput & { id: BookmarkId }` | `Bookmark` |
-| **ブックマーク削除**| `deleteBookmarkRequestSchema` | `action: DELETE_BOOKMARK`, `payload: DeleteBookmarkInput` | `null` |
-| **ブックマーク並替**| `reorderBookmarksRequestSchema` | `action: REORDER_BOOKMARKS`, `payload: ReorderBookmarksInput` | `null` |
+通信層のスキーマは、全て `BaseApiRequest` または共通レスポンス形式をベースに構成されます。
+
+| アクション           | Request スキーマ名              | Request 構造 (BaseApiRequest + α)                                              | Response (data 部) |
+| :------------------- | :------------------------------ | :----------------------------------------------------------------------------- | :----------------- |
+| **キーワード取得**   | `readKeywordsRequestSchema`     | `action: READ_KEYWORDS`, `payload: undefined`                                  | `Keywords`         |
+| **キーワード作成**   | `createKeywordRequestSchema`    | `action: CREATE_KEYWORD`, `payload: CreateKeywordInput`                        | `Keyword`          |
+| **キーワード更新**   | `updateKeywordRequestSchema`    | `action: UPDATE_KEYWORD`, `payload: UpdateKeywordInput & { id: KeywordId }`    | `Keyword`          |
+| **キーワード削除**   | `deleteKeywordRequestSchema`    | `action: DELETE_KEYWORD`, `payload: DeleteKeywordInput`                        | `null`             |
+| **キーワード紐付け** | `attachKeywordRequestSchema`    | `action: ATTACH_KEYWORD`, `payload: AttachKeywordInput`                        | `null`             |
+| **キーワード解除**   | `detachKeywordRequestSchema`    | `action: DETACH_KEYWORD`, `payload: DetachKeywordInput`                        | `null`             |
+| **ブックマーク取得** | `readBookmarksRequestSchema`    | `action: READ_BOOKMARKS`, `payload: undefined`                                 | `Bookmarks`        |
+| **ブックマーク追加** | `createBookmarkRequestSchema`   | `action: CREATE_BOOKMARK`, `payload: CreateBookmarkInput`                      | `Bookmark`         |
+| **ブックマーク更新** | `updateBookmarkRequestSchema`   | `action: UPDATE_BOOKMARK`, `payload: UpdateBookmarkInput & { id: BookmarkId }` | `Bookmark`         |
+| **ブックマーク削除** | `deleteBookmarkRequestSchema`   | `action: DELETE_BOOKMARK`, `payload: DeleteBookmarkInput`                      | `null`             |
+| **ブックマーク並替** | `reorderBookmarksRequestSchema` | `action: REORDER_BOOKMARKS`, `payload: ReorderBookmarksInput`                  | `null`             |

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -8,7 +8,7 @@ import {
   STORAGE_KEYS,
   LOG_MESSAGES,
 } from '@shared/constants'
-import type { BookmarksResponse } from '@shared/schemas/bookmark'
+import type { Bookmarks } from '@shared/schemas/bookmark'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
 
 import {
@@ -42,7 +42,7 @@ const getBookmarksData = async (apiUrl: string) => {
 
   const sanitizedBaseUrl = getOrigin(apiUrl)
 
-  return await queryClient.fetchQuery<BookmarksResponse>({
+  return await queryClient.fetchQuery<Bookmarks>({
     queryKey: [...QUERY_KEYS.BOOKMARKS.ALL, sanitizedBaseUrl],
     queryFn: async () => {
       const res = await fetch(`${sanitizedBaseUrl}/api/bookmarks`)

--- a/extension/src/hooks/useOptions.ts
+++ b/extension/src/hooks/useOptions.ts
@@ -13,7 +13,7 @@ import {
   UI_STATUS,
   type StatusInfo,
 } from '@shared/constants'
-import { bookmarksResponseSchema } from '@shared/schemas/bookmark'
+import { bookmarksSchema } from '@shared/schemas/bookmark'
 import { validateApiUrl, validateUrl, getOrigin } from '@shared/utils/url'
 
 import { storage } from '../lib/storage'
@@ -24,7 +24,7 @@ const DEFAULT_SETTINGS = {
 }
 
 // レスポンス全体のスキーマを定義
-const apiResponseSchema = bookmarksResponseSchema
+const apiResponseSchema = bookmarksSchema
 
 export const useOptions = () => {
   const [apiUrl, setApiUrl] = useState('')

--- a/extension/src/hooks/usePopup.ts
+++ b/extension/src/hooks/usePopup.ts
@@ -14,7 +14,7 @@ import {
   EXTENSION_MESSAGE_TYPES,
   type StatusInfo,
 } from '@shared/constants'
-import { createBookmarkSchema } from '@shared/schemas/bookmark'
+import { createBookmarkInputSchema } from '@shared/schemas/bookmark'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
 
 import { storage } from '../lib/storage'
@@ -76,7 +76,7 @@ export const usePopup = () => {
   const handleSave = useCallback(async () => {
     setStatus({ type: UI_STATUS.LOADING, message: COMMON_MESSAGES.SAVING })
 
-    const validation = createBookmarkSchema.safeParse({ title, url })
+    const validation = createBookmarkInputSchema.safeParse({ title, url })
     if (!validation.success) {
       setStatus({
         type: UI_STATUS.ERROR,

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -8,8 +8,8 @@ import {
   BookmarkIdSchema,
   createBookmarkInputSchema,
   type CreateBookmarkInput,
-  updateBookmarkSchema,
-  type UpdateBookmarkRequest,
+  updateBookmarkInputSchema,
+  type UpdateBookmarkInput,
   reorderBookmarksSchema,
 } from '@shared/schemas/bookmark'
 import {
@@ -101,12 +101,12 @@ export class BookmarkDatabase extends Dexie {
    */
   async updateBookmark(
     id: BookmarkId,
-    updates: UpdateBookmarkRequest,
+    updates: UpdateBookmarkInput,
   ): Promise<void> {
     // ID のバリデーション
     const validatedId = BookmarkIdSchema.parse(id)
     // 更新内容のバリデーション
-    const validated = updateBookmarkSchema.parse(updates)
+    const validated = updateBookmarkInputSchema.parse(updates)
 
     const updatedCount = await this.bookmarks.update(validatedId, validated)
     if (updatedCount === 0) {

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -6,8 +6,8 @@ import {
   type BookmarkEntity,
   type BookmarkId,
   BookmarkIdSchema,
-  createBookmarkSchema,
-  type CreateBookmarkRequest,
+  createBookmarkInputSchema,
+  type CreateBookmarkInput,
   updateBookmarkSchema,
   type UpdateBookmarkRequest,
   reorderBookmarksSchema,
@@ -73,9 +73,9 @@ export class BookmarkDatabase extends Dexie {
   /**
    * ブックマークを追加する
    */
-  async addBookmark(params: CreateBookmarkRequest): Promise<BookmarkId> {
+  async addBookmark(params: CreateBookmarkInput): Promise<BookmarkId> {
     // バリデーションにプロジェクト標準のスキーマを使用
-    const validated = createBookmarkSchema.parse(params)
+    const validated = createBookmarkInputSchema.parse(params)
 
     return await this.transaction('rw', this.bookmarks, async () => {
       // 現在の最小 sortOrder を取得
@@ -120,26 +120,30 @@ export class BookmarkDatabase extends Dexie {
   async deleteBookmark(id: BookmarkId): Promise<void> {
     const validatedId = BookmarkIdSchema.parse(id)
 
-    return await this.transaction('rw', [this.bookmarks, this.keywords], async () => {
-      // 存在確認
-      const bookmark = await this.bookmarks.get(validatedId)
-      if (!bookmark) {
-        throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
-      }
+    return await this.transaction(
+      'rw',
+      [this.bookmarks, this.keywords],
+      async () => {
+        // 存在確認
+        const bookmark = await this.bookmarks.get(validatedId)
+        if (!bookmark) {
+          throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+        }
 
-      // ブックマークを削除
-      await this.bookmarks.delete(validatedId)
+        // ブックマークを削除
+        await this.bookmarks.delete(validatedId)
 
-      // 紐付いていた各キーワードの統計情報を更新 (カウントダウン)
-      if (bookmark.keywordIds.length > 0) {
-        await this.keywords
-          .where('id')
-          .anyOf(bookmark.keywordIds)
-          .modify((kw) => {
-            kw.bookmarkCount = Math.max(0, kw.bookmarkCount - 1)
-          })
-      }
-    })
+        // 紐付いていた各キーワードの統計情報を更新 (カウントダウン)
+        if (bookmark.keywordIds.length > 0) {
+          await this.keywords
+            .where('id')
+            .anyOf(bookmark.keywordIds)
+            .modify((kw) => {
+              kw.bookmarkCount = Math.max(0, kw.bookmarkCount - 1)
+            })
+        }
+      },
+    )
   }
 
   /**
@@ -179,75 +183,89 @@ export class BookmarkDatabase extends Dexie {
   /**
    * ブックマークにキーワードを紐付ける
    */
-  async attachKeyword(bookmarkId: BookmarkId, keywordId: KeywordId): Promise<void> {
+  async attachKeyword(
+    bookmarkId: BookmarkId,
+    keywordId: KeywordId,
+  ): Promise<void> {
     // ID のバリデーション
     const vBookmarkId = BookmarkIdSchema.parse(bookmarkId)
     const vKeywordId = KeywordIdSchema.parse(keywordId)
 
-    return await this.transaction('rw', [this.bookmarks, this.keywords], async () => {
-      // 存在確認
-      const bookmark = await this.bookmarks.get(vBookmarkId)
-      if (!bookmark) {
-        throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
-      }
+    return await this.transaction(
+      'rw',
+      [this.bookmarks, this.keywords],
+      async () => {
+        // 存在確認
+        const bookmark = await this.bookmarks.get(vBookmarkId)
+        if (!bookmark) {
+          throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+        }
 
-      const keyword = await this.keywords.get(vKeywordId)
-      if (!keyword) {
-        throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
-      }
+        const keyword = await this.keywords.get(vKeywordId)
+        if (!keyword) {
+          throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
+        }
 
-      // 既に紐付けられているか確認
-      if (bookmark.keywordIds.includes(vKeywordId)) {
-        return
-      }
+        // 既に紐付けられているか確認
+        if (bookmark.keywordIds.includes(vKeywordId)) {
+          return
+        }
 
-      // 紐付け追加
-      await this.bookmarks.update(vBookmarkId, {
-        keywordIds: [...bookmark.keywordIds, vKeywordId],
-      })
+        // 紐付け追加
+        await this.bookmarks.update(vBookmarkId, {
+          keywordIds: [...bookmark.keywordIds, vKeywordId],
+        })
 
-      // キーワード側の統計情報を更新 (カウントアップ)
-      await this.keywords.update(vKeywordId, {
-        bookmarkCount: keyword.bookmarkCount + 1,
-      })
-    })
+        // キーワード側の統計情報を更新 (カウントアップ)
+        await this.keywords.update(vKeywordId, {
+          bookmarkCount: keyword.bookmarkCount + 1,
+        })
+      },
+    )
   }
 
   /**
    * ブックマークからキーワードを解除する
    */
-  async detachKeyword(bookmarkId: BookmarkId, keywordId: KeywordId): Promise<void> {
+  async detachKeyword(
+    bookmarkId: BookmarkId,
+    keywordId: KeywordId,
+  ): Promise<void> {
     // ID のバリデーション
     const vBookmarkId = BookmarkIdSchema.parse(bookmarkId)
     const vKeywordId = KeywordIdSchema.parse(keywordId)
 
-    return await this.transaction('rw', [this.bookmarks, this.keywords], async () => {
-      // 存在確認
-      const bookmark = await this.bookmarks.get(vBookmarkId)
-      if (!bookmark) {
-        throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
-      }
+    return await this.transaction(
+      'rw',
+      [this.bookmarks, this.keywords],
+      async () => {
+        // 存在確認
+        const bookmark = await this.bookmarks.get(vBookmarkId)
+        if (!bookmark) {
+          throw new Error(ERROR_MESSAGES.BOOKMARK_NOT_FOUND)
+        }
 
-      const keyword = await this.keywords.get(vKeywordId)
-      if (!keyword) {
-        throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
-      }
+        const keyword = await this.keywords.get(vKeywordId)
+        if (!keyword) {
+          throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
+        }
 
-      // 紐付けられていない場合は何もしない
-      if (!bookmark.keywordIds.includes(vKeywordId)) {
-        return
-      }
+        // 紐付けられていない場合は何もしない
+        if (!bookmark.keywordIds.includes(vKeywordId)) {
+          return
+        }
 
-      // 紐付け解除
-      await this.bookmarks.update(vBookmarkId, {
-        keywordIds: bookmark.keywordIds.filter((id) => id !== vKeywordId),
-      })
+        // 紐付け解除
+        await this.bookmarks.update(vBookmarkId, {
+          keywordIds: bookmark.keywordIds.filter((id) => id !== vKeywordId),
+        })
 
-      // キーワード側の統計情報を更新 (カウントダウン)
-      await this.keywords.update(vKeywordId, {
-        bookmarkCount: Math.max(0, keyword.bookmarkCount - 1),
-      })
-    })
+        // キーワード側の統計情報を更新 (カウントダウン)
+        await this.keywords.update(vKeywordId, {
+          bookmarkCount: Math.max(0, keyword.bookmarkCount - 1),
+        })
+      },
+    )
   }
 
   /**
@@ -266,7 +284,10 @@ export class BookmarkDatabase extends Dexie {
     const name = keywordSchema.shape.name.parse(params.name)
 
     // 重複チェック
-    const existing = await this.keywords.where('name').equalsIgnoreCase(name).first()
+    const existing = await this.keywords
+      .where('name')
+      .equalsIgnoreCase(name)
+      .first()
     if (existing) {
       return existing.id
     }
@@ -322,24 +343,30 @@ export class BookmarkDatabase extends Dexie {
     // ID のバリデーション
     const validatedId = KeywordIdSchema.parse(id)
 
-    return await this.transaction('rw', [this.keywords, this.bookmarks], async () => {
-      // 存在確認
-      const existing = await this.keywords.get(validatedId)
-      if (!existing) {
-        throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
-      }
+    return await this.transaction(
+      'rw',
+      [this.keywords, this.bookmarks],
+      async () => {
+        // 存在確認
+        const existing = await this.keywords.get(validatedId)
+        if (!existing) {
+          throw new Error(ERROR_MESSAGES.KEYWORD_NOT_FOUND)
+        }
 
-      // キーワード自体を削除
-      await this.keywords.delete(validatedId)
+        // キーワード自体を削除
+        await this.keywords.delete(validatedId)
 
-      // 関連するブックマークからキーワード ID を除去
-      await this.bookmarks
-        .where('keywordIds')
-        .equals(validatedId)
-        .modify((bookmark) => {
-          bookmark.keywordIds = bookmark.keywordIds.filter((kId) => kId !== validatedId)
-        })
-    })
+        // 関連するブックマークからキーワード ID を除去
+        await this.bookmarks
+          .where('keywordIds')
+          .equals(validatedId)
+          .modify((bookmark) => {
+            bookmark.keywordIds = bookmark.keywordIds.filter(
+              (kId) => kId !== validatedId,
+            )
+          })
+      },
+    )
   }
 }
 

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -10,7 +10,7 @@ import {
   type CreateBookmarkInput,
   updateBookmarkInputSchema,
   type UpdateBookmarkInput,
-  reorderBookmarksSchema,
+  reorderBookmarksInputSchema,
 } from '@shared/schemas/bookmark'
 import {
   type KeywordId,
@@ -151,7 +151,7 @@ export class BookmarkDatabase extends Dexie {
    */
   async reorderBookmarks(ids: BookmarkId[]): Promise<void> {
     // バリデーション
-    const validatedIds = reorderBookmarksSchema.parse({ ids }).ids
+    const validatedIds = reorderBookmarksInputSchema.parse({ ids }).ids
 
     return await this.transaction('rw', this.bookmarks, async () => {
       // 全ての ID が存在するか、件数をチェック

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -8,7 +8,7 @@ import {
   BookmarkIdSchema,
   KeywordIdSchema,
   bookmarksResponseSchema,
-  createBookmarkSchema,
+  createBookmarkInputSchema,
   updateBookmarkSchema,
   reorderBookmarksSchema,
   type Bookmark,
@@ -80,7 +80,7 @@ const bookmarksRoute = new Hono()
       throw error // Global handler will catch this
     }
   })
-  .post('/', zValidator('json', createBookmarkSchema), async (c) => {
+  .post('/', zValidator('json', createBookmarkInputSchema), async (c) => {
     const { title, url } = c.req.valid('json')
 
     try {

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -10,7 +10,7 @@ import {
   bookmarksSchema,
   createBookmarkInputSchema,
   updateBookmarkInputSchema,
-  reorderBookmarksSchema,
+  reorderBookmarksInputSchema,
   type Bookmark,
 } from '@shared/schemas/bookmark'
 import { attachKeywordRequestSchema } from '@shared/schemas/keyword'
@@ -220,38 +220,42 @@ const bookmarksRoute = new Hono()
       }
     },
   )
-  .put('/reorder', zValidator('json', reorderBookmarksSchema), async (c) => {
-    const { ids } = c.req.valid('json')
+  .put(
+    '/reorder',
+    zValidator('json', reorderBookmarksInputSchema),
+    async (c) => {
+      const { ids } = c.req.valid('json')
 
-    if (ids.length === 0) {
-      return c.json({ success: true, data: null })
-    }
+      if (ids.length === 0) {
+        return c.json({ success: true, data: null })
+      }
 
-    try {
-      const numericIds = ids.map((id) => parseInt(id, 10))
+      try {
+        const numericIds = ids.map((id) => parseInt(id, 10))
 
-      // CASE WHEN 構文を組み立てて一括更新
-      const cases = numericIds.map(
-        (id, index) =>
-          sql`WHEN ${bookmarksTable.bookmarkId} = ${id} THEN ${index}`,
-      )
+        // CASE WHEN 構文を組み立てて一括更新
+        const cases = numericIds.map(
+          (id, index) =>
+            sql`WHEN ${bookmarksTable.bookmarkId} = ${id} THEN ${index}`,
+        )
 
-      await db
-        .update(bookmarksTable)
-        .set({
-          sortOrder: sql`CASE ${sql.join(cases, sql` `)} END`,
+        await db
+          .update(bookmarksTable)
+          .set({
+            sortOrder: sql`CASE ${sql.join(cases, sql` `)} END`,
+          })
+          .where(inArray(bookmarksTable.bookmarkId, numericIds))
+
+        return c.json({
+          success: true,
+          data: null,
         })
-        .where(inArray(bookmarksTable.bookmarkId, numericIds))
-
-      return c.json({
-        success: true,
-        data: null,
-      })
-    } catch (error) {
-      console.error(LOG_MESSAGES.REORDER_FAILED_CONSOLE, error)
-      throw error
-    }
-  })
+      } catch (error) {
+        console.error(LOG_MESSAGES.REORDER_FAILED_CONSOLE, error)
+        throw error
+      }
+    },
+  )
   .post(
     '/:id/keywords',
     zValidator('param', z.object({ id: z.string().regex(/^[1-9]\d*$/) })),

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -7,7 +7,7 @@ import { ERROR_MESSAGES, LOG_MESSAGES, HTTP_STATUS } from '@shared/constants'
 import {
   BookmarkIdSchema,
   KeywordIdSchema,
-  bookmarksResponseSchema,
+  bookmarksSchema,
   createBookmarkInputSchema,
   updateBookmarkInputSchema,
   reorderBookmarksSchema,
@@ -70,7 +70,7 @@ const bookmarksRoute = new Hono()
 
       const bookmarks = rows.map(toBookmarkDto)
 
-      const result = bookmarksResponseSchema.parse({ bookmarks })
+      const result = bookmarksSchema.parse({ bookmarks })
       return c.json({
         success: true,
         data: result,

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -9,7 +9,7 @@ import {
   KeywordIdSchema,
   bookmarksResponseSchema,
   createBookmarkInputSchema,
-  updateBookmarkSchema,
+  updateBookmarkInputSchema,
   reorderBookmarksSchema,
   type Bookmark,
 } from '@shared/schemas/bookmark'
@@ -157,7 +157,7 @@ const bookmarksRoute = new Hono()
   .patch(
     '/:id',
     zValidator('param', z.object({ id: z.string().regex(/^[1-9]\d*$/) })),
-    zValidator('json', updateBookmarkSchema),
+    zValidator('json', updateBookmarkInputSchema),
     async (c) => {
       const { id } = c.req.valid('param')
       const bookmarkId = parseInt(id, 10)

--- a/server/routes/bookmarks.ts
+++ b/server/routes/bookmarks.ts
@@ -13,7 +13,7 @@ import {
   reorderBookmarksInputSchema,
   type Bookmark,
 } from '@shared/schemas/bookmark'
-import { attachKeywordRequestSchema } from '@shared/schemas/keyword'
+import { attachKeywordInputSchema } from '@shared/schemas/keyword'
 
 import { db } from '../db'
 import {
@@ -259,7 +259,7 @@ const bookmarksRoute = new Hono()
   .post(
     '/:id/keywords',
     zValidator('param', z.object({ id: z.string().regex(/^[1-9]\d*$/) })),
-    zValidator('json', attachKeywordRequestSchema),
+    zValidator('json', attachKeywordInputSchema),
     async (c) => {
       const { id } = c.req.valid('param')
       const { keywordId } = c.req.valid('json')

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 
 import { ERROR_MESSAGES, HTTP_STATUS, LOG_MESSAGES } from '@shared/constants'
 import {
-  createKeywordSchema,
+  createKeywordInputSchema,
   KeywordIdSchema,
   keywordResponseSchema,
   keywordsResponseSchema,
@@ -51,7 +51,7 @@ const keywordsRoute = new Hono()
       throw error
     }
   })
-  .post('/', zValidator('json', createKeywordSchema), async (c) => {
+  .post('/', zValidator('json', createKeywordInputSchema), async (c) => {
     const { name } = c.req.valid('json')
 
     try {

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -8,7 +8,7 @@ import {
   createKeywordInputSchema,
   KeywordIdSchema,
   keywordResponseSchema,
-  keywordsResponseSchema,
+  keywordsSchema,
   updateKeywordSchema,
 } from '@shared/schemas/keyword'
 
@@ -41,7 +41,7 @@ const keywordsRoute = new Hono()
         bookmarkCount: row.bookmarkCount,
       }))
 
-      const result = keywordsResponseSchema.parse({ keywords })
+      const result = keywordsSchema.parse({ keywords })
       return c.json({
         success: true,
         data: result,

--- a/server/routes/keywords.ts
+++ b/server/routes/keywords.ts
@@ -9,7 +9,7 @@ import {
   KeywordIdSchema,
   keywordResponseSchema,
   keywordsSchema,
-  updateKeywordSchema,
+  updateKeywordInputSchema,
 } from '@shared/schemas/keyword'
 
 import { db } from '../db'
@@ -106,7 +106,7 @@ const keywordsRoute = new Hono()
   .patch(
     '/:id',
     zValidator('param', z.object({ id: KeywordIdSchema })),
-    zValidator('json', updateKeywordSchema),
+    zValidator('json', updateKeywordInputSchema),
     async (c) => {
       const { id } = c.req.valid('param')
       const { name } = c.req.valid('json')

--- a/shared/schemas/api-bookmark.test.ts
+++ b/shared/schemas/api-bookmark.test.ts
@@ -5,8 +5,8 @@ import { API_ACTIONS, ERROR_MESSAGES, ERROR_CODES } from '../constants'
 import {
   readBookmarksRequestSchema,
   readBookmarksResponseSchema,
-  addBookmarkRequestSchema,
-  addBookmarkResponseSchema,
+  createBookmarkRequestSchema,
+  createBookmarkResponseSchema,
 } from './api'
 import {
   MOCK_BOOKMARKS,
@@ -57,7 +57,7 @@ describe('API Schemas - Bookmark Operations', () => {
     })
   })
 
-  describe('addBookmarkRequestSchema', () => {
+  describe('createBookmarkRequestSchema', () => {
     it('正しい ADD_BOOKMARK リクエストを受け入れること', () => {
       const validRequest = {
         action: API_ACTIONS.ADD_BOOKMARK,
@@ -66,7 +66,9 @@ describe('API Schemas - Bookmark Operations', () => {
           url: VALID_URLS.GOOGLE,
         },
       }
-      expect(addBookmarkRequestSchema.parse(validRequest)).toEqual(validRequest)
+      expect(createBookmarkRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
     })
 
     it('不正な形式のペイロード（空タイトル）を拒否すること', () => {
@@ -77,7 +79,7 @@ describe('API Schemas - Bookmark Operations', () => {
           url: VALID_URLS.GOOGLE,
         },
       }
-      expect(() => addBookmarkRequestSchema.parse(invalidRequest)).toThrow(
+      expect(() => createBookmarkRequestSchema.parse(invalidRequest)).toThrow(
         ZodError,
       )
     })
@@ -90,18 +92,18 @@ describe('API Schemas - Bookmark Operations', () => {
           url: VALID_URLS.GOOGLE,
         },
       }
-      const validated = addBookmarkRequestSchema.parse(request)
+      const validated = createBookmarkRequestSchema.parse(request)
       expect(validated.payload.title).toBe(TEST_STRINGS.TRIMMED_NAME)
     })
   })
 
-  describe('addBookmarkResponseSchema', () => {
+  describe('createBookmarkResponseSchema', () => {
     it('追加されたブックマーク詳細を含むレスポンスを検証できること', () => {
       const validResponse = {
         success: true,
         data: MOCK_BOOKMARK_1,
       }
-      expect(addBookmarkResponseSchema.parse(validResponse)).toEqual(
+      expect(createBookmarkResponseSchema.parse(validResponse)).toEqual(
         validResponse,
       )
     })
@@ -114,7 +116,7 @@ describe('API Schemas - Bookmark Operations', () => {
           code: ERROR_CODES.CONFLICT,
         },
       }
-      expect(addBookmarkResponseSchema.parse(errorResponse)).toEqual(
+      expect(createBookmarkResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })

--- a/shared/schemas/api-bookmark.test.ts
+++ b/shared/schemas/api-bookmark.test.ts
@@ -3,8 +3,8 @@ import { ZodError } from 'zod'
 
 import { API_ACTIONS, ERROR_MESSAGES, ERROR_CODES } from '../constants'
 import {
-  getBookmarksRequestSchema,
-  getBookmarksResponseSchema,
+  readBookmarksRequestSchema,
+  readBookmarksResponseSchema,
   addBookmarkRequestSchema,
   addBookmarkResponseSchema,
 } from './api'
@@ -16,29 +16,29 @@ import {
 } from '../test/fixtures'
 
 describe('API Schemas - Bookmark Operations', () => {
-  describe('getBookmarksRequestSchema', () => {
+  describe('readBookmarksRequestSchema', () => {
     it('正しい GET_BOOKMARKS リクエストを受け入れること', () => {
       const validRequest = { action: API_ACTIONS.GET_BOOKMARKS }
-      expect(getBookmarksRequestSchema.parse(validRequest)).toEqual(
+      expect(readBookmarksRequestSchema.parse(validRequest)).toEqual(
         validRequest,
       )
     })
 
     it('不正なアクションを持つリクエストを拒否すること', () => {
       const invalidRequest = { action: API_ACTIONS.GET_KEYWORDS }
-      expect(() => getBookmarksRequestSchema.parse(invalidRequest)).toThrow(
+      expect(() => readBookmarksRequestSchema.parse(invalidRequest)).toThrow(
         ZodError,
       )
     })
   })
 
-  describe('getBookmarksResponseSchema', () => {
+  describe('readBookmarksResponseSchema', () => {
     it('ブックマーク一覧を含むレスポンスを検証できること', () => {
       const validResponse = {
         success: true,
         data: { bookmarks: MOCK_BOOKMARKS },
       }
-      expect(getBookmarksResponseSchema.parse(validResponse)).toEqual(
+      expect(readBookmarksResponseSchema.parse(validResponse)).toEqual(
         validResponse,
       )
     })
@@ -51,7 +51,7 @@ describe('API Schemas - Bookmark Operations', () => {
           code: ERROR_CODES.INTERNAL_SERVER_ERROR,
         },
       }
-      expect(getBookmarksResponseSchema.parse(errorResponse)).toEqual(
+      expect(readBookmarksResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })
@@ -66,9 +66,7 @@ describe('API Schemas - Bookmark Operations', () => {
           url: VALID_URLS.GOOGLE,
         },
       }
-      expect(addBookmarkRequestSchema.parse(validRequest)).toEqual(
-        validRequest,
-      )
+      expect(addBookmarkRequestSchema.parse(validRequest)).toEqual(validRequest)
     })
 
     it('不正な形式のペイロード（空タイトル）を拒否すること', () => {
@@ -79,9 +77,9 @@ describe('API Schemas - Bookmark Operations', () => {
           url: VALID_URLS.GOOGLE,
         },
       }
-      expect(() =>
-        addBookmarkRequestSchema.parse(invalidRequest),
-      ).toThrow(ZodError)
+      expect(() => addBookmarkRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
     })
 
     it('前後の空白を含むタイトルがトリムされること', () => {

--- a/shared/schemas/api-keyword.test.ts
+++ b/shared/schemas/api-keyword.test.ts
@@ -5,8 +5,8 @@ import { API_ACTIONS, ERROR_MESSAGES, ERROR_CODES } from '../constants'
 import {
   readKeywordsRequestSchema,
   readKeywordsResponseSchema,
-  addKeywordRequestSchema,
-  addKeywordResponseSchema,
+  createKeywordRequestSchema,
+  createKeywordResponseSchema,
   updateKeywordRequestSchema,
   updateKeywordResponseSchema,
   deleteKeywordRequestSchema,
@@ -43,13 +43,15 @@ describe('API Schemas - Keyword Operations', () => {
     })
   })
 
-  describe('addKeywordRequestSchema', () => {
+  describe('createKeywordRequestSchema', () => {
     it('正しい ADD_KEYWORD リクエストを受け入れること', () => {
       const validRequest = {
         action: API_ACTIONS.ADD_KEYWORD,
         payload: { name: TEST_STRINGS.NEW_NAME },
       }
-      expect(addKeywordRequestSchema.parse(validRequest)).toEqual(validRequest)
+      expect(createKeywordRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
     })
 
     it('payload が不正（名前が空）なリクエストを拒否すること', () => {
@@ -57,20 +59,20 @@ describe('API Schemas - Keyword Operations', () => {
         action: API_ACTIONS.ADD_KEYWORD,
         payload: { name: '' },
       }
-      expect(() => addKeywordRequestSchema.parse(invalidRequest)).toThrow(
+      expect(() => createKeywordRequestSchema.parse(invalidRequest)).toThrow(
         ZodError,
       )
     })
   })
 
-  describe('addKeywordResponseSchema', () => {
+  describe('createKeywordResponseSchema', () => {
     it('追加されたキーワードを含むレスポンスを検証できること', () => {
       const keyword = { id: MOCK_KEYWORDS[0].id, name: MOCK_KEYWORDS[0].name }
       const validResponse = {
         success: true,
         data: { keyword },
       }
-      expect(addKeywordResponseSchema.parse(validResponse)).toEqual(
+      expect(createKeywordResponseSchema.parse(validResponse)).toEqual(
         validResponse,
       )
     })

--- a/shared/schemas/api-keyword.test.ts
+++ b/shared/schemas/api-keyword.test.ts
@@ -3,8 +3,8 @@ import { ZodError } from 'zod'
 
 import { API_ACTIONS, ERROR_MESSAGES, ERROR_CODES } from '../constants'
 import {
-  getKeywordsRequestSchema,
-  getKeywordsResponseSchema,
+  readKeywordsRequestSchema,
+  readKeywordsResponseSchema,
   addKeywordRequestSchema,
   addKeywordResponseSchema,
   updateKeywordRequestSchema,
@@ -15,27 +15,29 @@ import {
 import { MOCK_KEYWORDS, MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
 
 describe('API Schemas - Keyword Operations', () => {
-  describe('getKeywordsRequestSchema', () => {
+  describe('readKeywordsRequestSchema', () => {
     it('正しい GET_KEYWORDS リクエストを受け入れること', () => {
       const validRequest = { action: API_ACTIONS.GET_KEYWORDS }
-      expect(getKeywordsRequestSchema.parse(validRequest)).toEqual(validRequest)
+      expect(readKeywordsRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
     })
 
     it('不正なアクションを持つリクエストを拒否すること', () => {
       const invalidRequest = { action: API_ACTIONS.GET_BOOKMARKS }
-      expect(() => getKeywordsRequestSchema.parse(invalidRequest)).toThrow(
+      expect(() => readKeywordsRequestSchema.parse(invalidRequest)).toThrow(
         ZodError,
       )
     })
   })
 
-  describe('getKeywordsResponseSchema', () => {
+  describe('readKeywordsResponseSchema', () => {
     it('キーワード一覧を含むレスポンスを検証できること', () => {
       const validResponse = {
         success: true,
         data: { keywords: MOCK_KEYWORDS },
       }
-      expect(getKeywordsResponseSchema.parse(validResponse)).toEqual(
+      expect(readKeywordsResponseSchema.parse(validResponse)).toEqual(
         validResponse,
       )
     })
@@ -90,9 +92,9 @@ describe('API Schemas - Keyword Operations', () => {
         action: API_ACTIONS.UPDATE_KEYWORD,
         payload: { id: TEST_STRINGS.INVALID_ID, name: TEST_STRINGS.NEW_NAME },
       }
-      expect(() =>
-        updateKeywordRequestSchema.parse(invalidRequest),
-      ).toThrow(ZodError)
+      expect(() => updateKeywordRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
     })
 
     it('名前が空のリクエストを拒否すること', () => {
@@ -100,9 +102,9 @@ describe('API Schemas - Keyword Operations', () => {
         action: API_ACTIONS.UPDATE_KEYWORD,
         payload: { id: MOCK_IDS.KEYWORD_1, name: '' },
       }
-      expect(() =>
-        updateKeywordRequestSchema.parse(invalidRequest),
-      ).toThrow(ZodError)
+      expect(() => updateKeywordRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
     })
   })
 
@@ -151,9 +153,9 @@ describe('API Schemas - Keyword Operations', () => {
         action: API_ACTIONS.DELETE_KEYWORD,
         payload: { id: TEST_STRINGS.INVALID_ID },
       }
-      expect(() =>
-        deleteKeywordRequestSchema.parse(invalidRequest),
-      ).toThrow(ZodError)
+      expect(() => deleteKeywordRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
     })
   })
 

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -11,7 +11,7 @@ import {
   KeywordIdSchema,
   keywordResponseSchema,
   keywordsSchema,
-  updateKeywordSchema,
+  updateKeywordInputSchema,
 } from './keyword'
 
 /**
@@ -104,7 +104,7 @@ export type AddKeywordResponse = z.infer<typeof addKeywordResponseSchema>
  */
 export const updateKeywordRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.UPDATE_KEYWORD),
-  payload: updateKeywordSchema.extend({
+  payload: updateKeywordInputSchema.extend({
     id: KeywordIdSchema,
   }),
 })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -7,7 +7,7 @@ import {
   createBookmarkInputSchema,
 } from './bookmark'
 import {
-  createKeywordSchema,
+  createKeywordInputSchema,
   KeywordIdSchema,
   keywordResponseSchema,
   keywordsResponseSchema,
@@ -90,7 +90,7 @@ export type GetKeywordsResponse = z.infer<typeof getKeywordsResponseSchema>
  */
 export const addKeywordRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.ADD_KEYWORD),
-  payload: createKeywordSchema,
+  payload: createKeywordInputSchema,
 })
 
 export type AddKeywordRequest = z.infer<typeof addKeywordRequestSchema>

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -48,9 +48,8 @@ export type ApiError = z.infer<typeof ApiErrorSchema>
 /**
  * API レスポンスのユニオン型
  */
-export const createApiResponseSchema = <T extends z.ZodTypeAny>(
-  dataSchema: T,
-) => z.union([createApiSuccessSchema(dataSchema), ApiErrorSchema])
+export const baseApiResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
+  z.union([createApiSuccessSchema(dataSchema), ApiErrorSchema])
 
 /**
  * メッセージングで使用するアクションのリテラル型
@@ -79,7 +78,7 @@ export const getKeywordsRequestSchema = baseApiRequestSchema.extend({
 
 export type GetKeywordsRequest = z.infer<typeof getKeywordsRequestSchema>
 
-export const getKeywordsResponseSchema = createApiResponseSchema(keywordsSchema)
+export const getKeywordsResponseSchema = baseApiResponseSchema(keywordsSchema)
 
 export type GetKeywordsResponse = z.infer<typeof getKeywordsResponseSchema>
 
@@ -93,7 +92,7 @@ export const addKeywordRequestSchema = baseApiRequestSchema.extend({
 
 export type AddKeywordRequest = z.infer<typeof addKeywordRequestSchema>
 
-export const addKeywordResponseSchema = createApiResponseSchema(
+export const addKeywordResponseSchema = baseApiResponseSchema(
   keywordResponseSchema,
 )
 
@@ -111,7 +110,7 @@ export const updateKeywordRequestSchema = baseApiRequestSchema.extend({
 
 export type UpdateKeywordRequest = z.infer<typeof updateKeywordRequestSchema>
 
-export const updateKeywordResponseSchema = createApiResponseSchema(
+export const updateKeywordResponseSchema = baseApiResponseSchema(
   keywordResponseSchema,
 )
 
@@ -129,7 +128,7 @@ export const deleteKeywordRequestSchema = baseApiRequestSchema.extend({
 
 export type DeleteKeywordRequest = z.infer<typeof deleteKeywordRequestSchema>
 
-export const deleteKeywordResponseSchema = createApiResponseSchema(
+export const deleteKeywordResponseSchema = baseApiResponseSchema(
   z.null(), // 削除時はデータなし
 )
 
@@ -145,8 +144,7 @@ export const getBookmarksRequestSchema = baseApiRequestSchema.extend({
 
 export type GetBookmarksRequest = z.infer<typeof getBookmarksRequestSchema>
 
-export const getBookmarksResponseSchema =
-  createApiResponseSchema(bookmarksSchema)
+export const getBookmarksResponseSchema = baseApiResponseSchema(bookmarksSchema)
 
 export type GetBookmarksResponse = z.infer<typeof getBookmarksResponseSchema>
 
@@ -160,7 +158,7 @@ export const addBookmarkRequestSchema = baseApiRequestSchema.extend({
 
 export type AddBookmarkRequest = z.infer<typeof addBookmarkRequestSchema>
 
-export const addBookmarkResponseSchema = createApiResponseSchema(bookmarkSchema)
+export const addBookmarkResponseSchema = baseApiResponseSchema(bookmarkSchema)
 
 export type AddBookmarkResponse = z.infer<typeof addBookmarkResponseSchema>
 

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -152,16 +152,19 @@ export type ReadBookmarksResponse = z.infer<typeof readBookmarksResponseSchema>
 /**
  * ブックマーク追加 (ADD_BOOKMARK)
  */
-export const addBookmarkRequestSchema = baseApiRequestSchema.extend({
+export const createBookmarkRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.ADD_BOOKMARK),
   payload: createBookmarkInputSchema,
 })
 
-export type AddBookmarkRequest = z.infer<typeof addBookmarkRequestSchema>
+export type CreateBookmarkRequest = z.infer<typeof createBookmarkRequestSchema>
 
-export const addBookmarkResponseSchema = baseApiResponseSchema(bookmarkSchema)
+export const createBookmarkResponseSchema =
+  baseApiResponseSchema(bookmarkSchema)
 
-export type AddBookmarkResponse = z.infer<typeof addBookmarkResponseSchema>
+export type CreateBookmarkResponse = z.infer<
+  typeof createBookmarkResponseSchema
+>
 
 /**
  * 全てのメッセージリクエストを統合したディスクリミネイテッドユニオン型
@@ -173,7 +176,7 @@ export const ApiRequestSchema = z.discriminatedUnion('action', [
   updateKeywordRequestSchema,
   deleteKeywordRequestSchema,
   readBookmarksRequestSchema,
-  addBookmarkRequestSchema,
+  createBookmarkRequestSchema,
 ])
 
 export type ApiRequest = z.infer<typeof ApiRequestSchema>

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -10,7 +10,7 @@ import {
   createKeywordInputSchema,
   KeywordIdSchema,
   keywordResponseSchema,
-  keywordsResponseSchema,
+  keywordsSchema,
   updateKeywordSchema,
 } from './keyword'
 
@@ -79,9 +79,7 @@ export const getKeywordsRequestSchema = baseApiRequestSchema.extend({
 
 export type GetKeywordsRequest = z.infer<typeof getKeywordsRequestSchema>
 
-export const getKeywordsResponseSchema = createApiResponseSchema(
-  keywordsResponseSchema,
-)
+export const getKeywordsResponseSchema = createApiResponseSchema(keywordsSchema)
 
 export type GetKeywordsResponse = z.infer<typeof getKeywordsResponseSchema>
 

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -137,16 +137,17 @@ export type DeleteKeywordResponse = z.infer<typeof deleteKeywordResponseSchema>
 /**
  * ブックマーク一覧取得 (GET_BOOKMARKS)
  */
-export const getBookmarksRequestSchema = baseApiRequestSchema.extend({
+export const readBookmarksRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.GET_BOOKMARKS),
   payload: z.undefined().optional(),
 })
 
-export type GetBookmarksRequest = z.infer<typeof getBookmarksRequestSchema>
+export type ReadBookmarksRequest = z.infer<typeof readBookmarksRequestSchema>
 
-export const getBookmarksResponseSchema = baseApiResponseSchema(bookmarksSchema)
+export const readBookmarksResponseSchema =
+  baseApiResponseSchema(bookmarksSchema)
 
-export type GetBookmarksResponse = z.infer<typeof getBookmarksResponseSchema>
+export type ReadBookmarksResponse = z.infer<typeof readBookmarksResponseSchema>
 
 /**
  * ブックマーク追加 (ADD_BOOKMARK)
@@ -171,7 +172,7 @@ export const ApiRequestSchema = z.discriminatedUnion('action', [
   createKeywordRequestSchema,
   updateKeywordRequestSchema,
   deleteKeywordRequestSchema,
-  getBookmarksRequestSchema,
+  readBookmarksRequestSchema,
   addBookmarkRequestSchema,
 ])
 

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -85,18 +85,18 @@ export type ReadKeywordsResponse = z.infer<typeof readKeywordsResponseSchema>
 /**
  * キーワード追加 (ADD_KEYWORD)
  */
-export const addKeywordRequestSchema = baseApiRequestSchema.extend({
+export const createKeywordRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.ADD_KEYWORD),
   payload: createKeywordInputSchema,
 })
 
-export type AddKeywordRequest = z.infer<typeof addKeywordRequestSchema>
+export type CreateKeywordRequest = z.infer<typeof createKeywordRequestSchema>
 
-export const addKeywordResponseSchema = baseApiResponseSchema(
+export const createKeywordResponseSchema = baseApiResponseSchema(
   keywordResponseSchema,
 )
 
-export type AddKeywordResponse = z.infer<typeof addKeywordResponseSchema>
+export type CreateKeywordResponse = z.infer<typeof createKeywordResponseSchema>
 
 /**
  * キーワード更新 (UPDATE_KEYWORD)
@@ -168,7 +168,7 @@ export type AddBookmarkResponse = z.infer<typeof addBookmarkResponseSchema>
  */
 export const ApiRequestSchema = z.discriminatedUnion('action', [
   readKeywordsRequestSchema,
-  addKeywordRequestSchema,
+  createKeywordRequestSchema,
   updateKeywordRequestSchema,
   deleteKeywordRequestSchema,
   getBookmarksRequestSchema,

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -71,16 +71,16 @@ export const baseApiRequestSchema = z.object({
 /**
  * キーワード一覧取得 (GET_KEYWORDS)
  */
-export const getKeywordsRequestSchema = baseApiRequestSchema.extend({
+export const readKeywordsRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.GET_KEYWORDS),
   payload: z.undefined().optional(),
 })
 
-export type GetKeywordsRequest = z.infer<typeof getKeywordsRequestSchema>
+export type ReadKeywordsRequest = z.infer<typeof readKeywordsRequestSchema>
 
-export const getKeywordsResponseSchema = baseApiResponseSchema(keywordsSchema)
+export const readKeywordsResponseSchema = baseApiResponseSchema(keywordsSchema)
 
-export type GetKeywordsResponse = z.infer<typeof getKeywordsResponseSchema>
+export type ReadKeywordsResponse = z.infer<typeof readKeywordsResponseSchema>
 
 /**
  * キーワード追加 (ADD_KEYWORD)
@@ -167,7 +167,7 @@ export type AddBookmarkResponse = z.infer<typeof addBookmarkResponseSchema>
  * action フィールドを識別子として使用し、パースの効率とエラーメッセージを改善
  */
 export const ApiRequestSchema = z.discriminatedUnion('action', [
-  getKeywordsRequestSchema,
+  readKeywordsRequestSchema,
   addKeywordRequestSchema,
   updateKeywordRequestSchema,
   deleteKeywordRequestSchema,

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { API_ACTIONS, ERROR_CODES } from '../constants'
 import {
   bookmarkSchema,
-  bookmarksResponseSchema,
+  bookmarksSchema,
   createBookmarkInputSchema,
 } from './bookmark'
 import {
@@ -147,9 +147,8 @@ export const getBookmarksRequestSchema = baseApiRequestSchema.extend({
 
 export type GetBookmarksRequest = z.infer<typeof getBookmarksRequestSchema>
 
-export const getBookmarksResponseSchema = createApiResponseSchema(
-  bookmarksResponseSchema,
-)
+export const getBookmarksResponseSchema =
+  createApiResponseSchema(bookmarksSchema)
 
 export type GetBookmarksResponse = z.infer<typeof getBookmarksResponseSchema>
 

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -4,7 +4,7 @@ import { API_ACTIONS, ERROR_CODES } from '../constants'
 import {
   bookmarkSchema,
   bookmarksResponseSchema,
-  createBookmarkSchema,
+  createBookmarkInputSchema,
 } from './bookmark'
 import {
   createKeywordSchema,
@@ -48,8 +48,9 @@ export type ApiError = z.infer<typeof ApiErrorSchema>
 /**
  * API レスポンスのユニオン型
  */
-export const createApiResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
-  z.union([createApiSuccessSchema(dataSchema), ApiErrorSchema])
+export const createApiResponseSchema = <T extends z.ZodTypeAny>(
+  dataSchema: T,
+) => z.union([createApiSuccessSchema(dataSchema), ApiErrorSchema])
 
 /**
  * メッセージングで使用するアクションのリテラル型
@@ -157,14 +158,12 @@ export type GetBookmarksResponse = z.infer<typeof getBookmarksResponseSchema>
  */
 export const addBookmarkRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.ADD_BOOKMARK),
-  payload: createBookmarkSchema,
+  payload: createBookmarkInputSchema,
 })
 
 export type AddBookmarkRequest = z.infer<typeof addBookmarkRequestSchema>
 
-export const addBookmarkResponseSchema = createApiResponseSchema(
-  bookmarkSchema,
-)
+export const addBookmarkResponseSchema = createApiResponseSchema(bookmarkSchema)
 
 export type AddBookmarkResponse = z.infer<typeof addBookmarkResponseSchema>
 

--- a/shared/schemas/bookmark.test.ts
+++ b/shared/schemas/bookmark.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 
 import {
   bookmarkSchema,
-  createBookmarkSchema,
+  createBookmarkInputSchema,
   reorderBookmarksSchema,
   updateBookmarkSchema,
 } from './bookmark'
@@ -38,10 +38,10 @@ describe('bookmarkSchema', () => {
   })
 })
 
-describe('createBookmarkSchema', () => {
+describe('createBookmarkInputSchema', () => {
   it('正常なデータを受け入れること', () => {
     const valid = { title: MOCK_BOOKMARK_TITLE_PREFIX, url: VALID_URLS.HTTP }
-    expect(createBookmarkSchema.safeParse(valid).success).toBe(true)
+    expect(createBookmarkInputSchema.safeParse(valid).success).toBe(true)
   })
 
   it.each([
@@ -61,7 +61,7 @@ describe('createBookmarkSchema', () => {
       expected: VALIDATION_MESSAGES.URL_INVALID_PROTOCOL,
     },
   ])('異常系: $name の場合に正しいエラーを返すこと', ({ data, expected }) => {
-    const result = createBookmarkSchema.safeParse(data)
+    const result = createBookmarkInputSchema.safeParse(data)
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0]?.message).toBe(expected)
@@ -124,7 +124,9 @@ describe('reorderBookmarksSchema', () => {
 
   it('上限を超える ID リストを拒否すること', () => {
     // 1001個の有効な UUID v7 を生成
-    const manyIds = Array.from({ length: 1001 }, (_, i) => generateMockUuidV7(i))
+    const manyIds = Array.from({ length: 1001 }, (_, i) =>
+      generateMockUuidV7(i),
+    )
     const result = reorderBookmarksSchema.safeParse({ ids: manyIds })
     expect(result.success).toBe(false)
     if (!result.success) {

--- a/shared/schemas/bookmark.test.ts
+++ b/shared/schemas/bookmark.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest'
 import {
   bookmarkSchema,
   createBookmarkInputSchema,
-  reorderBookmarksSchema,
+  reorderBookmarksInputSchema,
   updateBookmarkInputSchema,
 } from './bookmark'
 import { VALIDATION_MESSAGES } from '../constants'
@@ -103,17 +103,17 @@ describe('updateBookmarkInputSchema', () => {
   })
 })
 
-describe('reorderBookmarksSchema', () => {
+describe('reorderBookmarksInputSchema', () => {
   it('正常な ID リストを受け入れること', () => {
     const valid = { ids: [MOCK_IDS.BOOKMARK_1, MOCK_IDS.BOOKMARK_2] }
-    expect(reorderBookmarksSchema.safeParse(valid).success).toBe(true)
+    expect(reorderBookmarksInputSchema.safeParse(valid).success).toBe(true)
   })
 
   it('重複した ID が含まれる場合にエラーを返すこと', () => {
     const invalid = {
       ids: [MOCK_IDS.BOOKMARK_1, MOCK_IDS.BOOKMARK_2, MOCK_IDS.BOOKMARK_1],
     }
-    const result = reorderBookmarksSchema.safeParse(invalid)
+    const result = reorderBookmarksInputSchema.safeParse(invalid)
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0]?.message).toBe(
@@ -127,7 +127,7 @@ describe('reorderBookmarksSchema', () => {
     const manyIds = Array.from({ length: 1001 }, (_, i) =>
       generateMockUuidV7(i),
     )
-    const result = reorderBookmarksSchema.safeParse({ ids: manyIds })
+    const result = reorderBookmarksInputSchema.safeParse({ ids: manyIds })
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0]?.message).toBe(

--- a/shared/schemas/bookmark.test.ts
+++ b/shared/schemas/bookmark.test.ts
@@ -4,7 +4,7 @@ import {
   bookmarkSchema,
   createBookmarkInputSchema,
   reorderBookmarksSchema,
-  updateBookmarkSchema,
+  updateBookmarkInputSchema,
 } from './bookmark'
 import { VALIDATION_MESSAGES } from '../constants'
 import {
@@ -69,13 +69,13 @@ describe('createBookmarkInputSchema', () => {
   })
 })
 
-describe('updateBookmarkSchema', () => {
+describe('updateBookmarkInputSchema', () => {
   it.each([
     { name: 'タイトルのみ', data: { title: 'Updated' } },
     { name: 'URLのみ', data: { url: VALID_URLS.HTTP } },
     { name: '両方', data: { title: 'Updated', url: VALID_URLS.HTTP } },
   ])('正常系: $name の場合に成功すること', ({ data }) => {
-    expect(updateBookmarkSchema.safeParse(data).success).toBe(true)
+    expect(updateBookmarkInputSchema.safeParse(data).success).toBe(true)
   })
 
   it.each([
@@ -95,7 +95,7 @@ describe('updateBookmarkSchema', () => {
       expected: VALIDATION_MESSAGES.URL_INVALID_FORMAT,
     },
   ])('異常系: $name の場合に正しいエラーを返すこと', ({ data, expected }) => {
-    const result = updateBookmarkSchema.safeParse(data)
+    const result = updateBookmarkInputSchema.safeParse(data)
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.issues[0]?.message).toBe(expected)

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -73,7 +73,7 @@ export const updateBookmarkInputSchema = z
 
 export type UpdateBookmarkInput = z.infer<typeof updateBookmarkInputSchema>
 
-export const reorderBookmarksSchema = z.object({
+export const reorderBookmarksInputSchema = z.object({
   ids: z
     .array(BookmarkIdSchema)
     .max(1000, VALIDATION_MESSAGES.REORDER_MAX_ITEMS)
@@ -82,7 +82,7 @@ export const reorderBookmarksSchema = z.object({
     }),
 })
 
-export type ReorderBookmarksRequest = z.infer<typeof reorderBookmarksSchema>
+export type ReorderBookmarksInput = z.infer<typeof reorderBookmarksInputSchema>
 
 export const bookmarksSchema = z.object({
   bookmarks: z.array(bookmarkSchema),

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -17,7 +17,10 @@ export type BookmarkId = z.infer<typeof BookmarkIdSchema>
 /**
  * ブックマークタイトルの共通バリデーションスキーマ
  */
-const bookmarkTitleSchema = z.string().trim().min(1, VALIDATION_MESSAGES.TITLE_REQUIRED)
+const bookmarkTitleSchema = z
+  .string()
+  .trim()
+  .min(1, VALIDATION_MESSAGES.TITLE_REQUIRED)
 
 /**
  * ブックマークURLの共通バリデーションスキーマ
@@ -52,12 +55,12 @@ export const bookmarkEntitySchema = bookmarkSchema
 
 export type BookmarkEntity = z.infer<typeof bookmarkEntitySchema>
 
-export const createBookmarkSchema = z.object({
+export const createBookmarkInputSchema = z.object({
   title: bookmarkTitleSchema,
   url: bookmarkUrlSchema,
 })
 
-export type CreateBookmarkRequest = z.infer<typeof createBookmarkSchema>
+export type CreateBookmarkInput = z.infer<typeof createBookmarkInputSchema>
 
 export const updateBookmarkSchema = z
   .object({

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -62,7 +62,7 @@ export const createBookmarkInputSchema = z.object({
 
 export type CreateBookmarkInput = z.infer<typeof createBookmarkInputSchema>
 
-export const updateBookmarkSchema = z
+export const updateBookmarkInputSchema = z
   .object({
     title: bookmarkTitleSchema.optional(),
     url: bookmarkUrlSchema.optional(),
@@ -71,7 +71,7 @@ export const updateBookmarkSchema = z
     message: VALIDATION_MESSAGES.UPDATE_MIN_FIELDS,
   })
 
-export type UpdateBookmarkRequest = z.infer<typeof updateBookmarkSchema>
+export type UpdateBookmarkInput = z.infer<typeof updateBookmarkInputSchema>
 
 export const reorderBookmarksSchema = z.object({
   ids: z

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -84,8 +84,8 @@ export const reorderBookmarksSchema = z.object({
 
 export type ReorderBookmarksRequest = z.infer<typeof reorderBookmarksSchema>
 
-export const bookmarksResponseSchema = z.object({
+export const bookmarksSchema = z.object({
   bookmarks: z.array(bookmarkSchema),
 })
 
-export type BookmarksResponse = z.infer<typeof bookmarksResponseSchema>
+export type Bookmarks = z.infer<typeof bookmarksSchema>

--- a/shared/schemas/keyword.test.ts
+++ b/shared/schemas/keyword.test.ts
@@ -5,7 +5,7 @@ import {
   keywordSchema,
   keywordWithCountSchema,
   keywordsSchema,
-  updateKeywordSchema,
+  updateKeywordInputSchema,
   createKeywordInputSchema,
 } from './keyword'
 import {
@@ -78,19 +78,19 @@ describe('Keyword Schemas', () => {
     })
   })
 
-  describe('updateKeywordSchema', () => {
+  describe('updateKeywordInputSchema', () => {
     it('有効な名前を受け入れること', () => {
       const validData = { name: TEST_STRINGS.UPDATED_NAME }
-      expect(updateKeywordSchema.parse(validData)).toEqual(validData)
+      expect(updateKeywordInputSchema.parse(validData)).toEqual(validData)
     })
 
     it('名前が空の場合にエラーになること', () => {
-      expect(() => updateKeywordSchema.parse({ name: '' })).toThrow()
+      expect(() => updateKeywordInputSchema.parse({ name: '' })).toThrow()
     })
 
     it('名前が50文字を超える場合にエラーになること', () => {
       expect(() =>
-        updateKeywordSchema.parse({ name: 'a'.repeat(51) }),
+        updateKeywordInputSchema.parse({ name: 'a'.repeat(51) }),
       ).toThrow()
     })
   })

--- a/shared/schemas/keyword.test.ts
+++ b/shared/schemas/keyword.test.ts
@@ -6,7 +6,7 @@ import {
   keywordWithCountSchema,
   keywordsResponseSchema,
   updateKeywordSchema,
-  createKeywordSchema,
+  createKeywordInputSchema,
 } from './keyword'
 import {
   MOCK_BOOKMARK_TITLE_PREFIX,
@@ -95,10 +95,10 @@ describe('Keyword Schemas', () => {
     })
   })
 
-  describe('createKeywordSchema', () => {
+  describe('createKeywordInputSchema', () => {
     it('有効な名前を受け入れること', () => {
       const validData = { name: TEST_STRINGS.NEW_NAME }
-      expect(createKeywordSchema.parse(validData)).toEqual(validData)
+      expect(createKeywordInputSchema.parse(validData)).toEqual(validData)
     })
   })
 })

--- a/shared/schemas/keyword.test.ts
+++ b/shared/schemas/keyword.test.ts
@@ -4,7 +4,7 @@ import {
   KeywordIdSchema,
   keywordSchema,
   keywordWithCountSchema,
-  keywordsResponseSchema,
+  keywordsSchema,
   updateKeywordSchema,
   createKeywordInputSchema,
 } from './keyword'
@@ -66,7 +66,7 @@ describe('Keyword Schemas', () => {
     })
   })
 
-  describe('keywordsResponseSchema', () => {
+  describe('keywordsSchema', () => {
     it('キーワードリストを含むレスポンスを受け入れること', () => {
       const validResponse = {
         keywords: [
@@ -74,7 +74,7 @@ describe('Keyword Schemas', () => {
           { id: MOCK_IDS.KEYWORD_2, name: 'Tag2', bookmarkCount: 0 },
         ],
       }
-      expect(keywordsResponseSchema.parse(validResponse)).toEqual(validResponse)
+      expect(keywordsSchema.parse(validResponse)).toEqual(validResponse)
     })
   })
 

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -33,10 +33,10 @@ export type KeywordsResponse = z.infer<typeof keywordsResponseSchema>
 /**
  * キーワード作成のバリデーションスキーマ
  */
-export const createKeywordSchema = z.object({
+export const createKeywordInputSchema = z.object({
   name: keywordNameSchema,
 })
-export type CreateKeywordInput = z.infer<typeof createKeywordSchema>
+export type CreateKeywordInput = z.infer<typeof createKeywordInputSchema>
 
 /**
  * キーワード更新のバリデーションスキーマ

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -41,10 +41,10 @@ export type CreateKeywordInput = z.infer<typeof createKeywordInputSchema>
 /**
  * キーワード更新のバリデーションスキーマ
  */
-export const updateKeywordSchema = z.object({
+export const updateKeywordInputSchema = z.object({
   name: keywordNameSchema,
 })
-export type UpdateKeywordInput = z.infer<typeof updateKeywordSchema>
+export type UpdateKeywordInput = z.infer<typeof updateKeywordInputSchema>
 
 /**
  * 単一キーワードのレスポンススキーマ

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -25,10 +25,10 @@ export const keywordWithCountSchema = keywordSchema.extend({
 })
 export type KeywordWithCount = z.infer<typeof keywordWithCountSchema>
 
-export const keywordsResponseSchema = z.object({
+export const keywordsSchema = z.object({
   keywords: z.array(keywordWithCountSchema),
 })
-export type KeywordsResponse = z.infer<typeof keywordsResponseSchema>
+export type Keywords = z.infer<typeof keywordsSchema>
 
 /**
  * キーワード作成のバリデーションスキーマ

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -57,7 +57,7 @@ export type KeywordResponse = z.infer<typeof keywordResponseSchema>
 /**
  * キーワード紐付けリクエストのバリデーションスキーマ
  */
-export const attachKeywordRequestSchema = z.object({
+export const attachKeywordInputSchema = z.object({
   keywordId: KeywordIdSchema,
 })
-export type AttachKeywordRequest = z.infer<typeof attachKeywordRequestSchema>
+export type AttachKeywordInput = z.infer<typeof attachKeywordInputSchema>

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -4,7 +4,7 @@ import { HTTP_STATUS, LOG_MESSAGES, UI_MESSAGES } from '@shared/constants'
 import type {
   BookmarkId,
   Bookmarks,
-  ReorderBookmarksRequest,
+  ReorderBookmarksInput,
   UpdateBookmarkInput,
 } from '@shared/schemas/bookmark'
 import type {
@@ -145,7 +145,7 @@ export const useReorderBookmarks = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: async (req: ReorderBookmarksRequest) => {
+    mutationFn: async (req: ReorderBookmarksInput) => {
       const res = await client.api.bookmarks.reorder.$put({
         json: req,
       })

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -5,7 +5,7 @@ import type {
   BookmarkId,
   BookmarksResponse,
   ReorderBookmarksRequest,
-  UpdateBookmarkRequest,
+  UpdateBookmarkInput,
 } from '@shared/schemas/bookmark'
 import type {
   KeywordId,
@@ -100,7 +100,7 @@ export const useUpdateBookmark = () => {
       updates,
     }: {
       id: BookmarkId
-      updates: UpdateBookmarkRequest
+      updates: UpdateBookmarkInput
     }) => {
       const res = await client.api.bookmarks[':id'].$patch({
         param: { id },

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -10,7 +10,7 @@ import type {
 import type {
   KeywordId,
   KeywordResponse,
-  KeywordsResponse,
+  Keywords,
   CreateKeywordInput,
   UpdateKeywordInput,
 } from '@shared/schemas/keyword'
@@ -82,7 +82,7 @@ export const useKeywords = () => {
     queryKey: QUERY_KEYS.KEYWORDS.LIST(),
     queryFn: async () => {
       const res = await client.api.keywords.$get()
-      return await parseResponse<KeywordsResponse>(
+      return await parseResponse<Keywords>(
         res,
         UI_MESSAGES.FETCH_KEYWORDS_FAILED,
       )
@@ -245,7 +245,7 @@ export const useUpdateKeyword = () => {
     onSuccess: (data) => {
       // キャッシュを直接更新して即座に UI に反映させる
       const updatedKeyword = data.keyword
-      queryClient.setQueryData<KeywordsResponse>(
+      queryClient.setQueryData<Keywords>(
         QUERY_KEYS.KEYWORDS.LIST(),
         (oldData) => {
           if (!oldData) return oldData
@@ -287,7 +287,7 @@ export const useDeleteKeyword = () => {
     },
     onSuccess: (deletedId) => {
       // キャッシュから削除対象を取り除く
-      queryClient.setQueryData<KeywordsResponse>(
+      queryClient.setQueryData<Keywords>(
         QUERY_KEYS.KEYWORDS.LIST(),
         (oldData) => {
           if (!oldData) return oldData

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { HTTP_STATUS, LOG_MESSAGES, UI_MESSAGES } from '@shared/constants'
 import type {
   BookmarkId,
-  BookmarksResponse,
+  Bookmarks,
   ReorderBookmarksRequest,
   UpdateBookmarkInput,
 } from '@shared/schemas/bookmark'
@@ -67,7 +67,7 @@ export const useBookmarks = () => {
     queryKey: QUERY_KEYS.BOOKMARKS.LIST(),
     queryFn: async () => {
       const res = await client.api.bookmarks.$get()
-      return await parseResponse<BookmarksResponse>(
+      return await parseResponse<Bookmarks>(
         res,
         UI_MESSAGES.FETCH_BOOKMARKS_FAILED,
       )
@@ -157,7 +157,7 @@ export const useReorderBookmarks = () => {
       await queryClient.cancelQueries({ queryKey: QUERY_KEYS.BOOKMARKS.LIST() })
 
       // 2. 現在の状態を保存
-      const previousData = queryClient.getQueryData<BookmarksResponse>(
+      const previousData = queryClient.getQueryData<Bookmarks>(
         QUERY_KEYS.BOOKMARKS.LIST(),
       )
 
@@ -170,13 +170,10 @@ export const useReorderBookmarks = () => {
           .map((id) => bookmarkMap.get(id))
           .filter((b): b is import('@shared/schemas/bookmark').Bookmark => !!b)
 
-        queryClient.setQueryData<BookmarksResponse>(
-          QUERY_KEYS.BOOKMARKS.LIST(),
-          {
-            ...previousData,
-            bookmarks: newBookmarks,
-          },
-        )
+        queryClient.setQueryData<Bookmarks>(QUERY_KEYS.BOOKMARKS.LIST(), {
+          ...previousData,
+          bookmarks: newBookmarks,
+        })
       }
 
       return { previousData }

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -10,7 +10,7 @@ import {
   EXTENSION_CONSTANTS,
   type StatusInfo,
 } from '@shared/constants'
-import { bookmarksResponseSchema } from '@shared/schemas/bookmark'
+import { bookmarksSchema } from '@shared/schemas/bookmark'
 import { validateApiUrl, getOrigin } from '@shared/utils/url'
 
 import { useApi } from '../contexts/ApiContext'
@@ -100,7 +100,7 @@ export const useSettings = () => {
 
       if (result.success) {
         // Zod スキーマを使用してレスポンス形式を厳格に検証
-        const parsed = bookmarksResponseSchema.safeParse(result.data)
+        const parsed = bookmarksSchema.safeParse(result.data)
         if (parsed.success) {
           setConnectionStatus({
             type: UI_STATUS.SUCCESS,

--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -11,7 +11,7 @@ import {
   LOG_MESSAGES,
   UI_MESSAGES,
 } from '@shared/constants'
-import { updateBookmarkSchema } from '@shared/schemas/bookmark'
+import { updateBookmarkInputSchema } from '@shared/schemas/bookmark'
 import { MOCK_BOOKMARK_1, MOCK_KEYWORDS, MOCK_IDS } from '@shared/test/fixtures'
 import * as urlUtils from '@shared/utils/url'
 
@@ -80,7 +80,7 @@ describe('BookmarkPage Component', () => {
     server.use(
       http.patch('*/api/bookmarks/:id', async ({ request }) => {
         const body = await request.json()
-        const parsed = updateBookmarkSchema.parse(body)
+        const parsed = updateBookmarkInputSchema.parse(body)
         expect(parsed.title).toBe('New Title')
         expect(parsed.url).toBe('https://new-url.com')
         patchCalled = true


### PR DESCRIPTION
Issue #451 に対する実装です。

### 変更内容
- **ガイドラインの策定**: `docs/design/naming-conventions.md` を作成し、CRUD 準拠かつ名称衝突を回避する命名マトリクスを定義。
- **ドメイン層のリファクタリング**: `bookmark.ts`, `keyword.ts` 内の全ての入力型を `Input` カテゴリに、取得結果を `Object` カテゴリに整理。
- **通信層（API）のリネーム**: `api.ts` において `read` / `create` への動詞統一と、ドメイン層の `Input` を再利用する構造へ最適化。
- **全域的な同期**: `idb.ts`, `server/`, 各種 Hooks およびテストコードにおける全参照を新しい命名規則に漏れなく同期。

これにより、プロジェクト全体のアーキテクチャがより予測可能で、名称衝突のない堅牢な状態になりました。

Closes #451