### PR TITLE
[Shared] ブックマーク削除 (DELETE_BOOKMARK) のスキーマ定義

### DIFF
--- a/shared/schemas/api-bookmark.test.ts
+++ b/shared/schemas/api-bookmark.test.ts
@@ -9,6 +9,8 @@ import {
   createBookmarkResponseSchema,
   updateBookmarkRequestSchema,
   updateBookmarkResponseSchema,
+  deleteBookmarkRequestSchema,
+  deleteBookmarkResponseSchema,
 } from './api'
 import {
   MOCK_BOOKMARKS,
@@ -212,6 +214,57 @@ describe('API Schemas - Bookmark Operations', () => {
         },
       }
       expect(updateBookmarkResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
+      )
+    })
+  })
+
+  describe('deleteBookmarkRequestSchema', () => {
+    it('正しい DELETE_BOOKMARK リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.DELETE_BOOKMARK,
+        payload: {
+          id: MOCK_IDS.BOOKMARK_1,
+        },
+      }
+      expect(deleteBookmarkRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('不正な形式の ID を拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.DELETE_BOOKMARK,
+        payload: {
+          id: TEST_STRINGS.INVALID_ID,
+        },
+      }
+      expect(() => deleteBookmarkRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+  })
+
+  describe('deleteBookmarkResponseSchema', () => {
+    it('成功時の空データレスポンスを検証できること', () => {
+      const validResponse = {
+        success: true,
+        data: null,
+      }
+      expect(deleteBookmarkResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.BOOKMARK_NOT_FOUND,
+          code: ERROR_CODES.NOT_FOUND,
+        },
+      }
+      expect(deleteBookmarkResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -6,6 +6,7 @@ import {
   bookmarkSchema,
   bookmarksSchema,
   createBookmarkInputSchema,
+  deleteBookmarkInputSchema,
   updateBookmarkInputSchema,
 } from './bookmark'
 import {
@@ -186,6 +187,24 @@ export type UpdateBookmarkResponse = z.infer<
 >
 
 /**
+ * ブックマーク削除 (DELETE_BOOKMARK)
+ */
+export const deleteBookmarkRequestSchema = baseApiRequestSchema.extend({
+  action: z.literal(API_ACTIONS.DELETE_BOOKMARK),
+  payload: deleteBookmarkInputSchema,
+})
+
+export type DeleteBookmarkRequest = z.infer<typeof deleteBookmarkRequestSchema>
+
+export const deleteBookmarkResponseSchema = baseApiResponseSchema(
+  z.null(), // 削除時はデータなし
+)
+
+export type DeleteBookmarkResponse = z.infer<
+  typeof deleteBookmarkResponseSchema
+>
+
+/**
  * 全てのメッセージリクエストを統合したディスクリミネイテッドユニオン型
  * action フィールドを識別子として使用し、パースの効率とエラーメッセージを改善
  */
@@ -197,6 +216,7 @@ export const ApiRequestSchema = z.discriminatedUnion('action', [
   readBookmarksRequestSchema,
   createBookmarkRequestSchema,
   updateBookmarkRequestSchema,
+  deleteBookmarkRequestSchema,
 ])
 
 export type ApiRequest = z.infer<typeof ApiRequestSchema>

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -73,6 +73,15 @@ export const updateBookmarkInputSchema = z
 
 export type UpdateBookmarkInput = z.infer<typeof updateBookmarkInputSchema>
 
+/**
+ * ブックマーク削除のバリデーションスキーマ
+ */
+export const deleteBookmarkInputSchema = z.object({
+  id: BookmarkIdSchema,
+})
+
+export type DeleteBookmarkInput = z.infer<typeof deleteBookmarkInputSchema>
+
 export const reorderBookmarksInputSchema = z.object({
   ids: z
     .array(BookmarkIdSchema)


### PR DESCRIPTION
Issue #453
ブックマーク削除のための Zod スキーマと TypeScript 型を定義しました。

## 変更内容
- `shared/schemas/bookmark.ts`: `deleteBookmarkInputSchema` の追加
- `shared/schemas/api.ts`: `deleteBookmarkRequestSchema`, `deleteBookmarkResponseSchema` の追加、および `ApiRequestSchema` への統合
- `shared/schemas/api-bookmark.test.ts`: 削除スキーマのテスト追加