### PR TITLE
[Shared] ブックマーク並べ替え (REORDER_BOOKMARKS) のスキーマ定義

### DIFF
--- a/shared/schemas/api-bookmark.test.ts
+++ b/shared/schemas/api-bookmark.test.ts
@@ -11,6 +11,8 @@ import {
   updateBookmarkResponseSchema,
   deleteBookmarkRequestSchema,
   deleteBookmarkResponseSchema,
+  reorderBookmarksRequestSchema,
+  reorderBookmarksResponseSchema,
 } from './api'
 import {
   MOCK_BOOKMARKS,
@@ -18,6 +20,7 @@ import {
   VALID_URLS,
   TEST_STRINGS,
   MOCK_IDS,
+  generateMockUuidV7,
 } from '../test/fixtures'
 
 describe('API Schemas - Bookmark Operations', () => {
@@ -265,6 +268,84 @@ describe('API Schemas - Bookmark Operations', () => {
         },
       }
       expect(deleteBookmarkResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
+      )
+    })
+  })
+
+  describe('reorderBookmarksRequestSchema', () => {
+    it('正しい REORDER_BOOKMARKS リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.REORDER_BOOKMARKS,
+        payload: {
+          ids: [MOCK_IDS.BOOKMARK_1, MOCK_IDS.BOOKMARK_2],
+        },
+      }
+      expect(reorderBookmarksRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('空の ID リストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.REORDER_BOOKMARKS,
+        payload: {
+          ids: [],
+        },
+      }
+      expect(reorderBookmarksRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('IDリストが重複している場合に拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.REORDER_BOOKMARKS,
+        payload: {
+          ids: [MOCK_IDS.BOOKMARK_1, MOCK_IDS.BOOKMARK_1],
+        },
+      }
+      expect(() => reorderBookmarksRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+
+    it('1000件を超える ID リストを拒否すること', () => {
+      const manyIds = Array.from({ length: 1001 }, (_, i) =>
+        generateMockUuidV7(i),
+      )
+      const invalidRequest = {
+        action: API_ACTIONS.REORDER_BOOKMARKS,
+        payload: {
+          ids: manyIds,
+        },
+      }
+      expect(() => reorderBookmarksRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+  })
+
+  describe('reorderBookmarksResponseSchema', () => {
+    it('成功時の空データレスポンスを検証できること', () => {
+      const validResponse = {
+        success: true,
+        data: null,
+      }
+      expect(reorderBookmarksResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        },
+      }
+      expect(reorderBookmarksResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -7,6 +7,7 @@ import {
   bookmarksSchema,
   createBookmarkInputSchema,
   deleteBookmarkInputSchema,
+  reorderBookmarksInputSchema,
   updateBookmarkInputSchema,
 } from './bookmark'
 import {
@@ -205,6 +206,26 @@ export type DeleteBookmarkResponse = z.infer<
 >
 
 /**
+ * ブックマーク並べ替え (REORDER_BOOKMARKS)
+ */
+export const reorderBookmarksRequestSchema = baseApiRequestSchema.extend({
+  action: z.literal(API_ACTIONS.REORDER_BOOKMARKS),
+  payload: reorderBookmarksInputSchema,
+})
+
+export type ReorderBookmarksRequest = z.infer<
+  typeof reorderBookmarksRequestSchema
+>
+
+export const reorderBookmarksResponseSchema = baseApiResponseSchema(
+  z.null(), // 並べ替え成功時はデータなし
+)
+
+export type ReorderBookmarksResponse = z.infer<
+  typeof reorderBookmarksResponseSchema
+>
+
+/**
  * 全てのメッセージリクエストを統合したディスクリミネイテッドユニオン型
  * action フィールドを識別子として使用し、パースの効率とエラーメッセージを改善
  */
@@ -217,6 +238,7 @@ export const ApiRequestSchema = z.discriminatedUnion('action', [
   createBookmarkRequestSchema,
   updateBookmarkRequestSchema,
   deleteBookmarkRequestSchema,
+  reorderBookmarksRequestSchema,
 ])
 
 export type ApiRequest = z.infer<typeof ApiRequestSchema>


### PR DESCRIPTION
Issue #455
ブックマーク並べ替えのための Zod スキーマと TypeScript 型を定義しました。

## 変更内容
- `shared/schemas/api.ts`: `reorderBookmarksRequestSchema`, `reorderBookmarksResponseSchema` の追加、および `ApiRequestSchema` への統合
- `shared/schemas/api-bookmark.test.ts`: 並べ替えスキーマのテスト追加（空リスト、エラーレスポンスを含む）