### PR TITLE
[Shared] キーワード紐付け (ATTACH_KEYWORD) のスキーマ定義

### DIFF
--- a/shared/schemas/api-keyword.test.ts
+++ b/shared/schemas/api-keyword.test.ts
@@ -11,6 +11,8 @@ import {
   updateKeywordResponseSchema,
   deleteKeywordRequestSchema,
   deleteKeywordResponseSchema,
+  attachKeywordRequestSchema,
+  attachKeywordResponseSchema,
 } from './api'
 import { MOCK_KEYWORDS, MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
 
@@ -178,6 +180,68 @@ describe('API Schemas - Keyword Operations', () => {
         },
       }
       expect(deleteKeywordResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
+      )
+    })
+  })
+
+  describe('attachKeywordRequestSchema', () => {
+    it('正しい ATTACH_KEYWORD リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.ATTACH_KEYWORD,
+        payload: {
+          bookmarkId: MOCK_IDS.BOOKMARK_1,
+          keywordId: MOCK_IDS.KEYWORD_1,
+        },
+      }
+      expect(attachKeywordRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('bookmarkId が欠落している場合に拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.ATTACH_KEYWORD,
+        payload: {
+          keywordId: MOCK_IDS.KEYWORD_1,
+        },
+      }
+      expect(() => attachKeywordRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+
+    it('不正な形式の bookmarkId を拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.ATTACH_KEYWORD,
+        payload: {
+          bookmarkId: TEST_STRINGS.INVALID_ID,
+          keywordId: MOCK_IDS.KEYWORD_1,
+        },
+      }
+      expect(() => attachKeywordRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+  })
+
+  describe('attachKeywordResponseSchema', () => {
+    it('成功時のレスポンスを検証できること', () => {
+      const validResponse = { success: true, data: null }
+      expect(attachKeywordResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        },
+      }
+      expect(attachKeywordResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -11,6 +11,7 @@ import {
   updateBookmarkInputSchema,
 } from './bookmark'
 import {
+  attachKeywordInputSchema,
   createKeywordInputSchema,
   KeywordIdSchema,
   keywordResponseSchema,
@@ -154,6 +155,24 @@ export const readBookmarksResponseSchema =
 export type ReadBookmarksResponse = z.infer<typeof readBookmarksResponseSchema>
 
 /**
+ * キーワード紐付け (ATTACH_KEYWORD)
+ */
+export const attachKeywordRequestSchema = baseApiRequestSchema.extend({
+  action: z.literal(API_ACTIONS.ATTACH_KEYWORD),
+  payload: attachKeywordInputSchema.extend({
+    bookmarkId: z.string().uuid(),
+  }),
+})
+
+export type AttachKeywordRequest = z.infer<typeof attachKeywordRequestSchema>
+
+export const attachKeywordResponseSchema = baseApiResponseSchema(
+  z.null(), // 紐付け成功時はデータなし
+)
+
+export type AttachKeywordResponse = z.infer<typeof attachKeywordResponseSchema>
+
+/**
  * ブックマーク追加 (ADD_BOOKMARK)
  */
 export const createBookmarkRequestSchema = baseApiRequestSchema.extend({
@@ -234,6 +253,7 @@ export const ApiRequestSchema = z.discriminatedUnion('action', [
   createKeywordRequestSchema,
   updateKeywordRequestSchema,
   deleteKeywordRequestSchema,
+  attachKeywordRequestSchema,
   readBookmarksRequestSchema,
   createBookmarkRequestSchema,
   updateBookmarkRequestSchema,


### PR DESCRIPTION
Issue #458
キーワード紐付けのための Zod スキーマと TypeScript 型を定義しました。

## 変更内容
- `shared/schemas/keyword.ts`: `attachKeywordInputSchema` を命名規則に合わせ修正（`bookmarkId` を `optional` で追加）
- `shared/schemas/api.ts`: `attachKeywordRequestSchema`, `attachKeywordResponseSchema` の追加、および `ApiRequestSchema` への統合
- `shared/schemas/api-keyword.test.ts`: 紐付けスキーマのテスト追加（`bookmarkId` の `optional` 検証、エラーレスポンスを含む）