### PR TITLE
[Shared] キーワード解除 (DETACH_KEYWORD) のスキーマ定義

### DIFF
--- a/shared/schemas/api-keyword.test.ts
+++ b/shared/schemas/api-keyword.test.ts
@@ -13,6 +13,8 @@ import {
   deleteKeywordResponseSchema,
   attachKeywordRequestSchema,
   attachKeywordResponseSchema,
+  detachKeywordRequestSchema,
+  detachKeywordResponseSchema,
 } from './api'
 import { MOCK_KEYWORDS, MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
 
@@ -242,6 +244,68 @@ describe('API Schemas - Keyword Operations', () => {
         },
       }
       expect(attachKeywordResponseSchema.parse(errorResponse)).toEqual(
+        errorResponse,
+      )
+    })
+  })
+
+  describe('detachKeywordRequestSchema', () => {
+    it('正しい DETACH_KEYWORD リクエストを受け入れること', () => {
+      const validRequest = {
+        action: API_ACTIONS.DETACH_KEYWORD,
+        payload: {
+          bookmarkId: MOCK_IDS.BOOKMARK_1,
+          keywordId: MOCK_IDS.KEYWORD_1,
+        },
+      }
+      expect(detachKeywordRequestSchema.parse(validRequest)).toEqual(
+        validRequest,
+      )
+    })
+
+    it('bookmarkId が欠落している場合に拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.DETACH_KEYWORD,
+        payload: {
+          keywordId: MOCK_IDS.KEYWORD_1,
+        },
+      }
+      expect(() => detachKeywordRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+
+    it('不正な形式の bookmarkId を拒否すること', () => {
+      const invalidRequest = {
+        action: API_ACTIONS.DETACH_KEYWORD,
+        payload: {
+          bookmarkId: TEST_STRINGS.INVALID_ID,
+          keywordId: MOCK_IDS.KEYWORD_1,
+        },
+      }
+      expect(() => detachKeywordRequestSchema.parse(invalidRequest)).toThrow(
+        ZodError,
+      )
+    })
+  })
+
+  describe('detachKeywordResponseSchema', () => {
+    it('成功時のレスポンスを検証できること', () => {
+      const validResponse = { success: true, data: null }
+      expect(detachKeywordResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+
+    it('エラー時のレスポンスを検証できること', () => {
+      const errorResponse = {
+        success: false,
+        error: {
+          message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+          code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+        },
+      }
+      expect(detachKeywordResponseSchema.parse(errorResponse)).toEqual(
         errorResponse,
       )
     })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -13,6 +13,7 @@ import {
 import {
   attachKeywordInputSchema,
   createKeywordInputSchema,
+  detachKeywordInputSchema,
   KeywordIdSchema,
   keywordResponseSchema,
   keywordsSchema,
@@ -160,7 +161,7 @@ export type ReadBookmarksResponse = z.infer<typeof readBookmarksResponseSchema>
 export const attachKeywordRequestSchema = baseApiRequestSchema.extend({
   action: z.literal(API_ACTIONS.ATTACH_KEYWORD),
   payload: attachKeywordInputSchema.extend({
-    bookmarkId: z.string().uuid(),
+    bookmarkId: BookmarkIdSchema,
   }),
 })
 
@@ -171,6 +172,20 @@ export const attachKeywordResponseSchema = baseApiResponseSchema(
 )
 
 export type AttachKeywordResponse = z.infer<typeof attachKeywordResponseSchema>
+
+/**
+ * キーワード解除 (DETACH_KEYWORD)
+ */
+export const detachKeywordRequestSchema = baseApiRequestSchema.extend({
+  action: z.literal(API_ACTIONS.DETACH_KEYWORD),
+  payload: detachKeywordInputSchema.extend({ bookmarkId: BookmarkIdSchema }),
+})
+
+export type DetachKeywordRequest = z.infer<typeof detachKeywordRequestSchema>
+
+export const detachKeywordResponseSchema = baseApiResponseSchema(z.null())
+
+export type DetachKeywordResponse = z.infer<typeof detachKeywordResponseSchema>
 
 /**
  * ブックマーク追加 (ADD_BOOKMARK)
@@ -254,6 +269,7 @@ export const ApiRequestSchema = z.discriminatedUnion('action', [
   updateKeywordRequestSchema,
   deleteKeywordRequestSchema,
   attachKeywordRequestSchema,
+  detachKeywordRequestSchema,
   readBookmarksRequestSchema,
   createBookmarkRequestSchema,
   updateBookmarkRequestSchema,

--- a/shared/schemas/keyword.ts
+++ b/shared/schemas/keyword.ts
@@ -61,3 +61,9 @@ export const attachKeywordInputSchema = z.object({
   keywordId: KeywordIdSchema,
 })
 export type AttachKeywordInput = z.infer<typeof attachKeywordInputSchema>
+
+export const detachKeywordInputSchema = z.object({
+  keywordId: KeywordIdSchema,
+})
+
+export type DetachKeywordInput = z.infer<typeof detachKeywordInputSchema>


### PR DESCRIPTION
Issue #460
キーワード解除のための Zod スキーマと TypeScript 型を定義しました。

## 変更内容
- `shared/schemas/keyword.ts`: `detachKeywordInputSchema` の追加
- `shared/schemas/api.ts`: `detachKeywordRequestSchema`, `detachKeywordResponseSchema` の追加、および `ApiRequestSchema` への統合
- `shared/schemas/api-keyword.test.ts`: 解除スキーマのテスト追加