### PR TITLE
[Shared] ブックマーク登録状態確認 (READ_BOOKMARK_STATUS) のスキーマ定義

### DIFF
--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -355,6 +355,8 @@ export const API_ACTIONS = {
   DELETE_BOOKMARK: 'DELETE_BOOKMARK',
   REORDER_BOOKMARKS: 'REORDER_BOOKMARKS',
 
+  READ_BOOKMARK_STATUS: 'READ_BOOKMARK_STATUS',
+
   // キーワード操作
   GET_KEYWORDS: 'GET_KEYWORDS',
   ADD_KEYWORD: 'ADD_KEYWORD',
@@ -446,6 +448,8 @@ export const VALIDATION_MESSAGES = {
     'タイトルまたは URL の少なくとも一方は指定する必要があります',
   REORDER_MAX_ITEMS: '一度に並び替えられるのは1000件までです',
   REORDER_DUPLICATE_IDS: 'IDリストに重複が含まれています',
+  BOOKMARK_STATUS_REQUIRED_BOOKMARKID:
+    '登録済み、変更ありの場合にはBOOKMARK IDが必要です',
 } as const
 
 /**

--- a/shared/schemas/api-bookmark.test.ts
+++ b/shared/schemas/api-bookmark.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import { ZodError } from 'zod'
 
-import { API_ACTIONS, ERROR_MESSAGES, ERROR_CODES } from '../constants'
+import {
+  API_ACTIONS,
+  ERROR_MESSAGES,
+  ERROR_CODES,
+  BOOKMARK_STATUS,
+} from '../constants'
 import {
   readBookmarksRequestSchema,
   readBookmarksResponseSchema,
@@ -13,6 +18,8 @@ import {
   deleteBookmarkResponseSchema,
   reorderBookmarksRequestSchema,
   reorderBookmarksResponseSchema,
+  readBookmarkStatusRequestSchema,
+  readBookmarkStatusResponseSchema,
 } from './api'
 import {
   MOCK_BOOKMARKS,
@@ -349,5 +356,93 @@ describe('API Schemas - Bookmark Operations', () => {
         errorResponse,
       )
     })
+  })
+
+  describe('readBookmarkStatusRequestSchema', () => {
+    it.each([
+      {
+        name: 'タイトルあり',
+        validPayload: {
+          url: MOCK_BOOKMARK_1.url,
+          title: MOCK_BOOKMARK_1.title,
+        },
+      },
+      {
+        name: 'タイトルなし',
+        validPayload: {
+          url: MOCK_BOOKMARK_1.url,
+        },
+      },
+    ])(
+      '正しいreadBookmarkStatusRequestSchemaリクエスト $name を受け入れること',
+      ({ validPayload }) => {
+        const validRequest = {
+          action: API_ACTIONS.READ_BOOKMARK_STATUS,
+          payload: validPayload,
+        }
+        expect(readBookmarkStatusRequestSchema.parse(validRequest)).toEqual(
+          validRequest,
+        )
+      },
+    )
+
+    it.each([
+      {
+        name: 'URLがない場合',
+        invalidPayload: {},
+      },
+      {
+        name: '不正な URL 形式',
+        invalidPayload: { url: TEST_STRINGS.INVALID_ID },
+      },
+    ])(
+      '間違ったreadBookmarkStatusRequestSchemaリクエスト $name を拒否すること',
+      ({ invalidPayload }) => {
+        expect(() =>
+          readBookmarkStatusRequestSchema.parse({
+            action: API_ACTIONS.READ_BOOKMARK_STATUS,
+            payload: invalidPayload,
+          }),
+        ).toThrow(ZodError)
+      },
+    )
+  })
+
+  describe('readBookmarkStatusResponseSchema', () => {
+    it.each([
+      { name: '未登録', validData: { status: BOOKMARK_STATUS.NONE } },
+      {
+        name: '登録済み',
+        validData: {
+          status: BOOKMARK_STATUS.REGISTERED,
+          bookmarkId: MOCK_IDS.BOOKMARK_1,
+        },
+      },
+      {
+        name: '変更あり',
+        validData: {
+          status: BOOKMARK_STATUS.MODIFIED,
+          bookmarkId: MOCK_IDS.BOOKMARK_1,
+        },
+      },
+    ])('成功時 $name のレスポンスを検証できること', ({ validData }) => {
+      const validResponse = { success: true, data: validData }
+      expect(readBookmarkStatusResponseSchema.parse(validResponse)).toEqual(
+        validResponse,
+      )
+    })
+  })
+
+  it('エラー時のレスポンスを検証できること', () => {
+    const errorResponse = {
+      success: false,
+      error: {
+        message: ERROR_MESSAGES.INTERNAL_SERVER_ERROR,
+        code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+      },
+    }
+    expect(readBookmarkStatusResponseSchema.parse(errorResponse)).toEqual(
+      errorResponse,
+    )
   })
 })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -7,8 +7,10 @@ import {
   bookmarksSchema,
   createBookmarkInputSchema,
   deleteBookmarkInputSchema,
+  bookmarkStatusResponseSchema,
   reorderBookmarksInputSchema,
   updateBookmarkInputSchema,
+  readBookmarkStatusInputSchema,
 } from './bookmark'
 import {
   attachKeywordInputSchema,
@@ -260,6 +262,27 @@ export type ReorderBookmarksResponse = z.infer<
 >
 
 /**
+ * ブックマーク登録状態確認 (READ_BOOKMARK_STATUS)
+ */
+
+export const readBookmarkStatusRequestSchema = baseApiRequestSchema.extend({
+  action: z.literal(API_ACTIONS.READ_BOOKMARK_STATUS),
+  payload: readBookmarkStatusInputSchema, // ドメイン層の定義を再利用
+})
+
+export type ReadBookmarkStatusRequest = z.infer<
+  typeof readBookmarkStatusRequestSchema
+>
+
+export const readBookmarkStatusResponseSchema = baseApiResponseSchema(
+  bookmarkStatusResponseSchema,
+)
+
+export type ReadBookmarkStatusResponse = z.infer<
+  typeof readBookmarkStatusResponseSchema
+>
+
+/**
  * 全てのメッセージリクエストを統合したディスクリミネイテッドユニオン型
  * action フィールドを識別子として使用し、パースの効率とエラーメッセージを改善
  */
@@ -275,6 +298,7 @@ export const ApiRequestSchema = z.discriminatedUnion('action', [
   updateBookmarkRequestSchema,
   deleteBookmarkRequestSchema,
   reorderBookmarksRequestSchema,
+  readBookmarkStatusRequestSchema,
 ])
 
 export type ApiRequest = z.infer<typeof ApiRequestSchema>

--- a/shared/schemas/bookmark.test.ts
+++ b/shared/schemas/bookmark.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect } from 'vitest'
+import { ZodError } from 'zod'
 
 import {
   bookmarkSchema,
+  bookmarkStatusResponseSchema,
+  bookmarkStatusSchema,
   createBookmarkInputSchema,
+  readBookmarkStatusInputSchema,
   reorderBookmarksInputSchema,
   updateBookmarkInputSchema,
 } from './bookmark'
-import { VALIDATION_MESSAGES } from '../constants'
+import { BOOKMARK_STATUS, VALIDATION_MESSAGES } from '../constants'
 import {
   MOCK_BOOKMARK_1,
   MOCK_BOOKMARK_TITLE_PREFIX,
@@ -14,6 +18,7 @@ import {
   VALID_URLS,
   MOCK_IDS,
   generateMockUuidV7,
+  TEST_STRINGS,
 } from '../test/fixtures'
 
 describe('bookmarkSchema', () => {
@@ -134,5 +139,101 @@ describe('reorderBookmarksInputSchema', () => {
         VALIDATION_MESSAGES.REORDER_MAX_ITEMS,
       )
     }
+  })
+})
+
+describe('readBookmarkStatusInputSchema', () => {
+  it('正常な入力(titleなし)を受け入れること', () => {
+    const valid = { url: MOCK_BOOKMARK_1.url }
+    expect(readBookmarkStatusInputSchema.safeParse(valid).success).toBe(true)
+  })
+
+  it('正常な入力(titleあり)を受け入れること', () => {
+    const valid = { url: MOCK_BOOKMARK_1.url, title: MOCK_BOOKMARK_1.title }
+    expect(readBookmarkStatusInputSchema.safeParse(valid).success).toBe(true)
+  })
+
+  it('URLがない場合エラーになること', () => {
+    const invalid = { title: MOCK_BOOKMARK_1.title }
+    expect(() => readBookmarkStatusInputSchema.parse(invalid)).toThrow(ZodError)
+  })
+})
+
+describe('bookmarkStatusSchema', () => {
+  it('定義された全ステータスを許可すること', () => {
+    Object.values(BOOKMARK_STATUS).forEach((status) => {
+      expect(bookmarkStatusSchema.parse(status)).toBe(status)
+    })
+  })
+
+  it('未定義のステータスを拒否すること', () => {
+    expect(() =>
+      bookmarkStatusSchema.parse(TEST_STRINGS.INVALID_ACTION),
+    ).toThrow(ZodError)
+  })
+})
+
+describe('bookmarkStatusResponseSchema', () => {
+  it.each([
+    {
+      name: '登録済み',
+      data: {
+        status: BOOKMARK_STATUS.REGISTERED,
+        bookmarkId: MOCK_IDS.BOOKMARK_1,
+      },
+    },
+    {
+      name: '変更',
+      data: {
+        status: BOOKMARK_STATUS.MODIFIED,
+        bookmarkId: MOCK_IDS.BOOKMARK_1,
+      },
+    },
+    {
+      name: '未登録',
+      data: {
+        status: BOOKMARK_STATUS.NONE,
+      },
+    },
+  ])('成功時 $name のレスポンスを検証できること', ({ data }) => {
+    expect(bookmarkStatusResponseSchema.parse(data)).toEqual(data)
+  })
+
+  it.each([
+    {
+      name: '不正なステータス値',
+      invalidData: {
+        status: 'INVALID_STATUS',
+      },
+    },
+    {
+      name: 'ステータスが欠落している場合',
+      invalidData: {
+        bookmarkId: MOCK_IDS.BOOKMARK_1,
+      },
+    },
+    {
+      name: '不正な形式の bookmarkId',
+      invalidData: {
+        status: BOOKMARK_STATUS.REGISTERED,
+        bookmarkId: 'not-a-uuid',
+      },
+    },
+    {
+      name: '登録済みでIDがない場合',
+      invalidData: {
+        status: BOOKMARK_STATUS.REGISTERED,
+      },
+    },
+    {
+      name: '変更ありでIDがない場合',
+      invalidData: {
+        status: BOOKMARK_STATUS.MODIFIED,
+      },
+    },
+  ])('異常系: $name を拒否すること', ({ invalidData }) => {
+    expect(() => bookmarkStatusResponseSchema.parse(invalidData)).toThrow(
+      ZodError,
+    )
   })
 })

--- a/shared/schemas/bookmark.ts
+++ b/shared/schemas/bookmark.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { VALIDATION_MESSAGES } from '../constants'
+import { BOOKMARK_STATUS, VALIDATION_MESSAGES } from '../constants'
 import { keywordSchema, KeywordIdSchema } from './keyword'
 import { isHttpUrl } from '../utils/url'
 
@@ -92,6 +92,44 @@ export const reorderBookmarksInputSchema = z.object({
 })
 
 export type ReorderBookmarksInput = z.infer<typeof reorderBookmarksInputSchema>
+
+/**
+ * ブックマーク登録状態確認のバリデーションスキーマ
+ */
+
+export const readBookmarkStatusInputSchema = z.object({
+  url: bookmarkUrlSchema,
+  title: z.string().optional(),
+})
+
+export type ReadBookmarkStatusInput = z.infer<
+  typeof readBookmarkStatusInputSchema
+>
+
+export const bookmarkStatusSchema = z.enum(
+  Object.values(BOOKMARK_STATUS) as [string, ...string[]],
+)
+
+export const bookmarkStatusResponseSchema = z
+  .object({
+    status: bookmarkStatusSchema,
+    bookmarkId: BookmarkIdSchema.optional(), // 登録済みの場合はIDを返す
+  })
+  .refine(
+    (data) => {
+      if (
+        data.status === BOOKMARK_STATUS.REGISTERED ||
+        data.status === BOOKMARK_STATUS.MODIFIED
+      ) {
+        return !!data.bookmarkId // IDが必須
+      }
+      return true
+    },
+    {
+      message: VALIDATION_MESSAGES.BOOKMARK_STATUS_REQUIRED_BOOKMARKID,
+      path: ['bookmarkId'],
+    },
+  )
 
 export const bookmarksSchema = z.object({
   bookmarks: z.array(bookmarkSchema),


### PR DESCRIPTION
Issue #463
ブックマーク登録状態確認のための Zod スキーマと TypeScript 型を定義しました。

## 変更内容
- `shared/constants.ts`: `READ_BOOKMARK_STATUS` アクションを追加
- `shared/schemas/bookmark.ts`: `readBookmarkStatusInputSchema`, `bookmarkStatusSchema`, `bookmarkStatusResponseSchema` を定義。ステータスに応じた ID 必須チェックを追加
- `shared/schemas/api.ts`: `readBookmarkStatusRequestSchema`, `readBookmarkStatusResponseSchema` の追加と統合
- `shared/schemas/bookmark.test.ts`: ドメイン層の厳格なバリデーションテストを追加
- `shared/schemas/api-bookmark.test.ts`: 通信層のテストケースを追加