### PR TITLE
[Shared] API アクション定数名の命名規則統一 (GET/ADD -> READ/CREATE)

### DIFF
--- a/docs/design/naming-conventions.md
+++ b/docs/design/naming-conventions.md
@@ -62,7 +62,7 @@
 | **キーワード紐付け** | Input    | `attachKeywordInputSchema`    | `{ bookmarkId: BookmarkId, keywordId: KeywordId }` |
 | **キーワード解除**   | Input    | `detachKeywordInputSchema`    | `{ bookmarkId: BookmarkId, keywordId: KeywordId }` |
 | **ブックマーク取得** | Object   | `bookmarksSchema`             | `{ bookmarks: Bookmark[] }`                        |
-| **ブックマーク追加** | Input    | `createBookmarkInputSchema`   | `{ title: string, url: string }`                   |
+| **ブックマーク作成** | Input    | `createBookmarkInputSchema`   | `{ title: string, url: string }`                   |
 | **ブックマーク更新** | Input    | `updateBookmarkInputSchema`   | `{ title?: string, url?: string }`                 |
 | **ブックマーク削除** | Input    | `deleteBookmarkInputSchema`   | `{ id: BookmarkId }`                               |
 | **ブックマーク並替** | Input    | `reorderBookmarksInputSchema` | `{ ids: BookmarkId[] }`                            |
@@ -80,7 +80,7 @@
 | **キーワード紐付け** | `attachKeywordRequestSchema`    | `action: ATTACH_KEYWORD`, `payload: AttachKeywordInput`                        | `null`             |
 | **キーワード解除**   | `detachKeywordRequestSchema`    | `action: DETACH_KEYWORD`, `payload: DetachKeywordInput`                        | `null`             |
 | **ブックマーク取得** | `readBookmarksRequestSchema`    | `action: READ_BOOKMARKS`, `payload: undefined`                                 | `Bookmarks`        |
-| **ブックマーク追加** | `createBookmarkRequestSchema`   | `action: CREATE_BOOKMARK`, `payload: CreateBookmarkInput`                      | `Bookmark`         |
+| **ブックマーク作成** | `createBookmarkRequestSchema`   | `action: CREATE_BOOKMARK`, `payload: CreateBookmarkInput`                      | `Bookmark`         |
 | **ブックマーク更新** | `updateBookmarkRequestSchema`   | `action: UPDATE_BOOKMARK`, `payload: UpdateBookmarkInput & { id: BookmarkId }` | `Bookmark`         |
 | **ブックマーク削除** | `deleteBookmarkRequestSchema`   | `action: DELETE_BOOKMARK`, `payload: DeleteBookmarkInput`                      | `null`             |
 | **ブックマーク並替** | `reorderBookmarksRequestSchema` | `action: REORDER_BOOKMARKS`, `payload: ReorderBookmarksInput`                  | `null`             |

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -34,7 +34,7 @@ const queryClient = new QueryClient({
 /**
  * ブックマーク一覧をキャッシュまたは API から取得する内部関数
  */
-const getBookmarksData = async (apiUrl: string) => {
+const readBookmarksData = async (apiUrl: string) => {
   const urlError = validateApiUrl(apiUrl)
   if (urlError) {
     throw new Error(urlError)
@@ -83,7 +83,7 @@ const updateIconStatus = async (
       return
     }
 
-    const data = await getBookmarksData(apiUrl)
+    const data = await readBookmarksData(apiUrl)
 
     // 状態判定 (共通ユーティリティを使用)
     const bookmark = findBookmarkByUrl(data.bookmarks, url)
@@ -136,7 +136,7 @@ const handleCheckBookmarkStatus = async (
       throw new Error('API URL not configured')
     }
 
-    const data = await getBookmarksData(apiUrl)
+    const data = await readBookmarksData(apiUrl)
     const bookmark = findBookmarkByUrl(data.bookmarks, url)
     const status = determineBookmarkStatus(bookmark, title)
 

--- a/extension/src/lib/bookmark-idb.test.ts
+++ b/extension/src/lib/bookmark-idb.test.ts
@@ -2,10 +2,7 @@ import 'fake-indexeddb/auto'
 import { describe, it, expect, beforeEach } from 'vitest'
 
 import { ERROR_MESSAGES } from '@shared/constants'
-import {
-  type BookmarkId,
-  BookmarkIdSchema,
-} from '@shared/schemas/bookmark'
+import { type BookmarkId, BookmarkIdSchema } from '@shared/schemas/bookmark'
 import {
   MOCK_BOOKMARK_ENTITY_1,
   MOCK_BOOKMARK_ENTITY_2,
@@ -37,19 +34,19 @@ describe('BookmarkDatabase - Bookmark Operations', () => {
       expect(result[1].id).toBe(b1.id) // sortOrder: 10 が次
     })
 
-    it('addBookmark が最初のアイテムを追加する際、sortOrder 0 を割り当てること', async () => {
+    it('createBookmark が最初のアイテムを追加する際、sortOrder 0 を割り当てること', async () => {
       const params = {
         title: `${MOCK_BOOKMARK_TITLE_PREFIX} First`,
         url: VALID_URLS.GOOGLE,
       }
-      const id = await db.addBookmark(params)
+      const id = await db.createBookmark(params)
 
       const saved = await db.bookmarks.get(id)
       expect(saved?.sortOrder).toBe(0)
       expect(saved?.title).toBe(params.title)
     })
 
-    it('addBookmark が既存アイテムがある場合、最小 sortOrder - 1 を割り当てること', async () => {
+    it('createBookmark が既存アイテムがある場合、最小 sortOrder - 1 を割り当てること', async () => {
       // 既存データ (sortOrder: 0)
       await db.bookmarks.add({ ...MOCK_BOOKMARK_ENTITY_1, sortOrder: 0 })
 
@@ -57,13 +54,13 @@ describe('BookmarkDatabase - Bookmark Operations', () => {
         title: `${MOCK_BOOKMARK_TITLE_PREFIX} New Top`,
         url: VALID_URLS.HTTPS,
       }
-      const id = await db.addBookmark(params)
+      const id = await db.createBookmark(params)
 
       const saved = await db.bookmarks.get(id)
       expect(saved?.sortOrder).toBe(-1)
 
       // さらに追加
-      const id2 = await db.addBookmark({
+      const id2 = await db.createBookmark({
         title: `${MOCK_BOOKMARK_TITLE_PREFIX} New Top 2`,
         url: VALID_URLS.HTTP,
       })
@@ -71,9 +68,9 @@ describe('BookmarkDatabase - Bookmark Operations', () => {
       expect(saved2?.sortOrder).toBe(-2)
     })
 
-    it('addBookmark が不正な URL の場合、バリデーションエラーを投げること', async () => {
+    it('createBookmark が不正な URL の場合、バリデーションエラーを投げること', async () => {
       const params = { title: 'Invalid', url: 'not-a-url' }
-      await expect(db.addBookmark(params)).rejects.toThrow()
+      await expect(db.createBookmark(params)).rejects.toThrow()
     })
 
     it('前後の空白を含むタイトルや URL が自動的にトリムされて保存されること', async () => {
@@ -81,7 +78,7 @@ describe('BookmarkDatabase - Bookmark Operations', () => {
         title: TEST_STRINGS.PRE_TRIMMED_NAME,
         url: `  ${VALID_URLS.GOOGLE}  `,
       }
-      const id = await db.addBookmark(params)
+      const id = await db.createBookmark(params)
 
       const saved = await db.bookmarks.get(id)
       expect(saved?.title).toBe(TEST_STRINGS.TRIMMED_NAME)
@@ -120,7 +117,8 @@ describe('BookmarkDatabase - Bookmark Operations', () => {
     })
 
     it('不正な形式の ID での更新を試みた場合にバリデーションエラーを投げること', async () => {
-      const invalidId = TEST_STRINGS.INVALID_ID as unknown as import('@shared/schemas/bookmark').BookmarkId
+      const invalidId =
+        TEST_STRINGS.INVALID_ID as unknown as import('@shared/schemas/bookmark').BookmarkId
       await expect(
         db.updateBookmark(invalidId, { title: TEST_STRINGS.NEW_NAME }),
       ).rejects.toThrow()

--- a/extension/src/lib/idb.ts
+++ b/extension/src/lib/idb.ts
@@ -71,9 +71,9 @@ export class BookmarkDatabase extends Dexie {
   }
 
   /**
-   * ブックマークを追加する
+   * ブックマークを作成する
    */
-  async addBookmark(params: CreateBookmarkInput): Promise<BookmarkId> {
+  async createBookmark(params: CreateBookmarkInput): Promise<BookmarkId> {
     // バリデーションにプロジェクト標準のスキーマを使用
     const validated = createBookmarkInputSchema.parse(params)
 
@@ -276,10 +276,10 @@ export class BookmarkDatabase extends Dexie {
   }
 
   /**
-   * キーワードを追加する。同名のキーワードが既に存在する場合は、その ID を返す。
+   * キーワードを作成する。同名のキーワードが既に存在する場合は、その ID を返す。
    * @param params 名前を含むキーワード情報（IDは任意）
    */
-  async addKeyword(params: { name: string }): Promise<KeywordId> {
+  async createKeyword(params: { name: string }): Promise<KeywordId> {
     // バリデーション (スキーマで定義された trim 等を適用)
     const name = keywordSchema.shape.name.parse(params.name)
 

--- a/extension/src/lib/keyword-idb.test.ts
+++ b/extension/src/lib/keyword-idb.test.ts
@@ -26,9 +26,9 @@ describe('BookmarkDatabase - Keyword Operations', () => {
       expect(result).toEqual(expect.arrayContaining(MOCK_KEYWORDS))
     })
 
-    it('addKeyword が新しいキーワードを保存し、その ID を返すこと', async () => {
+    it('createKeyword が新しいキーワードを保存し、その ID を返すこと', async () => {
       const newKeyword = { name: TEST_STRINGS.NEW_NAME }
-      const id = await db.addKeyword(newKeyword)
+      const id = await db.createKeyword(newKeyword)
 
       expect(KeywordIdSchema.safeParse(id).success).toBe(true)
 
@@ -41,20 +41,20 @@ describe('BookmarkDatabase - Keyword Operations', () => {
       const existing = MOCK_KEYWORDS[0]
       await db.keywords.add(existing)
 
-      const id = await db.addKeyword({ name: existing.name })
+      const id = await db.createKeyword({ name: existing.name })
 
       expect(id).toBe(existing.id)
       const count = await db.keywords.count()
       expect(count).toBe(1)
     })
 
-    it('不正な名前（空文字等）のキーワード追加を拒否すること', async () => {
-      await expect(db.addKeyword({ name: '' })).rejects.toThrow()
-      await expect(db.addKeyword({ name: '   ' })).rejects.toThrow()
+    it('不正な名前（空文字等）のキーワード作成を拒否すること', async () => {
+      await expect(db.createKeyword({ name: '' })).rejects.toThrow()
+      await expect(db.createKeyword({ name: '   ' })).rejects.toThrow()
     })
 
     it('前後の空白を含むキーワードが自動的にトリムされて保存されること', async () => {
-      const id = await db.addKeyword({ name: TEST_STRINGS.PRE_TRIMMED_NAME })
+      const id = await db.createKeyword({ name: TEST_STRINGS.PRE_TRIMMED_NAME })
       const saved = await db.keywords.get(id)
       expect(saved?.name).toBe(TEST_STRINGS.TRIMMED_NAME)
     })

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -31,7 +31,7 @@ export const FIELD_LABELS = {
   OTHER_BOOKMARKS_LABEL: 'その他のブックマーク',
   ASSIGNED_KEYWORDS_LABEL: '割り当て済みのキーワード',
   UNASSIGNED_KEYWORDS_LABEL: '利用可能なキーワード',
-  ADD_KEYWORD_LABEL: '追加するキーワード',
+  CREATE_KEYWORD_LABEL: '作成するキーワード',
   FRONTEND_URL: 'Web アプリ URL',
 } as const
 
@@ -349,8 +349,8 @@ export const DB_CONSTANTS = {
  */
 export const API_ACTIONS = {
   // ブックマーク操作
-  GET_BOOKMARKS: 'GET_BOOKMARKS',
-  ADD_BOOKMARK: 'ADD_BOOKMARK',
+  READ_BOOKMARKS: 'READ_BOOKMARKS',
+  CREATE_BOOKMARK: 'CREATE_BOOKMARK',
   UPDATE_BOOKMARK: 'UPDATE_BOOKMARK',
   DELETE_BOOKMARK: 'DELETE_BOOKMARK',
   REORDER_BOOKMARKS: 'REORDER_BOOKMARKS',
@@ -358,8 +358,8 @@ export const API_ACTIONS = {
   READ_BOOKMARK_STATUS: 'READ_BOOKMARK_STATUS',
 
   // キーワード操作
-  GET_KEYWORDS: 'GET_KEYWORDS',
-  ADD_KEYWORD: 'ADD_KEYWORD',
+  READ_KEYWORDS: 'READ_KEYWORDS',
+  CREATE_KEYWORD: 'CREATE_KEYWORD',
   UPDATE_KEYWORD: 'UPDATE_KEYWORD',
   DELETE_KEYWORD: 'DELETE_KEYWORD',
 
@@ -418,7 +418,8 @@ export const LOG_MESSAGES = {
   DELETE_KEYWORD_FAILED: 'Failed to delete keyword:',
   ATTACH_KEYWORD_FAILED: 'Failed to attach keyword:',
   DETACH_KEYWORD_FAILED: 'Failed to detach keyword:',
-  UNEXPECTED_ERROR_IN_ADD_KEYWORD: 'Unexpected error in handleAddKeyword:',
+  UNEXPECTED_ERROR_IN_CREATE_KEYWORD:
+    'Unexpected error in handleCreateKeyword:',
   UPDATE_KEYWORD_PLACEHOLDER: (name: string) => `Update keyword: ${name}`,
   DELETE_KEYWORD_PLACEHOLDER: (id: string | number) => `Delete keyword: ${id}`,
   API_RESPONSE_PARSE_FAILED: (status: number) =>

--- a/shared/schemas/api-bookmark.test.ts
+++ b/shared/schemas/api-bookmark.test.ts
@@ -32,15 +32,15 @@ import {
 
 describe('API Schemas - Bookmark Operations', () => {
   describe('readBookmarksRequestSchema', () => {
-    it('正しい GET_BOOKMARKS リクエストを受け入れること', () => {
-      const validRequest = { action: API_ACTIONS.GET_BOOKMARKS }
+    it('正しい READ_BOOKMARKS リクエストを受け入れること', () => {
+      const validRequest = { action: API_ACTIONS.READ_BOOKMARKS }
       expect(readBookmarksRequestSchema.parse(validRequest)).toEqual(
         validRequest,
       )
     })
 
     it('不正なアクションを持つリクエストを拒否すること', () => {
-      const invalidRequest = { action: API_ACTIONS.GET_KEYWORDS }
+      const invalidRequest = { action: API_ACTIONS.READ_KEYWORDS }
       expect(() => readBookmarksRequestSchema.parse(invalidRequest)).toThrow(
         ZodError,
       )
@@ -73,9 +73,9 @@ describe('API Schemas - Bookmark Operations', () => {
   })
 
   describe('createBookmarkRequestSchema', () => {
-    it('正しい ADD_BOOKMARK リクエストを受け入れること', () => {
+    it('正しい CREATE_BOOKMARK リクエストを受け入れること', () => {
       const validRequest = {
-        action: API_ACTIONS.ADD_BOOKMARK,
+        action: API_ACTIONS.CREATE_BOOKMARK,
         payload: {
           title: TEST_STRINGS.NEW_NAME,
           url: VALID_URLS.GOOGLE,
@@ -88,7 +88,7 @@ describe('API Schemas - Bookmark Operations', () => {
 
     it('不正な形式のペイロード（空タイトル）を拒否すること', () => {
       const invalidRequest = {
-        action: API_ACTIONS.ADD_BOOKMARK,
+        action: API_ACTIONS.CREATE_BOOKMARK,
         payload: {
           title: '',
           url: VALID_URLS.GOOGLE,
@@ -101,7 +101,7 @@ describe('API Schemas - Bookmark Operations', () => {
 
     it('前後の空白を含むタイトルがトリムされること', () => {
       const request = {
-        action: API_ACTIONS.ADD_BOOKMARK,
+        action: API_ACTIONS.CREATE_BOOKMARK,
         payload: {
           title: TEST_STRINGS.PRE_TRIMMED_NAME,
           url: VALID_URLS.GOOGLE,

--- a/shared/schemas/api-keyword.test.ts
+++ b/shared/schemas/api-keyword.test.ts
@@ -20,15 +20,15 @@ import { MOCK_KEYWORDS, MOCK_IDS, TEST_STRINGS } from '../test/fixtures'
 
 describe('API Schemas - Keyword Operations', () => {
   describe('readKeywordsRequestSchema', () => {
-    it('正しい GET_KEYWORDS リクエストを受け入れること', () => {
-      const validRequest = { action: API_ACTIONS.GET_KEYWORDS }
+    it('正しい READ_KEYWORDS リクエストを受け入れること', () => {
+      const validRequest = { action: API_ACTIONS.READ_KEYWORDS }
       expect(readKeywordsRequestSchema.parse(validRequest)).toEqual(
         validRequest,
       )
     })
 
     it('不正なアクションを持つリクエストを拒否すること', () => {
-      const invalidRequest = { action: API_ACTIONS.GET_BOOKMARKS }
+      const invalidRequest = { action: API_ACTIONS.READ_BOOKMARKS }
       expect(() => readKeywordsRequestSchema.parse(invalidRequest)).toThrow(
         ZodError,
       )
@@ -48,9 +48,9 @@ describe('API Schemas - Keyword Operations', () => {
   })
 
   describe('createKeywordRequestSchema', () => {
-    it('正しい ADD_KEYWORD リクエストを受け入れること', () => {
+    it('正しい CREATE_KEYWORD リクエストを受け入れること', () => {
       const validRequest = {
-        action: API_ACTIONS.ADD_KEYWORD,
+        action: API_ACTIONS.CREATE_KEYWORD,
         payload: { name: TEST_STRINGS.NEW_NAME },
       }
       expect(createKeywordRequestSchema.parse(validRequest)).toEqual(
@@ -60,7 +60,7 @@ describe('API Schemas - Keyword Operations', () => {
 
     it('payload が不正（名前が空）なリクエストを拒否すること', () => {
       const invalidRequest = {
-        action: API_ACTIONS.ADD_KEYWORD,
+        action: API_ACTIONS.CREATE_KEYWORD,
         payload: { name: '' },
       }
       expect(() => createKeywordRequestSchema.parse(invalidRequest)).toThrow(

--- a/shared/schemas/api.test.ts
+++ b/shared/schemas/api.test.ts
@@ -50,7 +50,7 @@ describe('API Schemas - Messaging Foundation', () => {
   describe('baseApiRequestSchema', () => {
     it('正しいメッセージ構造を受け入れること', () => {
       const validRequest = {
-        action: API_ACTIONS.GET_BOOKMARKS,
+        action: API_ACTIONS.READ_BOOKMARKS,
         payload: { some: TEST_STRINGS.NEW_NAME },
       }
       expect(baseApiRequestSchema.parse(validRequest)).toEqual(validRequest)
@@ -58,9 +58,7 @@ describe('API Schemas - Messaging Foundation', () => {
 
     it('不正な形式のリクエストを拒否すること', () => {
       const invalidRequest = { action: TEST_STRINGS.INVALID_ACTION }
-      expect(() => baseApiRequestSchema.parse(invalidRequest)).toThrow(
-        ZodError,
-      )
+      expect(() => baseApiRequestSchema.parse(invalidRequest)).toThrow(ZodError)
     })
   })
 })

--- a/shared/schemas/api.ts
+++ b/shared/schemas/api.ts
@@ -77,10 +77,10 @@ export const baseApiRequestSchema = z.object({
 })
 
 /**
- * キーワード一覧取得 (GET_KEYWORDS)
+ * キーワード一覧取得 (READ_KEYWORDS)
  */
 export const readKeywordsRequestSchema = baseApiRequestSchema.extend({
-  action: z.literal(API_ACTIONS.GET_KEYWORDS),
+  action: z.literal(API_ACTIONS.READ_KEYWORDS),
   payload: z.undefined().optional(),
 })
 
@@ -91,10 +91,10 @@ export const readKeywordsResponseSchema = baseApiResponseSchema(keywordsSchema)
 export type ReadKeywordsResponse = z.infer<typeof readKeywordsResponseSchema>
 
 /**
- * キーワード追加 (ADD_KEYWORD)
+ * キーワード作成 (CREATE_KEYWORD)
  */
 export const createKeywordRequestSchema = baseApiRequestSchema.extend({
-  action: z.literal(API_ACTIONS.ADD_KEYWORD),
+  action: z.literal(API_ACTIONS.CREATE_KEYWORD),
   payload: createKeywordInputSchema,
 })
 
@@ -143,10 +143,10 @@ export const deleteKeywordResponseSchema = baseApiResponseSchema(
 export type DeleteKeywordResponse = z.infer<typeof deleteKeywordResponseSchema>
 
 /**
- * ブックマーク一覧取得 (GET_BOOKMARKS)
+ * ブックマーク一覧取得 (READ_BOOKMARKS)
  */
 export const readBookmarksRequestSchema = baseApiRequestSchema.extend({
-  action: z.literal(API_ACTIONS.GET_BOOKMARKS),
+  action: z.literal(API_ACTIONS.READ_BOOKMARKS),
   payload: z.undefined().optional(),
 })
 
@@ -190,10 +190,10 @@ export const detachKeywordResponseSchema = baseApiResponseSchema(z.null())
 export type DetachKeywordResponse = z.infer<typeof detachKeywordResponseSchema>
 
 /**
- * ブックマーク追加 (ADD_BOOKMARK)
+ * ブックマーク作成 (CREATE_BOOKMARK)
  */
 export const createBookmarkRequestSchema = baseApiRequestSchema.extend({
-  action: z.literal(API_ACTIONS.ADD_BOOKMARK),
+  action: z.literal(API_ACTIONS.CREATE_BOOKMARK),
   payload: createBookmarkInputSchema,
 })
 

--- a/src/hooks/useBookmarkPage.test.ts
+++ b/src/hooks/useBookmarkPage.test.ts
@@ -153,7 +153,7 @@ describe('useBookmarkPage Hook', () => {
     expect(mockNavigate).toHaveBeenCalledWith(APP_PATHS.HOME)
   })
 
-  it('handleKeywordKeyDown が Enter キーで handleAddKeyword を呼び出すこと', async () => {
+  it('handleKeywordKeyDown が Enter キーで handleCreateKeyword を呼び出すこと', async () => {
     let createCalled = false
     server.use(
       http.post('*/api/keywords', () => {
@@ -281,7 +281,7 @@ describe('useBookmarkPage Hook', () => {
     })
   })
 
-  it('handleAddKeyword が成功した際、キーワードを作成して紐付けること', async () => {
+  it('handleCreateKeyword が成功した際、キーワードを作成して紐付けること', async () => {
     let createCalled = false
     let attachCalled = false
     const NEW_TAG = 'NewTag'
@@ -316,7 +316,7 @@ describe('useBookmarkPage Hook', () => {
     })
 
     await act(async () => {
-      await result.current.handleAddKeyword()
+      await result.current.handleCreateKeyword()
     })
 
     expect(createCalled).toBe(true)
@@ -422,7 +422,7 @@ describe('useBookmarkPage Hook', () => {
       )
     })
 
-    it('handleAddKeyword の作成失敗時にログ出力すること', async () => {
+    it('handleCreateKeyword の作成失敗時にログ出力すること', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       server.use(
         http.post('*/api/keywords', () => {
@@ -441,7 +441,7 @@ describe('useBookmarkPage Hook', () => {
       })
 
       await act(async () => {
-        await result.current.handleAddKeyword()
+        await result.current.handleCreateKeyword()
       })
 
       expect(consoleSpy).toHaveBeenCalledWith(
@@ -450,7 +450,7 @@ describe('useBookmarkPage Hook', () => {
       )
     })
 
-    it('handleAddKeyword の紐付け失敗時にログ出力すること', async () => {
+    it('handleCreateKeyword の紐付け失敗時にログ出力すること', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       server.use(
         http.post('*/api/keywords', () => {
@@ -475,7 +475,7 @@ describe('useBookmarkPage Hook', () => {
       })
 
       await act(async () => {
-        await result.current.handleAddKeyword()
+        await result.current.handleCreateKeyword()
       })
 
       expect(consoleSpy).toHaveBeenCalledWith(

--- a/src/hooks/useBookmarkPage.ts
+++ b/src/hooks/useBookmarkPage.ts
@@ -115,7 +115,7 @@ export const useBookmarkPage = (onBack?: () => void) => {
     }
   }, [editUrl])
 
-  const handleAddKeyword = useCallback(async () => {
+  const handleCreateKeyword = useCallback(async () => {
     if (!parsedId || !keywordInput.trim()) return
 
     try {
@@ -145,7 +145,7 @@ export const useBookmarkPage = (onBack?: () => void) => {
       setKeywordInput('')
     } catch (e) {
       // 予期せぬエラー用
-      console.error(LOG_MESSAGES.UNEXPECTED_ERROR_IN_ADD_KEYWORD, e)
+      console.error(LOG_MESSAGES.UNEXPECTED_ERROR_IN_CREATE_KEYWORD, e)
     }
   }, [parsedId, keywordInput, createKeywordMutation, attachKeywordMutation])
 
@@ -183,10 +183,10 @@ export const useBookmarkPage = (onBack?: () => void) => {
     (e: React.KeyboardEvent) => {
       if (e.key === KEY_VALUES.ENTER && !e.shiftKey) {
         e.preventDefault()
-        handleAddKeyword()
+        handleCreateKeyword()
       }
     },
-    [handleAddKeyword],
+    [handleCreateKeyword],
   )
 
   const handleDragStart = useCallback(
@@ -283,7 +283,7 @@ export const useBookmarkPage = (onBack?: () => void) => {
     handleDelete,
     handleOpen,
     handleBack,
-    handleAddKeyword,
+    handleCreateKeyword,
     handleAttachKeyword,
     handleDetachKeyword,
     handleKeywordKeyDown,

--- a/src/pages/BookmarkPage.test.tsx
+++ b/src/pages/BookmarkPage.test.tsx
@@ -257,7 +257,9 @@ describe('BookmarkPage Component', () => {
       APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
     )
 
-    const input = await screen.findByLabelText(FIELD_LABELS.ADD_KEYWORD_LABEL)
+    const input = await screen.findByLabelText(
+      FIELD_LABELS.CREATE_KEYWORD_LABEL,
+    )
     fireEvent.change(input, { target: { value: 'NewTag' } })
 
     const addButton = screen.getByRole(ARIA_ROLES.BUTTON, {
@@ -289,7 +291,9 @@ describe('BookmarkPage Component', () => {
       APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
     )
 
-    const input = await screen.findByLabelText(FIELD_LABELS.ADD_KEYWORD_LABEL)
+    const input = await screen.findByLabelText(
+      FIELD_LABELS.CREATE_KEYWORD_LABEL,
+    )
     fireEvent.change(input, { target: { value: 'EnterTag' } })
     fireEvent.keyDown(input, { key: KEY_VALUES.ENTER })
 
@@ -351,7 +355,7 @@ describe('BookmarkPage Component', () => {
     await waitFor(() => expect(deleteCalled).toBe(true))
   })
 
-  it('handleAddKeyword 内で予期せぬエラーが発生した場合にログ出力すること', async () => {
+  it('handleCreateKeyword 内で予期せぬエラーが発生した場合にログ出力すること', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     // mutateAsync が例外を投げるように設定
     server.use(
@@ -365,7 +369,9 @@ describe('BookmarkPage Component', () => {
       APP_PATHS.BOOKMARK_DETAIL(MOCK_BOOKMARK_1.id),
     )
 
-    const input = await screen.findByLabelText(FIELD_LABELS.ADD_KEYWORD_LABEL)
+    const input = await screen.findByLabelText(
+      FIELD_LABELS.CREATE_KEYWORD_LABEL,
+    )
     fireEvent.change(input, { target: { value: 'ErrorTag' } })
     const addButton = screen.getByRole(ARIA_ROLES.BUTTON, {
       name: FIELD_LABELS.BUTTON_ADD,

--- a/src/pages/BookmarkPage.tsx
+++ b/src/pages/BookmarkPage.tsx
@@ -63,7 +63,7 @@ export function BookmarkPage({ onBack }: BookmarkPageProps) {
     handleDelete,
     handleOpen,
     handleBack,
-    handleAddKeyword,
+    handleCreateKeyword,
     handleKeywordKeyDown,
     handleDragStart,
     handleDragEnd,
@@ -143,13 +143,13 @@ export function BookmarkPage({ onBack }: BookmarkPageProps) {
           </div>
         </div>
 
-        {/* 2. キーワード追加ブロック */}
+        {/* 2. キーワード作成ブロック */}
         <div className="bg-gray-50 p-4 border border-gray-200 rounded-lg shadow-sm">
           <div className="flex gap-2 items-end">
             <div className="flex-1">
               <InputField
                 id={ELEMENT_IDS.KEYWORD_INPUT}
-                label={FIELD_LABELS.ADD_KEYWORD_LABEL}
+                label={FIELD_LABELS.CREATE_KEYWORD_LABEL}
                 width="w-28"
                 value={keywordInput}
                 onChange={(e) => setKeywordInput(e.target.value)}
@@ -159,7 +159,7 @@ export function BookmarkPage({ onBack }: BookmarkPageProps) {
             </div>
             <div className="pb-1">
               <Button
-                onClick={handleAddKeyword}
+                onClick={handleCreateKeyword}
                 disabled={!keywordInput.trim() || isKeywordProcessing}
                 variant="secondary"
               >


### PR DESCRIPTION
Issue #464
`shared/constants.ts` およびプロジェクト全域で使用されている API アクション定数名を、命名規則ガイドライン (`naming-conventions.md`) に従い、CRUD 準拠の動詞（READ/CREATE）に統一しました。

## 変更内容
- `shared/constants.ts`: `GET_BOOKMARKS` -> `READ_BOOKMARKS`, `ADD_BOOKMARK` -> `CREATE_BOOKMARK` 等へのリネーム
- `shared/schemas/`: 定数リネームに伴うスキーマ定義およびテストの更新
- `extension/src/lib/idb.ts`: 関数名を `addBookmark` -> `createBookmark` 等へ変更
- その他、フックやコンポーネントにおける参照箇所の更新
- `extension/src/background.ts`: `getBookmarksData` -> `readBookmarksData` へ変更