### PR TITLE
[Extension] アイコン更新ロジックの IndexedDB 移行

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -1,13 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import 'fake-indexeddb/auto'
+
 import {
   BOOKMARK_STATUS,
   EXTENSION_ICONS,
   EXTENSION_MESSAGE_TYPES,
   LOG_MESSAGES,
   STORAGE_KEYS,
+  VALIDATION_MESSAGES,
 } from '@shared/constants'
-import { MOCK_BOOKMARK_1, VALID_URLS } from '@shared/test/fixtures'
+import {
+  MOCK_BOOKMARK_1,
+  TEST_STRINGS,
+  VALID_URLS,
+} from '@shared/test/fixtures'
+
+import { db } from './lib/idb'
 
 describe('background service worker', () => {
   const mockApiUrl = VALID_URLS.HTTP
@@ -75,19 +84,18 @@ describe('background service worker', () => {
   })
 
   describe('アイコン状態更新 (updateIconStatus)', () => {
-    const mockBookmarks = {
-      bookmarks: [MOCK_BOOKMARK_1],
-    }
+    beforeEach(async () => {
+      await db.bookmarks.clear()
 
-    beforeEach(() => {
-      // fetch のグローバルモック
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve({ success: true, data: mockBookmarks }),
-        }),
-      )
+      // 3. テストに必要なデータをあらかじめ DB に入れておく（これが「スタブ」の代わり）
+      // 例：URL が登録済みの状態をテストしたい場合
+      await db.bookmarks.add({
+        id: MOCK_BOOKMARK_1.id,
+        title: MOCK_BOOKMARK_1.title,
+        url: MOCK_BOOKMARK_1.url,
+        sortOrder: 1,
+        keywordIds: [],
+      })
     })
 
     it('未登録の URL の場合にデフォルトアイコンをセットすること', async () => {
@@ -96,8 +104,8 @@ describe('background service worker', () => {
 
       const handler = onUpdatedMock.mock.calls[0][0]
       handler(1, { status: 'complete' }, {
-        url: 'https://new-site.com',
-        title: 'New',
+        url: VALID_URLS.GOOGLE,
+        title: TEST_STRINGS.NEW_NAME,
       } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
@@ -133,7 +141,7 @@ describe('background service worker', () => {
       const handler = onUpdatedMock.mock.calls[0][0]
       handler(1, { status: 'complete' }, {
         url: MOCK_BOOKMARK_1.url,
-        title: 'Modified',
+        title: TEST_STRINGS.NEW_NAME,
       } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
@@ -144,86 +152,14 @@ describe('background service worker', () => {
       })
     })
 
-    it('不正な API URL がストレージにある場合、ERROR アイコンをセットすること', async () => {
-      vi.mocked(chrome.storage.sync.get).mockImplementation(
-        (_keys, callback) => {
-          const data = { [STORAGE_KEYS.API_URL]: 'ftp://invalid' }
-          if (callback) callback(data)
-          return Promise.resolve(data)
-        },
-      )
-      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
-      await import('./background')
-
-      const handler = onUpdatedMock.mock.calls[0][0]
-      handler(1, { status: 'complete' }, {
-        url: MOCK_BOOKMARK_1.url,
-        title: MOCK_BOOKMARK_1.title,
-      } as chrome.tabs.Tab)
-
-      await vi.waitFor(() => {
-        expect(chrome.action.setIcon).toHaveBeenCalledWith({
-          tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.ERROR],
-        })
-      })
-    })
-
-    it('API エラー（接続不可）の場合に ERROR アイコンをセットすること', async () => {
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockRejectedValue(new Error('Network Error')),
-      )
-      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
-      await import('./background')
-
-      const handler = onUpdatedMock.mock.calls[0][0]
-      handler(1, { status: 'complete' }, {
-        url: MOCK_BOOKMARK_1.url,
-        title: MOCK_BOOKMARK_1.title,
-      } as chrome.tabs.Tab)
-
-      await vi.waitFor(() => {
-        expect(chrome.action.setIcon).toHaveBeenCalledWith({
-          tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.ERROR],
-        })
-      })
-    })
-
     it('http 以外のプロトコルの場合に NONE アイコンをセットすること', async () => {
       const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
       await import('./background')
 
       const handler = onUpdatedMock.mock.calls[0][0]
       handler(1, { status: 'complete' }, {
-        url: 'chrome://settings',
-        title: 'Settings',
-      } as chrome.tabs.Tab)
-
-      await vi.waitFor(() => {
-        expect(chrome.action.setIcon).toHaveBeenCalledWith({
-          tabId: 1,
-          path: EXTENSION_ICONS[BOOKMARK_STATUS.NONE],
-        })
-      })
-    })
-
-    it('API URL が未設定（undefined）の場合に NONE アイコンをセットすること', async () => {
-      vi.mocked(chrome.storage.sync.get).mockImplementation(
-        (_keys, callback) => {
-          const data = { [STORAGE_KEYS.API_URL]: undefined }
-          if (callback) callback(data)
-          return Promise.resolve(data)
-        },
-      )
-      const onUpdatedMock = vi.mocked(chrome.tabs.onUpdated.addListener)
-      await import('./background')
-
-      const handler = onUpdatedMock.mock.calls[0][0]
-      handler(1, { status: 'complete' }, {
-        url: MOCK_BOOKMARK_1.url,
-        title: MOCK_BOOKMARK_1.title,
+        url: VALID_URLS.CHROME_SETTING,
+        title: TEST_STRINGS.NEW_NAME,
       } as chrome.tabs.Tab)
 
       await vi.waitFor(() => {
@@ -397,106 +333,9 @@ describe('background service worker', () => {
           expect(sendResponse).toHaveBeenCalledWith(
             expect.objectContaining({
               success: false,
-              error: expect.stringContaining('Invalid message payload'),
-            }),
-          )
-        })
-      })
-
-      it('API エラーの場合にエラーを返すこと', async () => {
-        const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
-        vi.stubGlobal(
-          'fetch',
-          vi.fn().mockResolvedValue({
-            ok: false,
-            status: 500,
-          }),
-        )
-
-        await import('./background')
-
-        const messageHandler = addListenerMock.mock.calls[0][0]
-        const sendResponse = vi.fn()
-
-        messageHandler(
-          {
-            type: EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS,
-            url: VALID_URLS.HTTPS,
-          },
-          {},
-          sendResponse,
-        )
-
-        await vi.waitFor(() => {
-          expect(sendResponse).toHaveBeenCalledWith(
-            expect.objectContaining({
-              success: false,
-              error: expect.stringContaining('HTTP Error: 500'),
-            }),
-          )
-        })
-      })
-
-      it('ネットワークエラーの場合にエラーを返すこと', async () => {
-        const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
-        vi.stubGlobal(
-          'fetch',
-          vi.fn().mockRejectedValue(new Error('Network Fail')),
-        )
-
-        await import('./background')
-
-        const messageHandler = addListenerMock.mock.calls[0][0]
-        const sendResponse = vi.fn()
-
-        messageHandler(
-          {
-            type: EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS,
-            url: VALID_URLS.HTTPS,
-          },
-          {},
-          sendResponse,
-        )
-
-        await vi.waitFor(() => {
-          expect(sendResponse).toHaveBeenCalledWith(
-            expect.objectContaining({
-              success: false,
-              error: 'Network Fail',
-            }),
-          )
-        })
-      })
-
-      it('API URL が未設定の場合にエラーを返すこと', async () => {
-        const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
-        vi.mocked(chrome.storage.sync.get).mockImplementation(
-          (_keys, callback) => {
-            const data = { [STORAGE_KEYS.API_URL]: undefined }
-            if (callback) callback(data)
-            return Promise.resolve(data)
-          },
-        )
-
-        await import('./background')
-
-        const messageHandler = addListenerMock.mock.calls[0][0]
-        const sendResponse = vi.fn()
-
-        messageHandler(
-          {
-            type: EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS,
-            url: VALID_URLS.HTTPS,
-          },
-          {},
-          sendResponse,
-        )
-
-        await vi.waitFor(() => {
-          expect(sendResponse).toHaveBeenCalledWith(
-            expect.objectContaining({
-              success: false,
-              error: 'API URL not configured',
+              error: expect.stringContaining(
+                VALIDATION_MESSAGES.URL_INVALID_FORMAT,
+              ),
             }),
           )
         })

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -7,14 +7,11 @@ import {
   EXTENSION_MESSAGE_TYPES,
   STORAGE_KEYS,
   LOG_MESSAGES,
+  VALIDATION_MESSAGES,
 } from '@shared/constants'
-import type { Bookmarks } from '@shared/schemas/bookmark'
-import { getOrigin, validateApiUrl } from '@shared/utils/url'
 
-import {
-  findBookmarkByUrl,
-  determineBookmarkStatus,
-} from './lib/bookmark-utils'
+import { determineBookmarkStatus } from './lib/bookmark-utils'
+import { db } from './lib/idb' // 共有インスタンスをインポートする
 import { QUERY_KEYS } from '../../src/lib/queryKeys'
 
 /**
@@ -34,26 +31,6 @@ const queryClient = new QueryClient({
 /**
  * ブックマーク一覧をキャッシュまたは API から取得する内部関数
  */
-const readBookmarksData = async (apiUrl: string) => {
-  const urlError = validateApiUrl(apiUrl)
-  if (urlError) {
-    throw new Error(urlError)
-  }
-
-  const sanitizedBaseUrl = getOrigin(apiUrl)
-
-  return await queryClient.fetchQuery<Bookmarks>({
-    queryKey: [...QUERY_KEYS.BOOKMARKS.ALL, sanitizedBaseUrl],
-    queryFn: async () => {
-      const res = await fetch(`${sanitizedBaseUrl}/api/bookmarks`)
-      if (!res.ok) throw new Error(`HTTP Error: ${res.status}`)
-      const result = await res.json()
-      if (!result.success) throw new Error(result.error?.message || 'Failed')
-      return result.data
-    },
-  })
-}
-
 /**
  * 指定された URL のブックマーク状態を判定し、アイコンを更新する
  */
@@ -71,23 +48,12 @@ const updateIconStatus = async (
   }
 
   try {
-    // 1. API URL を取得
-    const storage = await chrome.storage.sync.get(STORAGE_KEYS.API_URL)
-    const apiUrl = storage[STORAGE_KEYS.API_URL]
+    // IndexedDB から該当 URL のブックマークを直接検索
+    // Dexie のクエリ構文: テーブル名.where(インデックス名).equals(値).first()
+    const bookmark = await db.bookmarks.where('url').equals(url).first()
 
-    if (!apiUrl || typeof apiUrl !== 'string') {
-      chrome.action.setIcon({
-        tabId,
-        path: EXTENSION_ICONS[BOOKMARK_STATUS.NONE],
-      })
-      return
-    }
-
-    const data = await readBookmarksData(apiUrl)
-
-    // 状態判定 (共通ユーティリティを使用)
-    const bookmark = findBookmarkByUrl(data.bookmarks, url)
-    const statusKey = determineBookmarkStatus(bookmark, title)
+    // 判定ロジックは既存のものをそのまま使える
+    const statusKey = determineBookmarkStatus(bookmark?.title, title)
 
     chrome.action.setIcon({
       tabId,
@@ -106,9 +72,11 @@ const updateIconStatus = async (
  * ブックマークの登録状態をチェックし、結果を返送するメッセージハンドラ
  */
 const handleCheckBookmarkStatus = async (
-  message: unknown,
+  message: { url: string; title?: string }, // 型定義も整理されています
   sendResponse: (response: unknown) => void,
 ) => {
+  const { url, title } = message
+
   // 1. メッセージの型と内容を Zod で厳格に検証
   const checkStatusSchema = z.object({
     type: z.literal(EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS),
@@ -120,27 +88,16 @@ const handleCheckBookmarkStatus = async (
   if (!validation.success) {
     sendResponse({
       success: false,
-      error: `Invalid message payload: ${validation.error.message}`,
+      error: `${VALIDATION_MESSAGES.URL_INVALID_FORMAT}: ${validation.error.message}`,
     })
     return
   }
 
-  const { url, title } = validation.data
-
   try {
-    // 2. 設定とデータの取得
-    const storage = await chrome.storage.sync.get(STORAGE_KEYS.API_URL)
-    const apiUrl = storage[STORAGE_KEYS.API_URL]
+    const bookmark = await db.bookmarks.where('url').equals(url).first()
 
-    if (!apiUrl || typeof apiUrl !== 'string') {
-      throw new Error('API URL not configured')
-    }
+    const status = determineBookmarkStatus(bookmark?.title, title)
 
-    const data = await readBookmarksData(apiUrl)
-    const bookmark = findBookmarkByUrl(data.bookmarks, url)
-    const status = determineBookmarkStatus(bookmark, title)
-
-    // 3. 結果の返送
     sendResponse({
       success: true,
       status,

--- a/extension/src/lib/bookmark-utils.test.ts
+++ b/extension/src/lib/bookmark-utils.test.ts
@@ -37,19 +37,22 @@ describe('bookmark-utils', () => {
 
     it('タイトルが一致する場合は REGISTERED を返すこと', () => {
       const bookmark = mockBookmarks[0]
-      const result = determineBookmarkStatus(bookmark, MOCK_BOOKMARK_1.title)
+      const result = determineBookmarkStatus(
+        bookmark.title,
+        MOCK_BOOKMARK_1.title,
+      )
       expect(result).toBe('REGISTERED')
     })
 
     it('タイトルが異なる場合は MODIFIED を返すこと', () => {
       const bookmark = mockBookmarks[0]
-      const result = determineBookmarkStatus(bookmark, 'Different Title')
+      const result = determineBookmarkStatus(bookmark.title, 'Different Title')
       expect(result).toBe('MODIFIED')
     })
 
     it('タイトルが undefined の場合（かつブックマークあり）は MODIFIED を返すこと', () => {
       const bookmark = mockBookmarks[0]
-      const result = determineBookmarkStatus(bookmark, undefined)
+      const result = determineBookmarkStatus(bookmark.title, undefined)
       expect(result).toBe('MODIFIED')
     })
   })

--- a/extension/src/lib/bookmark-utils.ts
+++ b/extension/src/lib/bookmark-utils.ts
@@ -19,14 +19,11 @@ export const findBookmarkByUrl = (
  * - MODIFIED: 登録済みだがタイトルが異なる
  */
 export const determineBookmarkStatus = (
-  bookmark: Bookmark | undefined,
+  storedTitle: string | undefined,
   currentTitle: string | undefined,
 ): keyof typeof BOOKMARK_STATUS => {
-  if (!bookmark) {
+  if (storedTitle === undefined) {
     return 'NONE'
   }
-  if (bookmark.title === currentTitle) {
-    return 'REGISTERED'
-  }
-  return 'MODIFIED'
+  return storedTitle === currentTitle ? 'REGISTERED' : 'MODIFIED'
 }

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -334,7 +334,7 @@ export const DB_CONSTANTS = {
   DB_NAME: 'BookmarkDatabase',
   IDB_VERSION: 1,
   IDB_SCHEMA: {
-    bookmarks: 'id, sortOrder, *keywordIds',
+    bookmarks: 'id, url, sortOrder, *keywordIds',
     keywords: 'id, name',
   },
   FILENAME: 'bookmarks.sqlite',

--- a/shared/test/fixtures.ts
+++ b/shared/test/fixtures.ts
@@ -116,6 +116,7 @@ export const VALID_URLS = {
   IPV6_LOOPBACK: 'http://[::1]:3030',
   FRONTEND: 'http://localhost:5173',
   TEST_API: 'http://localhost:4000',
+  CHROME_SETTING: 'chrome://settings',
 } as const
 
 /**


### PR DESCRIPTION
Issue #467
拡張機能のアイコン状態表示（登録済み判定など）のデータソースを、API サーバーから IndexedDB に移行しました。これにより、実行時の API サーバーへの依存が解消されました。

## 変更内容
- `extension/src/background.ts`:
    - `BookmarkDatabase` を導入し、`updateIconStatus` 内の検索を IndexedDB クエリに置き換え。
    - `determineBookmarkStatus` の呼び出しを、新しい文字列ベースの引数に合わせ修正。
- `extension/src/lib/bookmark-utils.ts`:
    - `determineBookmarkStatus` の引数を `Bookmark` オブジェクトから `storedTitle` (string) へリファクタリング。
- `shared/constants.ts`:
    - `DB_CONSTANTS.IDB_SCHEMA` に `url` インデックスを追加。
- `extension/src/background.test.ts`:
    - `fake-indexeddb` を導入し、IndexedDB ベースのテストに刷新。
    - 古い fetch ベースのテストケースを削除。
- `extension/src/lib/bookmark-utils.test.ts`:
    - 引数変更に伴うテストの更新。