### PR TITLE
[Extension] バックグラウンドスクリプトのクリーンアップ

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -186,51 +186,6 @@ describe('background service worker', () => {
       )
     })
 
-    it('API URL 設定変更時にキャッシュをクリアし全タブのアイコンを更新すること', async () => {
-      const onChangedMock = vi.mocked(chrome.storage.onChanged.addListener)
-      vi.mocked(chrome.tabs.query).mockImplementation((_query, callback) => {
-        ;(callback as unknown as (tabs: unknown[]) => void)([
-          {
-            id: 1,
-            url: MOCK_BOOKMARK_1.url,
-            title: MOCK_BOOKMARK_1.title,
-          },
-        ])
-      })
-      await import('./background')
-
-      const handler = onChangedMock.mock.calls[0][0]
-      handler(
-        { [STORAGE_KEYS.API_URL]: { newValue: 'http://new-api.com' } },
-        'sync',
-      )
-
-      await vi.waitFor(() => {
-        expect(chrome.tabs.query).toHaveBeenCalled()
-      })
-    })
-
-    it('内部メッセージ INVALIDATE_CACHE でアイコンを再更新すること', async () => {
-      const onMessageMock = vi.mocked(chrome.runtime.onMessage.addListener)
-      vi.mocked(chrome.tabs.query).mockImplementation((_query, callback) => {
-        ;(callback as unknown as (tabs: unknown[]) => void)([
-          {
-            id: 1,
-            url: MOCK_BOOKMARK_1.url,
-            title: MOCK_BOOKMARK_1.title,
-          },
-        ])
-      })
-      await import('./background')
-
-      const handler = onMessageMock.mock.calls[0][0]
-      handler({ type: EXTENSION_MESSAGE_TYPES.INVALIDATE_CACHE }, {}, vi.fn())
-
-      await vi.waitFor(() => {
-        expect(chrome.tabs.query).toHaveBeenCalled()
-      })
-    })
-
     it('タブのアクティブ化 (onActivated) 時にアイコンを更新すること', async () => {
       const onActivatedMock = vi.mocked(chrome.tabs.onActivated.addListener)
       const tabData = {

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,36 +1,20 @@
-import { QueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
 
 import {
   BOOKMARK_STATUS,
   EXTENSION_ICONS,
   EXTENSION_MESSAGE_TYPES,
-  STORAGE_KEYS,
   LOG_MESSAGES,
   VALIDATION_MESSAGES,
 } from '@shared/constants'
 
 import { determineBookmarkStatus } from './lib/bookmark-utils'
 import { db } from './lib/idb' // 共有インスタンスをインポートする
-import { QUERY_KEYS } from '../../src/lib/queryKeys'
 
 /**
  * 拡張機能のバックグラウンドプロセス
  */
 
-// TanStack Query のセットアップ (staleTime: 0 で常に最新を確認)
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 0,
-      retry: false,
-    },
-  },
-})
-
-/**
- * ブックマーク一覧をキャッシュまたは API から取得する内部関数
- */
 /**
  * 指定された URL のブックマーク状態を判定し、アイコンを更新する
  */
@@ -143,32 +127,9 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
 })
 
 /**
- * 設定（API URL）の変更を監視
- */
-chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === 'sync' && changes[STORAGE_KEYS.API_URL]) {
-    queryClient.clear()
-    chrome.tabs.query({}, (tabs) => {
-      for (const tab of tabs) {
-        if (tab.id) updateIconStatus(tab.id, tab.url, tab.title)
-      }
-    })
-  }
-})
-
-/**
  * 内部メッセージを処理
  */
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (message.type === EXTENSION_MESSAGE_TYPES.INVALIDATE_CACHE) {
-    queryClient.invalidateQueries({ queryKey: QUERY_KEYS.BOOKMARKS.ALL })
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const tab = tabs[0]
-      if (tab?.id) updateIconStatus(tab.id, tab.url, tab.title)
-    })
-    return false
-  }
-
   if (message.type === EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS) {
     handleCheckBookmarkStatus(message, sendResponse)
     return true // 非同期レスポンスのために true を返す


### PR DESCRIPTION
Issue #469
Issue #467 での IndexedDB 移行に伴い、バックグラウンドスクリプトに残っていた不要な API サーバーアクセス関連のコードを完全に削除しました。

## 変更内容
- `QueryClient` (TanStack Query) の初期化および関連ロジックの削除
- `readBookmarksData` 関数 (API fetch 処理) の削除
- API URL の変更監視リスナーの削除
- `INVALIDATE_CACHE` メッセージハンドラの削除
- 不要になったインポートの整理
- テストコードにおける、上記機能に関連するテストケースの削除

これにより、バックグラウンドスクリプトがより軽量かつクリーンな構造になりました。