### PR TITLE
[Extension] メッセージディスパッチャの実装

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -3,11 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import 'fake-indexeddb/auto'
 
 import {
+  API_ACTIONS,
   BOOKMARK_STATUS,
+  ERROR_CODES,
   EXTENSION_ICONS,
   EXTENSION_MESSAGE_TYPES,
   LOG_MESSAGES,
-  STORAGE_KEYS,
   VALIDATION_MESSAGES,
 } from '@shared/constants'
 import {
@@ -19,8 +20,6 @@ import {
 import { db } from './lib/idb'
 
 describe('background service worker', () => {
-  const mockApiUrl = VALID_URLS.HTTP
-
   beforeEach(() => {
     vi.restoreAllMocks()
     vi.clearAllMocks()
@@ -51,20 +50,6 @@ describe('background service worker', () => {
         setIcon: vi.fn(),
       },
     })
-
-    // chrome.storage.sync.get の共通モック実装 (型定義を Chrome API に合わせる)
-    vi.mocked(chrome.storage.sync.get).mockImplementation(
-      (
-        _keys?: string | string[] | Record<string, unknown> | null,
-        callback?: (items: Record<string, unknown>) => void,
-      ) => {
-        const data = { [STORAGE_KEYS.API_URL]: mockApiUrl }
-        if (callback) {
-          callback(data)
-        }
-        return Promise.resolve(data)
-      },
-    )
 
     // background.ts を再読み込み
     vi.resetModules()
@@ -169,22 +154,6 @@ describe('background service worker', () => {
         })
       })
     })
-  })
-
-  describe('イベントリスナーとメッセージ', () => {
-    const mockBookmarks = {
-      bookmarks: [MOCK_BOOKMARK_1],
-    }
-
-    beforeEach(() => {
-      vi.stubGlobal(
-        'fetch',
-        vi.fn().mockResolvedValue({
-          ok: true,
-          json: () => Promise.resolve({ success: true, data: mockBookmarks }),
-        }),
-      )
-    })
 
     it('タブのアクティブ化 (onActivated) 時にアイコンを更新すること', async () => {
       const onActivatedMock = vi.mocked(chrome.tabs.onActivated.addListener)
@@ -226,18 +195,6 @@ describe('background service worker', () => {
     describe('CHECK_BOOKMARK_STATUS', () => {
       it('メッセージを受信した際に判定結果を返すこと (正常系)', async () => {
         const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
-        const mockBookmarksResult = {
-          bookmarks: [MOCK_BOOKMARK_1],
-        }
-
-        vi.stubGlobal(
-          'fetch',
-          vi.fn().mockResolvedValue({
-            ok: true,
-            json: () =>
-              Promise.resolve({ success: true, data: mockBookmarksResult }),
-          }),
-        )
 
         await import('./background')
 
@@ -294,6 +251,56 @@ describe('background service worker', () => {
             }),
           )
         })
+      })
+    })
+  })
+  describe('統合メッセージディスパッチャ (ApiRequestSchema)', () => {
+    it('有効なアクションを受信した際に、適切なハンドラ（現在は未実装エラー）へルーティングすること', async () => {
+      const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
+      await import('./background')
+
+      const messageHandler = addListenerMock.mock.calls[0][0]
+      const sendResponse = vi.fn()
+
+      // READ_BOOKMARKS アクションを送信
+      const result = messageHandler(
+        { action: API_ACTIONS.READ_BOOKMARKS },
+        {},
+        sendResponse,
+      )
+
+      // 非同期レスポンス（true）を返すことを確認
+      expect(result).toBe(true)
+
+      // レスポンスの内容を確認
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            success: false,
+            error: expect.objectContaining({
+              code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+              message: expect.stringContaining('is not yet implemented'),
+            }),
+          }),
+        )
+      })
+    })
+
+    it('不正な形式のメッセージを受信した際、handleApiMessage へ渡さず無視すること', async () => {
+      const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
+      await import('./background')
+
+      const messageHandler = addListenerMock.mock.calls[0][0]
+      const sendResponse = vi.fn()
+
+      // action プロパティがない不正なメッセージを送信
+      const result = messageHandler({ invalid: 'payload' }, {}, sendResponse)
+
+      // ディスパッチャが無視した場合は false を返す（または後続の古いハンドラへ行く）
+      expect(result).toBe(false)
+
+      await vi.waitFor(() => {
+        expect(sendResponse).toHaveBeenCalledTimes(0)
       })
     })
   })

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,12 +1,19 @@
 import { z } from 'zod'
 
 import {
+  API_ACTIONS,
   BOOKMARK_STATUS,
+  ERROR_CODES,
   EXTENSION_ICONS,
   EXTENSION_MESSAGE_TYPES,
   LOG_MESSAGES,
   VALIDATION_MESSAGES,
 } from '@shared/constants'
+import {
+  ApiRequestSchema,
+  type ApiRequest,
+  type ApiError,
+} from '@shared/schemas/api'
 
 import { determineBookmarkStatus } from './lib/bookmark-utils'
 import { db } from './lib/idb' // 共有インスタンスをインポートする
@@ -127,12 +134,76 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
 })
 
 /**
+ * 統合メッセージディスパッチャ
+ * ApiRequestSchema に基づく全てのメッセージを処理し、適切なハンドラへルーティングする
+ */
+const handleApiMessage = async (
+  request: ApiRequest,
+): Promise<{ success: true; data: unknown } | ApiError> => {
+  try {
+    switch (request.action) {
+      // ブックマーク操作
+      case API_ACTIONS.READ_BOOKMARKS:
+      case API_ACTIONS.CREATE_BOOKMARK:
+      case API_ACTIONS.UPDATE_BOOKMARK:
+      case API_ACTIONS.DELETE_BOOKMARK:
+      case API_ACTIONS.REORDER_BOOKMARKS:
+      case API_ACTIONS.READ_BOOKMARK_STATUS:
+      // キーワード操作
+      // eslint-disable-next-line no-fallthrough
+      case API_ACTIONS.READ_KEYWORDS:
+      case API_ACTIONS.CREATE_KEYWORD:
+      case API_ACTIONS.UPDATE_KEYWORD:
+      case API_ACTIONS.DELETE_KEYWORD:
+      // リレーション操作
+      // eslint-disable-next-line no-fallthrough
+      case API_ACTIONS.ATTACH_KEYWORD:
+      case API_ACTIONS.DETACH_KEYWORD:
+        // 今回の Issue では「未実装エラー」を返すプレースホルダのみ
+        // 実際の接続は今後の個別 Issue で実施
+        return {
+          success: false,
+          error: {
+            message: LOG_MESSAGES.ACTION_NOT_IMPLEMENTED(request.action),
+            code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+          },
+        }
+
+      default:
+        return {
+          success: false,
+          error: {
+            message: LOG_MESSAGES.UNKNOWN_ACTION,
+            code: ERROR_CODES.BAD_REQUEST,
+          },
+        }
+    }
+  } catch (err) {
+    return {
+      success: false,
+      error: {
+        message: err instanceof Error ? err.message : String(err),
+        code: ERROR_CODES.INTERNAL_SERVER_ERROR,
+      },
+    }
+  }
+}
+
+/**
  * 内部メッセージを処理
  */
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  // 1. ApiRequestSchema による検証（新しい統一形式）
+  const apiValidation = ApiRequestSchema.safeParse(message)
+  if (apiValidation.success) {
+    handleApiMessage(apiValidation.data).then(sendResponse)
+    return true // 非同期レスポンスのために true を返す
+  }
+
+  // 2. 旧来のメッセージ形式の処理（後方互換性のため当面維持）
   if (message.type === EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS) {
     handleCheckBookmarkStatus(message, sendResponse)
-    return true // 非同期レスポンスのために true を返す
+    return true
   }
 
   return false

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -424,6 +424,9 @@ export const LOG_MESSAGES = {
   DELETE_KEYWORD_PLACEHOLDER: (id: string | number) => `Delete keyword: ${id}`,
   API_RESPONSE_PARSE_FAILED: (status: number) =>
     `Failed to parse API response (Status: ${status}):`,
+  ACTION_NOT_IMPLEMENTED: (action: string) =>
+    `Action ${action} is not yet implemented.`,
+  UNKNOWN_ACTION: 'Unknown action received.',
 } as const
 
 /**


### PR DESCRIPTION
Issue #462
Web アプリからのメッセージを統一的に処理するため、`ApiRequestSchema` に基づくメッセージディスパッチャの基盤をバックグラウンドスクリプトに構築しました。

## 変更内容
- `extension/src/background.ts`:
    - `ApiRequestSchema` を入り口とする統一的なメッセージリスナーを実装。
    - 各アクション（`READ_BOOKMARKS` 等）に応じたルーティング処理（`switch` 分岐）を構築。
    - パース失敗や実行時エラー時の共通レスポンス形式を定義。
    - 旧来のメッセージ形式との共存（後方互換性）を維持。

本 PR は基盤の実装のみであり、各アクションの具体的なロジック接続は今後の個別 Issue で実施します。