### PR TITLE
[Extension] READ_BOOKMARK_STATUS ハンドラの実装と統合

### DIFF
--- a/extension/src/background.test.ts
+++ b/extension/src/background.test.ts
@@ -7,12 +7,12 @@ import {
   BOOKMARK_STATUS,
   ERROR_CODES,
   EXTENSION_ICONS,
-  EXTENSION_MESSAGE_TYPES,
   LOG_MESSAGES,
-  VALIDATION_MESSAGES,
 } from '@shared/constants'
 import {
+  INVALID_URLS,
   MOCK_BOOKMARK_1,
+  MOCK_BOOKMARK_2,
   TEST_STRINGS,
   VALID_URLS,
 } from '@shared/test/fixtures'
@@ -192,115 +192,137 @@ describe('background service worker', () => {
       await expect(handler({ tabId: 1, windowId: 1 })).resolves.not.toThrow()
     })
 
-    describe('CHECK_BOOKMARK_STATUS', () => {
-      it('メッセージを受信した際に判定結果を返すこと (正常系)', async () => {
-        const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
+    describe('統合メッセージディスパッチャ (READ_BOOKMARK_STATUS)', () => {
+      describe('正常なメッセージを受信した場合', () => {
+        beforeEach(async () => {
+          await db.bookmarks.clear()
 
-        await import('./background')
+          // 3. テストに必要なデータをあらかじめ DB に入れておく（これが「スタブ」の代わり）
+          // 例：URL が登録済みの状態をテストしたい場合
+          await db.bookmarks.add({
+            id: MOCK_BOOKMARK_1.id,
+            title: MOCK_BOOKMARK_1.title,
+            url: MOCK_BOOKMARK_1.url,
+            sortOrder: 1,
+            keywordIds: [],
+          })
+        })
 
-        const messageHandler = addListenerMock.mock.calls[0][0]
-        const sendResponse = vi.fn()
-
-        const result = messageHandler(
+        it.each([
           {
-            type: EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS,
+            name: '未登録',
+            url: MOCK_BOOKMARK_2.url,
+            title: MOCK_BOOKMARK_2.title,
+            status: BOOKMARK_STATUS.NONE,
+            bookmarkId: undefined,
+          },
+          {
+            name: '登録済み',
             url: MOCK_BOOKMARK_1.url,
             title: MOCK_BOOKMARK_1.title,
+            status: BOOKMARK_STATUS.REGISTERED,
+            bookmarkId: MOCK_BOOKMARK_1.id,
           },
-          {},
-          sendResponse,
+          {
+            name: '変更あり',
+            url: MOCK_BOOKMARK_1.url,
+            title: TEST_STRINGS.NEW_NAME,
+            status: BOOKMARK_STATUS.MODIFIED,
+            bookmarkId: MOCK_BOOKMARK_1.id,
+          },
+        ])(
+          'ブックマークのスタータス( $name )',
+          async ({ url, title, status, bookmarkId }) => {
+            const addListenerMock = vi.mocked(
+              chrome.runtime.onMessage.addListener,
+            )
+            await import('./background')
+
+            const messageHandler = addListenerMock.mock.calls[0][0]
+            const sendResponse = vi.fn()
+
+            // READ_BOOKMARK_STATUS アクションを送信
+            const result = messageHandler(
+              {
+                action: API_ACTIONS.READ_BOOKMARK_STATUS,
+                payload: {
+                  url: url,
+                  title: title,
+                },
+              },
+              {},
+              sendResponse,
+            )
+
+            // 非同期レスポンス（true）を返すことを確認
+            expect(result).toBe(true)
+
+            // レスポンスの内容を確認
+            await vi.waitFor(() => {
+              expect(sendResponse).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  success: true,
+                  data: { status, bookmarkId },
+                }),
+              )
+            })
+          },
         )
-
-        expect(result).toBe(true)
-
-        await vi.waitFor(() => {
-          expect(sendResponse).toHaveBeenCalledWith(
-            expect.objectContaining({
-              success: true,
-              status: 'REGISTERED',
-              bookmarkId: MOCK_BOOKMARK_1.id,
-            }),
-          )
-        })
       })
 
-      it('不正なペイロード (URL形式エラー) の場合にエラーを返すこと', async () => {
+      it('不正なペイロードを受信した際に、エラーを返すこと', async () => {
         const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
         await import('./background')
 
         const messageHandler = addListenerMock.mock.calls[0][0]
         const sendResponse = vi.fn()
 
+        // READ_BOOKMARK_STATUS アクションを送信
         const result = messageHandler(
           {
-            type: EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS,
-            url: 'invalid-url', // 不正なURL
+            action: API_ACTIONS.READ_BOOKMARK_STATUS,
+            payload: {
+              url: INVALID_URLS.MALFORMED,
+              title: TEST_STRINGS.NEW_NAME,
+            },
           },
           {},
           sendResponse,
         )
 
+        // 非同期レスポンス（true）を返すことを確認
         expect(result).toBe(true)
+
+        // レスポンスの内容を確認
         await vi.waitFor(() => {
           expect(sendResponse).toHaveBeenCalledWith(
             expect.objectContaining({
               success: false,
-              error: expect.stringContaining(
-                VALIDATION_MESSAGES.URL_INVALID_FORMAT,
-              ),
+              error: expect.objectContaining({
+                code: ERROR_CODES.BAD_REQUEST,
+                message: expect.stringContaining('Invalid payload: '),
+              }),
             }),
           )
         })
       })
-    })
-  })
-  describe('統合メッセージディスパッチャ (ApiRequestSchema)', () => {
-    it('有効なアクションを受信した際に、適切なハンドラ（現在は未実装エラー）へルーティングすること', async () => {
-      const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
-      await import('./background')
 
-      const messageHandler = addListenerMock.mock.calls[0][0]
-      const sendResponse = vi.fn()
+      it('不正な形式のメッセージを受信した際、handleApiMessage へ渡さず無視すること', async () => {
+        const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
+        await import('./background')
 
-      // READ_BOOKMARKS アクションを送信
-      const result = messageHandler(
-        { action: API_ACTIONS.READ_BOOKMARKS },
-        {},
-        sendResponse,
-      )
+        const messageHandler = addListenerMock.mock.calls[0][0]
+        const sendResponse = vi.fn()
 
-      // 非同期レスポンス（true）を返すことを確認
-      expect(result).toBe(true)
+        // action プロパティがない不正なメッセージを送信
+        const result = messageHandler({ invalid: 'payload' }, {}, sendResponse)
 
-      // レスポンスの内容を確認
-      await vi.waitFor(() => {
-        expect(sendResponse).toHaveBeenCalledWith(
-          expect.objectContaining({
-            success: false,
-            error: expect.objectContaining({
-              code: ERROR_CODES.INTERNAL_SERVER_ERROR,
-              message: expect.stringContaining('is not yet implemented'),
-            }),
-          }),
-        )
-      })
-    })
+        // ディスパッチャが無視した場合は false を返す（または後続の古いハンドラへ行く）
+        expect(result).toBe(false)
 
-    it('不正な形式のメッセージを受信した際、handleApiMessage へ渡さず無視すること', async () => {
-      const addListenerMock = vi.mocked(chrome.runtime.onMessage.addListener)
-      await import('./background')
-
-      const messageHandler = addListenerMock.mock.calls[0][0]
-      const sendResponse = vi.fn()
-
-      // action プロパティがない不正なメッセージを送信
-      const result = messageHandler({ invalid: 'payload' }, {}, sendResponse)
-
-      // ディスパッチャが無視した場合は false を返す（または後続の古いハンドラへ行く）
-      expect(result).toBe(false)
-
-      await vi.waitFor(() => {
-        expect(sendResponse).toHaveBeenCalledTimes(0)
+        await vi.waitFor(() => {
+          expect(sendResponse).toHaveBeenCalledTimes(0)
+        })
       })
     })
   })

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -1,18 +1,15 @@
-import { z } from 'zod'
-
 import {
   API_ACTIONS,
   BOOKMARK_STATUS,
   ERROR_CODES,
   EXTENSION_ICONS,
-  EXTENSION_MESSAGE_TYPES,
   LOG_MESSAGES,
-  VALIDATION_MESSAGES,
 } from '@shared/constants'
 import {
   ApiRequestSchema,
   type ApiRequest,
   type ApiError,
+  readBookmarkStatusRequestSchema,
 } from '@shared/schemas/api'
 
 import { determineBookmarkStatus } from './lib/bookmark-utils'
@@ -44,60 +41,17 @@ const updateIconStatus = async (
     const bookmark = await db.bookmarks.where('url').equals(url).first()
 
     // 判定ロジックは既存のものをそのまま使える
-    const statusKey = determineBookmarkStatus(bookmark?.title, title)
+    const status = determineBookmarkStatus(bookmark?.title, title)
 
     chrome.action.setIcon({
       tabId,
-      path: EXTENSION_ICONS[BOOKMARK_STATUS[statusKey]],
+      path: EXTENSION_ICONS[status],
     })
   } catch (err) {
     console.error(LOG_MESSAGES.ICON_STATUS_UPDATE_FAILED, err)
     chrome.action.setIcon({
       tabId,
       path: EXTENSION_ICONS[BOOKMARK_STATUS.ERROR],
-    })
-  }
-}
-
-/**
- * ブックマークの登録状態をチェックし、結果を返送するメッセージハンドラ
- */
-const handleCheckBookmarkStatus = async (
-  message: { url: string; title?: string }, // 型定義も整理されています
-  sendResponse: (response: unknown) => void,
-) => {
-  const { url, title } = message
-
-  // 1. メッセージの型と内容を Zod で厳格に検証
-  const checkStatusSchema = z.object({
-    type: z.literal(EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS),
-    url: z.string().url(),
-    title: z.string().optional(),
-  })
-
-  const validation = checkStatusSchema.safeParse(message)
-  if (!validation.success) {
-    sendResponse({
-      success: false,
-      error: `${VALIDATION_MESSAGES.URL_INVALID_FORMAT}: ${validation.error.message}`,
-    })
-    return
-  }
-
-  try {
-    const bookmark = await db.bookmarks.where('url').equals(url).first()
-
-    const status = determineBookmarkStatus(bookmark?.title, title)
-
-    sendResponse({
-      success: true,
-      status,
-      bookmarkId: bookmark?.id,
-    })
-  } catch (err) {
-    sendResponse({
-      success: false,
-      error: err instanceof Error ? err.message : String(err),
     })
   }
 }
@@ -148,9 +102,33 @@ const handleApiMessage = async (
       case API_ACTIONS.UPDATE_BOOKMARK:
       case API_ACTIONS.DELETE_BOOKMARK:
       case API_ACTIONS.REORDER_BOOKMARKS:
-      case API_ACTIONS.READ_BOOKMARK_STATUS:
+      case API_ACTIONS.READ_BOOKMARK_STATUS: {
+        // 1. 個別のスキーマでパース（safeParse を推奨）
+        const validation = readBookmarkStatusRequestSchema.safeParse(request)
+
+        // 2. バリデーション失敗時のエラーレスポンス
+        if (!validation.success) {
+          return {
+            success: false,
+            error: {
+              message: LOG_MESSAGES.INVALID_PAYLOAD(validation.error.message),
+              code: ERROR_CODES.BAD_REQUEST, // ここが重要
+            },
+          }
+        }
+
+        // 3. 成功時の処理（validation.data.payload を安全に使用できる）
+        const { url, title } = validation.data.payload
+        const bookmark = await db.bookmarks.where('url').equals(url).first()
+        const status = determineBookmarkStatus(bookmark?.title, title)
+
+        return {
+          success: true,
+          data: { status, bookmarkId: bookmark?.id },
+        }
+      }
+
       // キーワード操作
-      // eslint-disable-next-line no-fallthrough
       case API_ACTIONS.READ_KEYWORDS:
       case API_ACTIONS.CREATE_KEYWORD:
       case API_ACTIONS.UPDATE_KEYWORD:
@@ -193,16 +171,21 @@ const handleApiMessage = async (
  * 内部メッセージを処理
  */
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  // 1. ApiRequestSchema による検証（新しい統一形式）
-  const apiValidation = ApiRequestSchema.safeParse(message)
-  if (apiValidation.success) {
-    handleApiMessage(apiValidation.data).then(sendResponse)
-    return true // 非同期レスポンスのために true を返す
-  }
-
-  // 2. 旧来のメッセージ形式の処理（後方互換性のため当面維持）
-  if (message.type === EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS) {
-    handleCheckBookmarkStatus(message, sendResponse)
+  // メッセージが { action: ... } という形式を持っているかチェック
+  if (message && typeof message === 'object' && 'action' in message) {
+    const apiValidation = ApiRequestSchema.safeParse(message)
+    if (apiValidation.success) {
+      handleApiMessage(apiValidation.data).then(sendResponse)
+    } else {
+      // アクションはあるが形式が不正な場合は、BAD_REQUEST を返す
+      sendResponse({
+        success: false,
+        error: {
+          message: LOG_MESSAGES.INVALID_PAYLOAD(apiValidation.error.message),
+          code: ERROR_CODES.BAD_REQUEST,
+        },
+      })
+    }
     return true
   }
 

--- a/extension/src/hooks/usePopup.test.ts
+++ b/extension/src/hooks/usePopup.test.ts
@@ -7,9 +7,10 @@ import {
   APP_PATHS,
   VALIDATION_MESSAGES,
   UI_STATUS,
-  EXTENSION_MESSAGE_TYPES,
   EXTENSION_MESSAGES,
   LOG_MESSAGES,
+  API_ACTIONS,
+  BOOKMARK_STATUS,
 } from '@shared/constants'
 import {
   INVALID_URLS,
@@ -54,11 +55,13 @@ describe('usePopup Hook', () => {
     ])
 
     mockChrome.runtime.sendMessage.mockImplementation((message, callback) => {
-      if (message.type === EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS) {
+      if (message.action === API_ACTIONS.READ_BOOKMARK_STATUS) {
         callback({
           success: true,
-          status: 'REGISTERED',
-          bookmarkId: MOCK_BOOKMARK_1.id,
+          data: {
+            status: BOOKMARK_STATUS.REGISTERED,
+            bookmarkId: MOCK_BOOKMARK_1.id,
+          },
         })
       }
     })

--- a/extension/src/hooks/usePopup.ts
+++ b/extension/src/hooks/usePopup.ts
@@ -13,6 +13,7 @@ import {
   UI_STATUS,
   EXTENSION_MESSAGE_TYPES,
   type StatusInfo,
+  API_ACTIONS,
 } from '@shared/constants'
 import { createBookmarkInputSchema } from '@shared/schemas/bookmark'
 import { getOrigin, validateApiUrl } from '@shared/utils/url'
@@ -51,9 +52,11 @@ export const usePopup = () => {
           // 2. バックグラウンドに登録状態を問い合わせる
           chrome.runtime.sendMessage(
             {
-              type: EXTENSION_MESSAGE_TYPES.CHECK_BOOKMARK_STATUS,
-              url: activeTab.url,
-              title: activeTab.title,
+              action: API_ACTIONS.READ_BOOKMARK_STATUS,
+              payload: {
+                url: activeTab.url,
+                title: activeTab.title,
+              },
             },
             (response) => {
               if (isMounted && response?.success) {

--- a/extension/src/lib/bookmark-utils.test.ts
+++ b/extension/src/lib/bookmark-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
 
+import { BOOKMARK_STATUS } from '@shared/constants'
 import { bookmarkSchema } from '@shared/schemas/bookmark'
 import { MOCK_BOOKMARK_1, MOCK_BOOKMARK_2 } from '@shared/test/fixtures'
 
@@ -32,7 +33,7 @@ describe('bookmark-utils', () => {
   describe('determineBookmarkStatus', () => {
     it('ブックマークが存在しない場合は NONE を返すこと', () => {
       const result = determineBookmarkStatus(undefined, 'Title')
-      expect(result).toBe('NONE')
+      expect(result).toBe(BOOKMARK_STATUS.NONE)
     })
 
     it('タイトルが一致する場合は REGISTERED を返すこと', () => {
@@ -41,19 +42,19 @@ describe('bookmark-utils', () => {
         bookmark.title,
         MOCK_BOOKMARK_1.title,
       )
-      expect(result).toBe('REGISTERED')
+      expect(result).toBe(BOOKMARK_STATUS.REGISTERED)
     })
 
     it('タイトルが異なる場合は MODIFIED を返すこと', () => {
       const bookmark = mockBookmarks[0]
       const result = determineBookmarkStatus(bookmark.title, 'Different Title')
-      expect(result).toBe('MODIFIED')
+      expect(result).toBe(BOOKMARK_STATUS.MODIFIED)
     })
 
     it('タイトルが undefined の場合（かつブックマークあり）は MODIFIED を返すこと', () => {
       const bookmark = mockBookmarks[0]
       const result = determineBookmarkStatus(bookmark.title, undefined)
-      expect(result).toBe('MODIFIED')
+      expect(result).toBe(BOOKMARK_STATUS.MODIFIED)
     })
   })
 })

--- a/extension/src/lib/bookmark-utils.ts
+++ b/extension/src/lib/bookmark-utils.ts
@@ -21,9 +21,11 @@ export const findBookmarkByUrl = (
 export const determineBookmarkStatus = (
   storedTitle: string | undefined,
   currentTitle: string | undefined,
-): keyof typeof BOOKMARK_STATUS => {
+) => {
   if (storedTitle === undefined) {
-    return 'NONE'
+    return BOOKMARK_STATUS.NONE
   }
-  return storedTitle === currentTitle ? 'REGISTERED' : 'MODIFIED'
+  return storedTitle === currentTitle
+    ? BOOKMARK_STATUS.REGISTERED
+    : BOOKMARK_STATUS.MODIFIED
 }

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -427,6 +427,7 @@ export const LOG_MESSAGES = {
   ACTION_NOT_IMPLEMENTED: (action: string) =>
     `Action ${action} is not yet implemented.`,
   UNKNOWN_ACTION: 'Unknown action received.',
+  INVALID_PAYLOAD: (message: string) => `Invalid payload: ${message}`,
 } as const
 
 /**


### PR DESCRIPTION
Issue #472
統合メッセージディスパッチャにおいて `READ_BOOKMARK_STATUS` アクションを正式にサポートし、拡張機能 UI からの呼び出しを新形式のメッセージングに移行しました。

## 変更内容
- `extension/src/background.ts`:
    - `handleApiMessage` 内に `READ_BOOKMARK_STATUS` ハンドラを実装（IndexedDB 参照）。
    - メッセージリスナーの入り口で `ApiRequestSchema` による検証とエラー返送を強化。
    - 不要になった `handleCheckBookmarkStatus` を削除。
- `extension/src/hooks/usePopup.ts`:
    - 登録状態の確認メッセージを新形式（action/payload）に更新。
- `extension/src/lib/bookmark-utils.ts`:
    - ステータス判定に定数 `BOOKMARK_STATUS` を使用するように修正。
- `shared/constants.ts`:
    - バリデーションエラー用のログメッセージ定数を追加。
- 各種テストコードの更新:
    - `background.test.ts`, `usePopup.test.ts`, `bookmark-utils.test.ts` を新形式に合わせて刷新。