### PR TITLE
feat:ブックマークの詳細ページの戻るボタンを実装しました

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bookmark Page Extension",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "閲覧中のページをブックマークに追加します",
   "permissions": ["activeTab", "storage"],
   "host_permissions": ["http://localhost:8788/*"],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bookmark-page",
   "type": "module",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "scripts": {
     "dev:frontend": "vite",
     "dev:backend": "wrangler pages dev ./dist",

--- a/src/components/BookmarkForm.test.tsx
+++ b/src/components/BookmarkForm.test.tsx
@@ -6,12 +6,14 @@ import { UI_LABELS } from '../../shared/constants/uiMessages'
 import { userEvent } from '@testing-library/user-event'
 
 const mockBack = vi.fn()
+const mockNavigate = vi.fn()
 
 vi.mock('@tanstack/react-router', () => ({
   useRouter: () => ({
     history: {
       back: mockBack,
     },
+    navigate: mockNavigate,
   }),
 }))
 
@@ -111,9 +113,10 @@ describe('BookmarkForm', () => {
       vi.resetAllMocks()
     })
 
+    const testBookmark = TestBookmarks[0]
+
     it('戻るボタンをクリックしたときに、router.history.back が呼び出されること', async () => {
       const user = userEvent.setup()
-      const testBookmark = TestBookmarks[0]
 
       render(<BookmarkForm bookmark={testBookmark} />)
 
@@ -126,7 +129,27 @@ describe('BookmarkForm', () => {
       await user.click(backButton)
 
       // 💡 3. モック関数が1回呼び出されたかを検証
+      expect(mockBack).not.toHaveBeenCalled()
+      expect(mockNavigate).toHaveBeenCalledTimes(1)
+    })
+
+    it('履歴が存在する場合（window.history.length > 1）、router.history.back が呼び出されること', async () => {
+      const user = userEvent.setup()
+
+      // 💡 1. window.history.length が常に「2」を返すように偽装する
+      vi.spyOn(window.history, 'length', 'get').mockReturnValue(2)
+
+      render(<BookmarkForm bookmark={testBookmark} />)
+
+      const backButton = screen.getByRole('button', {
+        name: UI_LABELS.ACTIONS.BACK,
+      })
+
+      await user.click(backButton)
+
+      // 💡 2. router.history.back が呼ばれ、navigate は呼ばれていないことを検証
       expect(mockBack).toHaveBeenCalledTimes(1)
+      expect(mockNavigate).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/components/BookmarkForm.test.tsx
+++ b/src/components/BookmarkForm.test.tsx
@@ -1,9 +1,19 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { BookmarkForm } from './BookmarkForm'
 import { INVALID_STRING, TestBookmarks } from '../../functions/test/fixtures'
 import { UI_LABELS } from '../../shared/constants/uiMessages'
 import { userEvent } from '@testing-library/user-event'
+
+const mockBack = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({
+    history: {
+      back: mockBack,
+    },
+  }),
+}))
 
 describe('BookmarkForm', () => {
   it('該当するブックマークのurlとタイトルが正しく表示されること', async () => {
@@ -20,7 +30,7 @@ describe('BookmarkForm', () => {
     expect(urlElement).toHaveValue(targetBookmark.url)
   })
 
-  describe('開くボタン', () => {
+  describe('開くボタンの動作', () => {
     it('開くボタンをクリックしたときに、正しいURLと属性で window.open が呼び出されること', async () => {
       const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
 
@@ -93,6 +103,30 @@ describe('BookmarkForm', () => {
       })
 
       expect(openButton).toBeDisabled()
+    })
+  })
+
+  describe('戻るボタンの動作', () => {
+    beforeEach(() => {
+      vi.resetAllMocks()
+    })
+
+    it('戻るボタンをクリックしたときに、router.history.back が呼び出されること', async () => {
+      const user = userEvent.setup()
+      const testBookmark = TestBookmarks[0]
+
+      render(<BookmarkForm bookmark={testBookmark} />)
+
+      // 💡 2. UI_LABELS.ACTIONS.BACK (戻る) のボタンを取得
+      const backButton = screen.getByRole('button', {
+        name: UI_LABELS.ACTIONS.BACK,
+      })
+
+      // ボタンをクリック
+      await user.click(backButton)
+
+      // 💡 3. モック関数が1回呼び出されたかを検証
+      expect(mockBack).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/BookmarkForm.tsx
+++ b/src/components/BookmarkForm.tsx
@@ -28,9 +28,17 @@ export const BookmarkForm = ({ bookmark }: BookmarkFormProps) => {
 
   const isSubmitDisable = !isValidateUrl()
 
-  const handleSubmit = (e: React.ChangeEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
     window.open(url, '_blank', 'noreferrer')
+  }
+
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      router.history.back()
+    } else {
+      router.navigate({ to: '/' })
+    }
   }
 
   return (
@@ -83,7 +91,7 @@ export const BookmarkForm = ({ bookmark }: BookmarkFormProps) => {
           </button>
           <button
             type="button"
-            onClick={() => router.history.back()}
+            onClick={handleBack}
             className="border border-slate-300 text-slate-700 bg-indigo-200 rounded px-2 py-1 cursor-pointer hover:text-slate-200 hover:bg-indigo-700 hover:font-semibold"
           >
             {UI_LABELS.ACTIONS.BACK}

--- a/src/components/BookmarkForm.tsx
+++ b/src/components/BookmarkForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { UI_LABELS } from '../../shared/constants/uiMessages'
+import { useRouter } from '@tanstack/react-router'
 
 interface BookmarkFormProps {
   bookmark: {
@@ -12,6 +13,7 @@ interface BookmarkFormProps {
 export const BookmarkForm = ({ bookmark }: BookmarkFormProps) => {
   const [title, setTitle] = useState(bookmark.title)
   const [url, setUrl] = useState(bookmark.url)
+  const router = useRouter()
 
   const isValidateUrl = () => {
     try {
@@ -81,6 +83,7 @@ export const BookmarkForm = ({ bookmark }: BookmarkFormProps) => {
           </button>
           <button
             type="button"
+            onClick={() => router.history.back()}
             className="border border-slate-300 text-slate-700 bg-indigo-200 rounded px-2 py-1 cursor-pointer hover:text-slate-200 hover:bg-indigo-700 hover:font-semibold"
           >
             {UI_LABELS.ACTIONS.BACK}


### PR DESCRIPTION
## 概要

TanStack Routerが提供している useRouter() の history.back() メソッドを使用しました。

## router.history.back() の採用理由:

特定のパスへ移動する router.navigate({ to: '/' }) でも一覧には戻れますが、もし今後「別の動的なページ（検索結果やタグ一覧）から詳細ページへ飛んできた」場合に、history.back() であれば常にユーザーが直前にいた正しいページへと戻すことができるため。

## vi.mock('@tanstack/react-router', ...) によるテスト:

ボタンを押したときに「ルーターの戻る機能がトリガーされたか」という事実さえ確認できれば十分なため、フックごとモック化してスパイするテストを作成しました。

closes #44 