### PR TITLE
feat: ブックマークの削除のAPIとしてDELETE /bookmarks/:idを作成しました

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bookmark Page Extension",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "閲覧中のページをブックマークに追加します",
   "permissions": ["activeTab", "storage"],
   "host_permissions": ["http://localhost:8788/*"],

--- a/functions/api/[[route]].delete-bookmarks.test.ts
+++ b/functions/api/[[route]].delete-bookmarks.test.ts
@@ -8,7 +8,7 @@ import {
   REQUEST_API_PATH,
   TEST_ERROR_MESSAGE,
 } from '../test/fixtures'
-import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
+import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
 import { API_MESSAGE } from '../../shared/constants/api'
 import { LOG_MESSAGE } from '../constants/logMessage'
 import { DATABASE_NAME } from '../constants/db'
@@ -16,7 +16,6 @@ import { DATABASE_NAME } from '../constants/db'
 // D1 データベースの準備（モック用）
 const mockPrepare = vi.fn()
 const mockBind = vi.fn()
-const mockFirst = vi.fn()
 const mockRun = vi.fn()
 
 const mockDb = {
@@ -29,7 +28,6 @@ describe('DELETE /api/bookmarks/:id', () => {
     vi.resetAllMocks()
     mockPrepare.mockReturnValue({ bind: mockBind })
     mockBind.mockReturnValue({
-      first: mockFirst,
       run: mockRun,
     })
   })
@@ -41,7 +39,6 @@ describe('DELETE /api/bookmarks/:id', () => {
   // -------------------------------------------------------------
   it('正常なIDが指定された場合、削除に成功して204を返すこと', async () => {
     // 存在確認でデータを返すよう設定
-    mockFirst.mockResolvedValueOnce({ id: validId })
     // 削除実行で成功（{ success: true }）を返すよう設定
     mockRun.mockResolvedValueOnce({ success: true })
 
@@ -82,11 +79,11 @@ describe('DELETE /api/bookmarks/:id', () => {
     })
 
     // -------------------------------------------------------------
-    // 3. 指定されたIDのブックマークが存在しない場合 (404)
+    // 3. 指定されたIDのブックマークが存在しない場合 (204)
     // -------------------------------------------------------------
-    it('存在しないIDが指定された場合、404を返すこと', async () => {
-      // 存在確認で null を返すよう設定
-      mockFirst.mockResolvedValueOnce(null)
+    it('存在しないIDが指定された場合も、削除に成功して204を返すこと（冪等性の担保）', async () => {
+      // 削除実行で成功（{ success: true }）を返すよう設定
+      mockRun.mockResolvedValueOnce({ success: true })
 
       const res = await app.request(
         REQUEST_API_PATH.DELETE_BOOKMARK(validId),
@@ -94,12 +91,8 @@ describe('DELETE /api/bookmarks/:id', () => {
         { BOOKMARK_PAGE_DB: mockDb as unknown as D1Database },
       )
 
-      expect(res.status).toBe(404)
-      const body = await res.json()
-      expect(body).toEqual({
-        success: false,
-        error: UI_MESSAGES.API.NOT_FOUND_BOOKMARK,
-      })
+      expect(res.status).toBe(204)
+      expect(res.body).toBeNull()
     })
 
     it('IDを指定せずにDELETEを呼び出した場合、Hono標準の404を返すこと', async () => {
@@ -113,7 +106,6 @@ describe('DELETE /api/bookmarks/:id', () => {
     })
 
     it('データベースの削除処理中に例外が発生した場合、500を返すこと', async () => {
-      mockFirst.mockResolvedValueOnce({ id: validId })
       // 削除処理の段階で例外エラーをスローさせる
       const dbError = new Error(TEST_ERROR_MESSAGE.DB_ERROR)
 
@@ -135,7 +127,6 @@ describe('DELETE /api/bookmarks/:id', () => {
     })
 
     it('データベースの削除処理中にエラーが発生した場合、500を返すこと', async () => {
-      mockFirst.mockResolvedValueOnce({ id: validId })
       // 削除処理の段階で例外エラーをスローさせる
       mockRun.mockResolvedValueOnce({ success: false })
 

--- a/functions/api/[[route]].delete-bookmarks.test.ts
+++ b/functions/api/[[route]].delete-bookmarks.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
+import { app } from './[[route]]' // appのインポートパスは環境に合わせて調整してください
+import { uuidv7 } from 'uuidv7'
+import { D1Database } from '@cloudflare/workers-types'
+import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
+import {
+  INVALID_STRING,
+  REQUEST_API_PATH,
+  TEST_ERROR_MESSAGE,
+} from '../test/fixtures'
+import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
+import { API_MESSAGE } from '../../shared/constants/api'
+import { LOG_MESSAGE } from '../constants/logMessage'
+import { DATABASE_NAME } from '../constants/db'
+
+// D1 データベースの準備（モック用）
+const mockPrepare = vi.fn()
+const mockBind = vi.fn()
+const mockFirst = vi.fn()
+const mockRun = vi.fn()
+
+const mockDb = {
+  prepare: mockPrepare,
+}
+
+describe('DELETE /api/bookmarks/:id', () => {
+  // 毎テスト前にモックのチェーンをリセット
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockPrepare.mockReturnValue({ bind: mockBind })
+    mockBind.mockReturnValue({
+      first: mockFirst,
+      run: mockRun,
+    })
+  })
+
+  const validId = uuidv7() // 正しい形式のUUID
+
+  // -------------------------------------------------------------
+  // 1. 正常にブックマークが削除できた場合 (204)
+  // -------------------------------------------------------------
+  it('正常なIDが指定された場合、削除に成功して204を返すこと', async () => {
+    // 存在確認でデータを返すよう設定
+    mockFirst.mockResolvedValueOnce({ id: validId })
+    // 削除実行で成功（{ success: true }）を返すよう設定
+    mockRun.mockResolvedValueOnce({ success: true })
+
+    const res = await app.request(
+      REQUEST_API_PATH.DELETE_BOOKMARK(validId),
+      { method: 'DELETE' },
+      { BOOKMARK_PAGE_DB: mockDb as unknown as D1Database },
+    )
+
+    expect(res.status).toBe(204)
+    expect(res.body).toBeNull() // 204なのでボディは空
+  })
+
+  describe('Hono API - DELETE /api/bookmarks (異常系)', () => {
+    let consoleSpy: Mock<(...data: unknown[]) => void>
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    // -------------------------------------------------------------
+    // 2. 指定されたIDの形式が無効な場合 (400)
+    // -------------------------------------------------------------
+    it('無効なID形式（非UUID）が指定された場合、400を返すこと', async () => {
+      const invalidId = INVALID_STRING.ID
+
+      const res = await app.request(
+        REQUEST_API_PATH.DELETE_BOOKMARK(invalidId),
+        { method: 'DELETE' },
+        { BOOKMARK_PAGE_DB: mockDb as unknown as D1Database },
+      )
+
+      expect(res.status).toBe(400)
+      const body = await res.json()
+      expect(body).toEqual({
+        success: false,
+        error: SCHEMA_MESSAGE.INVALID_ID_FORMAT,
+      })
+    })
+
+    // -------------------------------------------------------------
+    // 3. 指定されたIDのブックマークが存在しない場合 (404)
+    // -------------------------------------------------------------
+    it('存在しないIDが指定された場合、404を返すこと', async () => {
+      // 存在確認で null を返すよう設定
+      mockFirst.mockResolvedValueOnce(null)
+
+      const res = await app.request(
+        REQUEST_API_PATH.DELETE_BOOKMARK(validId),
+        { method: 'DELETE' },
+        { BOOKMARK_PAGE_DB: mockDb as unknown as D1Database },
+      )
+
+      expect(res.status).toBe(404)
+      const body = await res.json()
+      expect(body).toEqual({
+        success: false,
+        error: UI_MESSAGES.API.NOT_FOUND_BOOKMARK,
+      })
+    })
+
+    it('IDを指定せずにDELETEを呼び出した場合、Hono標準の404を返すこと', async () => {
+      const res = await app.request(
+        REQUEST_API_PATH.DELETE_BOOKMARK(''),
+        { method: 'DELETE' },
+        { BOOKMARK_PAGE_DB: mockDb as unknown as D1Database },
+      )
+
+      expect(res.status).toBe(404)
+    })
+
+    it('データベースの削除処理中に例外が発生した場合、500を返すこと', async () => {
+      mockFirst.mockResolvedValueOnce({ id: validId })
+      // 削除処理の段階で例外エラーをスローさせる
+      const dbError = new Error(TEST_ERROR_MESSAGE.DB_ERROR)
+
+      mockRun.mockRejectedValueOnce(dbError)
+
+      const res = await app.request(
+        REQUEST_API_PATH.DELETE_BOOKMARK(validId),
+        { method: 'DELETE' },
+        { BOOKMARK_PAGE_DB: mockDb as unknown as D1Database },
+      )
+
+      expect(res.status).toBe(500)
+      const body = await res.json()
+      expect(body).toEqual({
+        success: false,
+        error: TEST_ERROR_MESSAGE.DB_ERROR,
+      })
+      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGE.DB_ERROR(dbError))
+    })
+
+    it('データベースの削除処理中にエラーが発生した場合、500を返すこと', async () => {
+      mockFirst.mockResolvedValueOnce({ id: validId })
+      // 削除処理の段階で例外エラーをスローさせる
+      mockRun.mockResolvedValueOnce({ success: false })
+
+      const res = await app.request(
+        REQUEST_API_PATH.DELETE_BOOKMARK(validId),
+        { method: 'DELETE' },
+        { BOOKMARK_PAGE_DB: mockDb as unknown as D1Database },
+      )
+
+      expect(res.status).toBe(500)
+      const body = await res.json()
+      expect(body).toEqual({
+        success: false,
+        error: TEST_ERROR_MESSAGE.DB_ERROR,
+      })
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(ERROR_MESSAGE.FAILED_DELETE_BOOKMARK),
+      )
+    })
+
+    it('データベースのバインディング（BOOKMARK_PAGE_DB）が未設定の場合、500を返すこと', async () => {
+      const res = await app.request(
+        `/api/bookmarks/${validId}`,
+        { method: 'DELETE' },
+        {},
+      )
+
+      expect(res.status).toBe(500)
+
+      const body = await res.json()
+      expect(body).toEqual({
+        success: false,
+        error: API_MESSAGE.DB_ERROR,
+      })
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(ERROR_MESSAGE.DB_BINDING_ERROR(DATABASE_NAME)),
+      )
+    })
+  })
+})

--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -4,14 +4,16 @@ import { zValidator } from '@hono/zod-validator'
 import { handle } from 'hono/cloudflare-pages'
 import type { D1Database } from '@cloudflare/workers-types'
 import { API_MESSAGE, API_PATH } from '../../shared/constants/api'
-import { BOOKMARKS } from '../constants/db'
-import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
-import { Bookmark, CreateBookmarkSchema } from '../schemas/bookmark'
+import { BOOKMARKS, DATABASE_NAME } from '../constants/db'
+import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
+import {
+  Bookmark,
+  BookmarkIdSchema,
+  CreateBookmarkSchema,
+} from '../schemas/bookmark'
 import { uuidv7 } from 'uuidv7'
 import { cors } from 'hono/cors'
 import { LOG_MESSAGE } from '../constants/logMessage'
-
-const DATABASE_NAME = 'BOOKMARK_PAGE_DB'
 
 type Env = {
   Bindings: {
@@ -106,6 +108,58 @@ const routes = app
           } as const,
           201,
         )
+      } catch (error) {
+        console.error(LOG_MESSAGE.DB_ERROR(error))
+        return c.json(
+          {
+            success: false,
+            error: API_MESSAGE.DB_ERROR,
+          } as const,
+          500,
+        )
+      }
+    },
+  )
+
+  .delete(
+    API_PATH.DELETE_BOOKMARK,
+    zValidator('param', BookmarkIdSchema, (result, c) => {
+      return !result.success
+        ? c.json({ success: false, error: result.error.issues[0].message }, 400)
+        : undefined
+    }),
+    async (c) => {
+      // 💡 バリデーション済みの安全なパラメータを取得
+      const { id } = c.req.valid('param')
+
+      try {
+        const db = c.env.BOOKMARK_PAGE_DB
+        if (!db) {
+          throw new Error(ERROR_MESSAGE.DB_BINDING_ERROR(DATABASE_NAME))
+        }
+
+        // 1. 存在確認
+        const existing = await db.prepare(BOOKMARKS.SELECT_ID).bind(id).first()
+
+        if (!existing) {
+          return c.json(
+            {
+              success: false,
+              error: UI_MESSAGES.API.NOT_FOUND_BOOKMARK,
+            } as const,
+            404,
+          )
+        }
+
+        // 2. 削除クエリを実行
+        const { success } = await db.prepare(BOOKMARKS.DELETE).bind(id).run()
+
+        if (!success) {
+          throw new Error(ERROR_MESSAGE.FAILED_DELETE_BOOKMARK)
+        }
+
+        // 3. 204 No Content を返す
+        return c.body(null, 204)
       } catch (error) {
         console.error(LOG_MESSAGE.DB_ERROR(error))
         return c.json(

--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -5,7 +5,7 @@ import { handle } from 'hono/cloudflare-pages'
 import type { D1Database } from '@cloudflare/workers-types'
 import { API_MESSAGE, API_PATH } from '../../shared/constants/api'
 import { BOOKMARKS, DATABASE_NAME } from '../constants/db'
-import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
+import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
 import {
   Bookmark,
   BookmarkIdSchema,
@@ -138,27 +138,12 @@ const routes = app
           throw new Error(ERROR_MESSAGE.DB_BINDING_ERROR(DATABASE_NAME))
         }
 
-        // 1. 存在確認
-        const existing = await db.prepare(BOOKMARKS.SELECT_ID).bind(id).first()
-
-        if (!existing) {
-          return c.json(
-            {
-              success: false,
-              error: UI_MESSAGES.API.NOT_FOUND_BOOKMARK,
-            } as const,
-            404,
-          )
-        }
-
-        // 2. 削除クエリを実行
         const { success } = await db.prepare(BOOKMARKS.DELETE).bind(id).run()
 
         if (!success) {
           throw new Error(ERROR_MESSAGE.FAILED_DELETE_BOOKMARK)
         }
 
-        // 3. 204 No Content を返す
         return c.body(null, 204)
       } catch (error) {
         console.error(LOG_MESSAGE.DB_ERROR(error))

--- a/functions/constants/db.ts
+++ b/functions/constants/db.ts
@@ -1,4 +1,8 @@
 export const BOOKMARKS = {
   SELECT_ALL: 'SELECT id, title, url FROM bookmarks ORDER BY created_at DESC',
+  SELECT_ID: 'SELECT id FROM bookmarks WHERE id = ?',
   INSERT: 'INSERT INTO bookmarks (id, title, url) VALUES (?, ?, ?) RETURNING *',
+  DELETE: 'DELETE FROM bookmarks WHERE id = ?',
 } as const
+
+export const DATABASE_NAME = 'BOOKMARK_PAGE_DB'

--- a/functions/schemas/bookmark.ts
+++ b/functions/schemas/bookmark.ts
@@ -33,3 +33,8 @@ export const CreateBookmarkSchema = z.object({
 })
 
 export type CreateBookmarkInput = z.infer<typeof CreateBookmarkSchema>
+
+// 💡 ID（UUID v7形式など）を検証するスキーマ
+export const BookmarkIdSchema = z.object({
+  id: z.uuid({ message: SCHEMA_MESSAGE.INVALID_ID_FORMAT }),
+})

--- a/functions/test/fixtures.ts
+++ b/functions/test/fixtures.ts
@@ -53,3 +53,8 @@ export const getExpectedText = (
     ? ''
     : schemaResult.error.issues.find((issue) => issue.path[0] === name)?.message
 }
+
+export const REQUEST_API_PATH = {
+  GET_BOOKMARKS: '/api/bookmarks',
+  DELETE_BOOKMARK: (id: string) => `/api/bookmarks/${id}`,
+} as const

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bookmark-page",
   "type": "module",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.4.0",
   "scripts": {
     "dev:frontend": "vite",
     "dev:backend": "wrangler pages dev ./dist",

--- a/shared/constants/api.ts
+++ b/shared/constants/api.ts
@@ -1,6 +1,7 @@
 export const API_PATH = {
   ROOT: '/api',
   GET_BOOKMARKS: '/bookmarks',
+  DELETE_BOOKMARK: `/bookmarks/:id`,
 } as const
 
 // フォールバック用のデフォルトURL（未設定時の挙動対策）

--- a/shared/constants/uiMessages.ts
+++ b/shared/constants/uiMessages.ts
@@ -5,6 +5,7 @@ export const ERROR_MESSAGE = {
     `データベース ${binding} のバインディングが設定されていません`,
   INSERT_BOOKMARK_ERROR: 'ブックマークの追加に失敗しました',
   STATUS_CODE: (code: number) => `ステータスコード: ${code}`,
+  FAILED_DELETE_BOOKMARK: 'ブックマークの削除に失敗しました。',
 } as const
 
 export const UI_LABELS = {
@@ -50,5 +51,6 @@ export const UI_MESSAGES = {
       '接続に失敗しました。URLまたはサーバーの状態を確認してください。',
     TIMEOUT_CONNECT_SERVER:
       '接続がタイムアウトしました。URLが正しいか確認してください。',
+    NOT_FOUND_BOOKMARK: '指定されたブックマークが見つかりません。',
   },
 } as const

--- a/shared/constants/validation.ts
+++ b/shared/constants/validation.ts
@@ -6,9 +6,9 @@ export const LENGTH_LIMITATION = {
 export const SCHEMA_MESSAGE = {
   URL_REQUIRED: 'URLは必須です',
   TITLE_REQUIRED: 'タイトルは必須です',
-  MIN_LENGTH_TITLE:
-    `タイトルは${LENGTH_LIMITATION.TITLE.MIN}文字以上で入力してください`,
+  MIN_LENGTH_TITLE: `タイトルは${LENGTH_LIMITATION.TITLE.MIN}文字以上で入力してください`,
   MAX_LENGTH_TITLE: `タイトルは${LENGTH_LIMITATION.TITLE.MAX}文字以内で入力してください`,
   MAX_LENGTH_URL: `URLは${LENGTH_LIMITATION.URL.MAX}文字以内で入力してください`,
   INVALID_URL: '不正なURL形式です',
+  INVALID_ID_FORMAT: '無効なID形式です',
 } as const


### PR DESCRIPTION
## 概要

ブックマークを削除するAPIとしてDELETE /bookmarks/:idを作成しました。

## 背景・目的

ブックマークの編集機能を実装するため

## 変更内容

- functions/api/[[route]].tsに.delete(/bookmarks/:id)を追加しました。
- ブックマークを削除するAPIのテストとしてfunctions/api/[[route]].delete-bookmarks.test.tsを作成しました。

## 対象外

フロントエンド側の対応は別のissueとします。

## 確認方法

1. ブックマークを正常に削除できる
2. 指定したidのフォーマットが不正な場合
3. 指定したidのブックマークが存在しない場合
4. ブックマークの削除中にデータベースにエラーあるいは例外が発生した場合
5. データベースのバインディングが設定されていない場合

## テスト

- [x] 単体テストを追加・更新した
- [ ] 手動確認を実施した
- [x] 既存テストが成功することを確認した

## 影響範囲

- [x] API
- [x] データベース
- [ ] フロントエンド
- [ ] 拡張機能
- [ ] 外部サービス
- [ ] 影響なし

## セキュリティ

- [ ] 外部入力を検証している
- [ ] 機密情報をログへ出力していない
- [ ] 新しいシークレットを追加していない

## データベース変更

- [ ] マイグレーションなし
- [ ] マイグレーションあり
- [ ] ロールバック方法を確認した

## 関連Issue

Closes #48 

## スクリーンショット

UIの変更はありません