### PR TITLE
ブックマークの更新のAPIとしてPATCH /bookmarks/:idを作成した

### DIFF
--- a/functions/api/[[route]].delete-bookmarks.test.ts
+++ b/functions/api/[[route]].delete-bookmarks.test.ts
@@ -8,8 +8,7 @@ import {
   REQUEST_API_PATH,
   TEST_ERROR_MESSAGE,
 } from '../test/fixtures'
-import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
-import { API_MESSAGE } from '../../shared/constants/api'
+import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
 import { LOG_MESSAGE } from '../constants/logMessage'
 import { DATABASE_NAME } from '../constants/db'
 
@@ -159,7 +158,7 @@ describe('DELETE /api/bookmarks/:id', () => {
       const body = await res.json()
       expect(body).toEqual({
         success: false,
-        error: API_MESSAGE.DB_ERROR,
+        error: UI_MESSAGES.API.DB_ERROR,
       })
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining(ERROR_MESSAGE.DB_BINDING_ERROR(DATABASE_NAME)),

--- a/functions/api/[[route]].get-bookmarks.test.ts
+++ b/functions/api/[[route]].get-bookmarks.test.ts
@@ -4,7 +4,7 @@ import { TEST_ERROR_MESSAGE, TestBookmarks } from '../test/fixtures'
 import { D1Database } from '@cloudflare/workers-types'
 import { BOOKMARKS } from '../constants/db'
 import { LOG_MESSAGE } from '../constants/logMessage'
-import { API_MESSAGE } from '../../shared/constants/api'
+import { UI_MESSAGES } from '../../shared/constants/uiMessages'
 
 describe('Hono Backend API - app.request', () => {
   it('GET /api/bookmarks が正しいJSONを返すこと', async () => {
@@ -62,7 +62,7 @@ describe('Hono Backend API - app.request', () => {
     const json = await res.json()
     expect(json).toEqual({
       success: false,
-      error: API_MESSAGE.FAILED_CONNECT_DATABASE,
+      error: UI_MESSAGES.API.FAILED_CONNECT_DATABASE,
     })
     expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGE.DB_ERROR(dbError))
   })

--- a/functions/api/[[route]].patch-bookmarks.test.ts
+++ b/functions/api/[[route]].patch-bookmarks.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { app } from './[[route]]' // appのインポートパスは環境に合わせて調整してください
+import { REQUEST_API_PATH, TestBookmarks } from '../test/fixtures'
+import { D1Database } from '@cloudflare/workers-types'
+import { BOOKMARKS } from '../constants/db'
+
+// D1 データベースの準備（モック用）
+
+describe('Hono API - PATCH /api/bookmarks/:id', () => {
+  const mockPrepare = vi.fn()
+  const mockBind = vi.fn()
+  const mockRun = vi.fn()
+  const updateBookmark = TestBookmarks[0]
+  const requestBody = {
+    title: updateBookmark.title,
+    url: updateBookmark.url,
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockPrepare.mockReturnValue({ bind: mockBind })
+    mockBind.mockReturnValue({
+      run: mockRun,
+    })
+  })
+
+  it('正常系: 有効なパラメータを送信したとき、ブックマークが更新されて200を返すこと', async () => {
+    mockRun.mockResolvedValueOnce({ success: true, meta: { changes: 1 } })
+
+    const mockD1Database: Partial<D1Database> = {
+      prepare: mockPrepare as D1Database['prepare'],
+    }
+
+    const res = await app.request(
+      REQUEST_API_PATH.UPDATE_BOOKMARK(updateBookmark.id),
+      {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      },
+      {
+        BOOKMARK_PAGE_DB: mockD1Database as D1Database,
+      },
+    )
+
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.success).toBe(true)
+    expect(json.data.title).toBe(updateBookmark.title)
+    expect(json.data.url).toBe(updateBookmark.url)
+    expect(json.data.id).toBe(updateBookmark.id)
+
+    expect(mockPrepare).toHaveBeenCalledWith(BOOKMARKS.UPDATE)
+    expect(mockBind).toHaveBeenCalledWith(
+      requestBody.title,
+      requestBody.url,
+      updateBookmark.id,
+    )
+  })
+})

--- a/functions/api/[[route]].patch-bookmarks.test.ts
+++ b/functions/api/[[route]].patch-bookmarks.test.ts
@@ -1,8 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest'
 import { app } from './[[route]]' // appのインポートパスは環境に合わせて調整してください
-import { REQUEST_API_PATH, TestBookmarks } from '../test/fixtures'
+import {
+  INVALID_STRING,
+  REQUEST_API_PATH,
+  TestBookmarks,
+} from '../test/fixtures'
 import { D1Database } from '@cloudflare/workers-types'
-import { BOOKMARKS } from '../constants/db'
+import { BOOKMARKS, DATABASE_NAME } from '../constants/db'
+import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
+import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
 
 // D1 データベースの準備（モック用）
 
@@ -58,5 +64,165 @@ describe('Hono API - PATCH /api/bookmarks/:id', () => {
       requestBody.url,
       updateBookmark.id,
     )
+  })
+
+  describe('異常系(400): ', () => {
+    it.each([
+      {
+        description: 'IDが不正な形式',
+        id: INVALID_STRING.ID,
+        invalidBody: { title: updateBookmark.title, url: updateBookmark.url },
+        expectedError: SCHEMA_MESSAGE.INVALID_ID_FORMAT,
+      },
+      {
+        description: 'タイトルが不足',
+        id: updateBookmark.id,
+        invalidBody: { url: updateBookmark.url },
+        expectedError: SCHEMA_MESSAGE.TITLE_REQUIRED,
+      },
+      {
+        description: 'urlが不足',
+        id: updateBookmark.id,
+        invalidBody: { title: updateBookmark.title },
+        expectedError: SCHEMA_MESSAGE.URL_REQUIRED,
+      },
+    ])(`$description`, async ({ invalidBody, expectedError, id }) => {
+      const mockD1Database: Partial<D1Database> = {
+        prepare: mockPrepare as D1Database['prepare'],
+      }
+
+      const res = await app.request(
+        REQUEST_API_PATH.UPDATE_BOOKMARK(id),
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(invalidBody),
+        },
+        {
+          BOOKMARK_PAGE_DB: mockD1Database as D1Database,
+        },
+      )
+
+      expect(res.status).toBe(400)
+      const json = await res.json()
+      expect(json.success).toBe(false)
+      expect(json.error).toBe(expectedError)
+
+      expect(mockPrepare).not.toHaveBeenCalled()
+    })
+
+    it('IDを指定せずにUPDATEを呼び出した場合、Hono標準の404を返すこと', async () => {
+      const mockD1Database: Partial<D1Database> = {
+        prepare: mockPrepare as D1Database['prepare'],
+      }
+
+      const res = await app.request(
+        REQUEST_API_PATH.UPDATE_BOOKMARK(''),
+        { method: 'PATCH' },
+        { BOOKMARK_PAGE_DB: mockD1Database as D1Database },
+      )
+
+      expect(res.status).toBe(404)
+      expect(res.statusText).toBe('')
+    })
+  })
+
+  describe('異常系(404): ', () => {
+    it('データベースの更新結果が0件の場合', async () => {
+      mockRun.mockResolvedValueOnce({ success: true, meta: { changes: 0 } })
+
+      const mockD1Database: Partial<D1Database> = {
+        prepare: mockPrepare as D1Database['prepare'],
+      }
+
+      const res = await app.request(
+        REQUEST_API_PATH.UPDATE_BOOKMARK(updateBookmark.id),
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
+        },
+        {
+          BOOKMARK_PAGE_DB: mockD1Database as D1Database,
+        },
+      )
+
+      expect(res.status).toBe(404)
+
+      const body = await res.json()
+      expect(body).toEqual({
+        success: false,
+        error: UI_MESSAGES.API.NOT_FOUND_BOOKMARK,
+      })
+    })
+  })
+
+  describe('異常系(500): ', () => {
+    let consoleSpy: Mock<(...data: unknown[]) => void>
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    })
+
+    it('データベースのバインディング（BOOKMARK_PAGE_DB）が未設定の場合、500を返すこと', async () => {
+      const res = await app.request(
+        REQUEST_API_PATH.UPDATE_BOOKMARK(updateBookmark.id),
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
+        },
+        {},
+      )
+
+      expect(res.status).toBe(500)
+
+      const body = await res.json()
+      expect(body).toEqual({
+        success: false,
+        error: UI_MESSAGES.API.DB_ERROR,
+      })
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(ERROR_MESSAGE.DB_BINDING_ERROR(DATABASE_NAME)),
+      )
+    })
+
+    it('データベースの更新エラーの場合', async () => {
+      mockRun.mockResolvedValueOnce({ success: false })
+
+      const mockD1Database: Partial<D1Database> = {
+        prepare: mockPrepare as D1Database['prepare'],
+      }
+
+      const res = await app.request(
+        REQUEST_API_PATH.UPDATE_BOOKMARK(updateBookmark.id),
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(requestBody),
+        },
+        {
+          BOOKMARK_PAGE_DB: mockD1Database as D1Database,
+        },
+      )
+
+      expect(res.status).toBe(500)
+
+      const body = await res.json()
+      expect(body).toEqual({
+        success: false,
+        error: UI_MESSAGES.API.DB_ERROR,
+      })
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK),
+      )
+    })
   })
 })

--- a/functions/api/[[route]].patch-bookmarks.test.ts
+++ b/functions/api/[[route]].patch-bookmarks.test.ts
@@ -9,6 +9,7 @@ import { D1Database } from '@cloudflare/workers-types'
 import { BOOKMARKS, DATABASE_NAME } from '../constants/db'
 import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
 import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
+import { LOG_MESSAGE } from '../constants/logMessage'
 
 // D1 データベースの準備（モック用）
 
@@ -193,9 +194,8 @@ describe('Hono API - PATCH /api/bookmarks/:id', () => {
     })
 
     it('データベースの更新エラーの場合', async () => {
-      mockFirst.mockRejectedValueOnce(
-        new Error(ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK),
-      )
+      const dbError = new Error(ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK)
+      mockFirst.mockRejectedValueOnce(dbError)
 
       const mockD1Database: Partial<D1Database> = {
         prepare: mockPrepare as D1Database['prepare'],
@@ -222,9 +222,7 @@ describe('Hono API - PATCH /api/bookmarks/:id', () => {
         success: false,
         error: UI_MESSAGES.API.DB_ERROR,
       })
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining(ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK),
-      )
+      expect(consoleSpy).toHaveBeenCalledWith(LOG_MESSAGE.DB_ERROR(dbError))
     })
   })
 })

--- a/functions/api/[[route]].patch-bookmarks.test.ts
+++ b/functions/api/[[route]].patch-bookmarks.test.ts
@@ -15,7 +15,7 @@ import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
 describe('Hono API - PATCH /api/bookmarks/:id', () => {
   const mockPrepare = vi.fn()
   const mockBind = vi.fn()
-  const mockRun = vi.fn()
+  const mockFirst = vi.fn()
   const updateBookmark = TestBookmarks[0]
   const requestBody = {
     title: updateBookmark.title,
@@ -26,12 +26,12 @@ describe('Hono API - PATCH /api/bookmarks/:id', () => {
     vi.resetAllMocks()
     mockPrepare.mockReturnValue({ bind: mockBind })
     mockBind.mockReturnValue({
-      run: mockRun,
+      first: mockFirst,
     })
   })
 
   it('正常系: 有効なパラメータを送信したとき、ブックマークが更新されて200を返すこと', async () => {
-    mockRun.mockResolvedValueOnce({ success: true, meta: { changes: 1 } })
+    mockFirst.mockResolvedValueOnce(updateBookmark)
 
     const mockD1Database: Partial<D1Database> = {
       prepare: mockPrepare as D1Database['prepare'],
@@ -131,7 +131,7 @@ describe('Hono API - PATCH /api/bookmarks/:id', () => {
 
   describe('異常系(404): ', () => {
     it('データベースの更新結果が0件の場合', async () => {
-      mockRun.mockResolvedValueOnce({ success: true, meta: { changes: 0 } })
+      mockFirst.mockResolvedValueOnce(null)
 
       const mockD1Database: Partial<D1Database> = {
         prepare: mockPrepare as D1Database['prepare'],
@@ -193,7 +193,9 @@ describe('Hono API - PATCH /api/bookmarks/:id', () => {
     })
 
     it('データベースの更新エラーの場合', async () => {
-      mockRun.mockResolvedValueOnce({ success: false })
+      mockFirst.mockRejectedValueOnce(
+        new Error(ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK),
+      )
 
       const mockD1Database: Partial<D1Database> = {
         prepare: mockPrepare as D1Database['prepare'],

--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -46,7 +46,7 @@ app.use(
       }
       return undefined
     },
-    allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     allowHeaders: ['Content-Type', 'Authorization'],
     credentials: true,
   }),

--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -3,13 +3,14 @@ import { zValidator } from '@hono/zod-validator'
 
 import { handle } from 'hono/cloudflare-pages'
 import type { D1Database } from '@cloudflare/workers-types'
-import { API_MESSAGE, API_PATH } from '../../shared/constants/api'
+import { API_PATH } from '../../shared/constants/api'
 import { BOOKMARKS, DATABASE_NAME } from '../constants/db'
-import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
+import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
 import {
   Bookmark,
   BookmarkIdParamSchema,
   CreateBookmarkSchema,
+  UpdateBookmarkSchema,
 } from '../schemas/bookmark'
 import { uuidv7 } from 'uuidv7'
 import { cors } from 'hono/cors'
@@ -70,7 +71,7 @@ const routes = app
       return c.json(
         {
           success: false,
-          error: API_MESSAGE.FAILED_CONNECT_DATABASE,
+          error: UI_MESSAGES.API.FAILED_CONNECT_DATABASE,
         } as const,
         500,
       )
@@ -113,7 +114,7 @@ const routes = app
         return c.json(
           {
             success: false,
-            error: API_MESSAGE.DB_ERROR,
+            error: UI_MESSAGES.API.DB_ERROR,
           } as const,
           500,
         )
@@ -150,7 +151,64 @@ const routes = app
         return c.json(
           {
             success: false,
-            error: API_MESSAGE.DB_ERROR,
+            error: UI_MESSAGES.API.DB_ERROR,
+          } as const,
+          500,
+        )
+      }
+    },
+  )
+  .patch(
+    API_PATH.UPDATE_BOOKMARK,
+    zValidator('param', BookmarkIdParamSchema, (result, c) => {
+      return !result.success
+        ? c.json({ success: false, error: result.error.issues[0].message }, 400)
+        : undefined
+    }),
+    zValidator('json', UpdateBookmarkSchema, (result, c) => {
+      return !result.success
+        ? c.json({ success: false, error: result.error.issues[0].message }, 400)
+        : undefined
+    }),
+    async (c) => {
+      const { id } = c.req.valid('param')
+      const updates = c.req.valid('json')
+
+      try {
+        const db = c.env.BOOKMARK_PAGE_DB
+        if (!db) {
+          throw new Error(ERROR_MESSAGE.DB_BINDING_ERROR(DATABASE_NAME))
+        }
+
+        const { success, meta } = await db
+          .prepare(BOOKMARKS.UPDATE)
+          .bind(updates.title, updates.url, id)
+          .run()
+
+        if (!success) {
+          throw new Error(ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK)
+        }
+
+        if (meta.changes === 0) {
+          return c.json(
+            {
+              success: false,
+              error: UI_MESSAGES.API.NOT_FOUND_BOOKMARK,
+            } as const,
+            404,
+          )
+        }
+
+        return c.json({
+          success: true,
+          data: { id, title: updates.title, url: updates.url },
+        } as const)
+      } catch (error) {
+        console.error(LOG_MESSAGE.DB_ERROR(error))
+        return c.json(
+          {
+            success: false,
+            error: UI_MESSAGES.API.DB_ERROR,
           } as const,
           500,
         )

--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -8,7 +8,7 @@ import { BOOKMARKS, DATABASE_NAME } from '../constants/db'
 import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
 import {
   Bookmark,
-  BookmarkIdSchema,
+  BookmarkIdParamSchema,
   CreateBookmarkSchema,
 } from '../schemas/bookmark'
 import { uuidv7 } from 'uuidv7'
@@ -123,7 +123,7 @@ const routes = app
 
   .delete(
     API_PATH.DELETE_BOOKMARK,
-    zValidator('param', BookmarkIdSchema, (result, c) => {
+    zValidator('param', BookmarkIdParamSchema, (result, c) => {
       return !result.success
         ? c.json({ success: false, error: result.error.issues[0].message }, 400)
         : undefined

--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -180,16 +180,11 @@ const routes = app
           throw new Error(ERROR_MESSAGE.DB_BINDING_ERROR(DATABASE_NAME))
         }
 
-        const { success, meta } = await db
+        const updatedBookmark = await db
           .prepare(BOOKMARKS.UPDATE)
           .bind(updates.title, updates.url, id)
-          .run()
-
-        if (!success) {
-          throw new Error(ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK)
-        }
-
-        if (meta.changes === 0) {
+          .first<Bookmark>()
+        if (!updatedBookmark) {
           return c.json(
             {
               success: false,
@@ -198,10 +193,9 @@ const routes = app
             404,
           )
         }
-
         return c.json({
           success: true,
-          data: { id, title: updates.title, url: updates.url },
+          data: updatedBookmark,
         } as const)
       } catch (error) {
         console.error(LOG_MESSAGE.DB_ERROR(error))

--- a/functions/constants/db.ts
+++ b/functions/constants/db.ts
@@ -3,7 +3,8 @@ export const BOOKMARKS = {
   SELECT_ID: 'SELECT id FROM bookmarks WHERE id = ?',
   INSERT: 'INSERT INTO bookmarks (id, title, url) VALUES (?, ?, ?) RETURNING *',
   DELETE: 'DELETE FROM bookmarks WHERE id = ?',
-  UPDATE: 'UPDATE bookmarks SET title = ?, url = ? WHERE id = ?',
+  UPDATE:
+    'UPDATE bookmarks SET title = ?, url = ? WHERE id = ? RETURNING id, title, url',
 } as const
 
 export const DATABASE_NAME = 'BOOKMARK_PAGE_DB'

--- a/functions/constants/db.ts
+++ b/functions/constants/db.ts
@@ -3,6 +3,7 @@ export const BOOKMARKS = {
   SELECT_ID: 'SELECT id FROM bookmarks WHERE id = ?',
   INSERT: 'INSERT INTO bookmarks (id, title, url) VALUES (?, ?, ?) RETURNING *',
   DELETE: 'DELETE FROM bookmarks WHERE id = ?',
+  UPDATE: 'UPDATE bookmarks SET title = ?, url = ? WHERE id = ?',
 } as const
 
 export const DATABASE_NAME = 'BOOKMARK_PAGE_DB'

--- a/functions/schemas/bookmark.ts
+++ b/functions/schemas/bookmark.ts
@@ -17,7 +17,7 @@ export const BookmarkTitleSchema = z
 
 export const BookmarkUrlSchema = z
   // 💡 ステップ1: まずはただの文字列として「必須」と「文字数」をチェック
-  .string()
+  .string({ message: SCHEMA_MESSAGE.URL_REQUIRED })
   .trim()
   .min(1, SCHEMA_MESSAGE.URL_REQUIRED) // 空文字を弾くための明示的なガード
   .max(LENGTH_LIMITATION.URL.MAX, SCHEMA_MESSAGE.MAX_LENGTH_URL)

--- a/functions/schemas/bookmark.ts
+++ b/functions/schemas/bookmark.ts
@@ -5,10 +5,29 @@ import {
 } from '../../shared/constants/validation'
 
 // Zodで型を定義（バリデーションや安全なパース用）
+export const BookmarkIdSchema = z.uuid({
+  message: SCHEMA_MESSAGE.INVALID_ID_FORMAT,
+})
+
+export const BookmarkTitleSchema = z
+  .string({ message: SCHEMA_MESSAGE.TITLE_REQUIRED })
+  .trim()
+  .min(LENGTH_LIMITATION.TITLE.MIN, SCHEMA_MESSAGE.MIN_LENGTH_TITLE)
+  .max(LENGTH_LIMITATION.TITLE.MAX, SCHEMA_MESSAGE.MAX_LENGTH_TITLE)
+
+export const BookmarkUrlSchema = z
+  // 💡 ステップ1: まずはただの文字列として「必須」と「文字数」をチェック
+  .string()
+  .trim()
+  .min(1, SCHEMA_MESSAGE.URL_REQUIRED) // 空文字を弾くための明示的なガード
+  .max(LENGTH_LIMITATION.URL.MAX, SCHEMA_MESSAGE.MAX_LENGTH_URL)
+  // 🎯 ステップ2: 合格した文字列を、Zod v4 推奨の z.url() スキーマに流し込む（バリデーションの結合）
+  .pipe(z.url({ message: SCHEMA_MESSAGE.INVALID_URL }))
+
 export const BookmarkSchema = z.object({
-  id: z.uuidv7(),
-  title: z.string(),
-  url: z.url(),
+  id: BookmarkIdSchema,
+  title: BookmarkTitleSchema,
+  url: BookmarkUrlSchema,
 })
 export type Bookmark = z.infer<typeof BookmarkSchema>
 
@@ -16,25 +35,19 @@ export type Bookmark = z.infer<typeof BookmarkSchema>
  * 💡 ブックマーク新規登録時のバリデーションスキーマ
  */
 export const CreateBookmarkSchema = z.object({
-  title: z
-    .string({ message: SCHEMA_MESSAGE.TITLE_REQUIRED })
-    .trim()
-    .min(LENGTH_LIMITATION.TITLE.MIN, SCHEMA_MESSAGE.MIN_LENGTH_TITLE)
-    .max(LENGTH_LIMITATION.TITLE.MAX, SCHEMA_MESSAGE.MAX_LENGTH_TITLE),
-
-  url: z
-    // 💡 ステップ1: まずはただの文字列として「必須」と「文字数」をチェック
-    .string()
-    .trim()
-    .min(1, SCHEMA_MESSAGE.URL_REQUIRED) // 空文字を弾くための明示的なガード
-    .max(LENGTH_LIMITATION.URL.MAX, SCHEMA_MESSAGE.MAX_LENGTH_URL)
-    // 🎯 ステップ2: 合格した文字列を、Zod v4 推奨の z.url() スキーマに流し込む（バリデーションの結合）
-    .pipe(z.url({ message: SCHEMA_MESSAGE.INVALID_URL })),
+  title: BookmarkTitleSchema,
+  url: BookmarkUrlSchema,
 })
 
 export type CreateBookmarkInput = z.infer<typeof CreateBookmarkSchema>
 
 // 💡 ID（UUID v7形式など）を検証するスキーマ
-export const BookmarkIdSchema = z.object({
-  id: z.uuid({ message: SCHEMA_MESSAGE.INVALID_ID_FORMAT }),
+export const BookmarkIdParamSchema = z.object({
+  id: BookmarkIdSchema,
+})
+
+// 💡 どちらか片方だけの送信は「不可」。必ず両方を要求する
+export const UpdateBookmarkSchema = z.object({
+  title: BookmarkTitleSchema,
+  url: BookmarkUrlSchema,
 })

--- a/functions/test/fixtures.ts
+++ b/functions/test/fixtures.ts
@@ -57,4 +57,5 @@ export const getExpectedText = (
 export const REQUEST_API_PATH = {
   GET_BOOKMARKS: '/api/bookmarks',
   DELETE_BOOKMARK: (id: string) => `/api/bookmarks/${id}`,
+  UPDATE_BOOKMARK: (id: string) => `/api/bookmarks/${id}`,
 } as const

--- a/shared/constants/api.ts
+++ b/shared/constants/api.ts
@@ -2,14 +2,10 @@ export const API_PATH = {
   ROOT: '/api',
   GET_BOOKMARKS: '/bookmarks',
   DELETE_BOOKMARK: `/bookmarks/:id`,
+  UPDATE_BOOKMARK: `/bookmarks/:id`,
 } as const
 
 // フォールバック用のデフォルトURL（未設定時の挙動対策）
 export const DEFAULT_API_URL = 'http://localhost:8788'
 
 export const TIMEOUT_MILLISECOND = 5000
-
-export const API_MESSAGE = {
-  DB_ERROR: 'データベースにエラーが発生しました',
-  FAILED_CONNECT_DATABASE: 'データベースの接続に失敗しました',
-} as const

--- a/shared/constants/uiMessages.ts
+++ b/shared/constants/uiMessages.ts
@@ -6,6 +6,7 @@ export const ERROR_MESSAGE = {
   INSERT_BOOKMARK_ERROR: 'ブックマークの追加に失敗しました',
   STATUS_CODE: (code: number) => `ステータスコード: ${code}`,
   FAILED_DELETE_BOOKMARK: 'ブックマークの削除に失敗しました。',
+  FAILED_UPDATE_BOOKMARK: 'ブックマークの更新に失敗しました。',
 } as const
 
 export const UI_LABELS = {
@@ -47,6 +48,8 @@ export const UI_MESSAGES = {
       `「${title}」を削除してもよろしいですか？`,
   },
   API: {
+    DB_ERROR: 'データベースにエラーが発生しました',
+    FAILED_CONNECT_DATABASE: 'データベースの接続に失敗しました',
     SAVED_API_URL: 'APIのURLを保存しました。',
     FAILED_SAVE_API_URL: 'APIのURLの保存に失敗しました。',
     FAILED_CONNECT_SERVER:


### PR DESCRIPTION
## 概要

ブックマークの更新のAPIとしてPATCH /bookmarks/:idをfunctions/api/[[route]].tsに追加した。

## 背景・目的

バックエンドにブックマークの管理機能を作成するため。

## 変更内容

- functions/api/[[route]].tsに.patchを追加しました。
- PATCH /bookmarks/:idのテストを作成しました。

## 対象外

ブックマークの更新に関するフロントエンドの対応は別のissueとします。

## 確認方法

1. ブックマークが正常に更新される場合のテスト
2. idの形式やタイトルやurlが不足している場合のテスト
3. ブックマークの更新がエラーの場合のテスト

## テスト

- [x] 単体テストを追加・更新した
- [ ] 手動確認を実施した
- [x] 既存テストが成功することを確認した

## 影響範囲

- [x] API
- [x] データベース
- [ ] フロントエンド
- [ ] 拡張機能
- [ ] 外部サービス
- [ ] 影響なし

## セキュリティ

- [ ] 外部入力を検証している
- [x] 機密情報をログへ出力していない
- [x] 新しいシークレットを追加していない

## データベース変更

- [x] マイグレーションなし
- [ ] マイグレーションあり
- [ ] ロールバック方法を確認した

## 関連Issue

Closes #49 