### PR TITLE
feat: ブックマーク更新用カスタムフック (useUpdateBookmark) とテストの実装

### DIFF
--- a/functions/schemas/bookmark.ts
+++ b/functions/schemas/bookmark.ts
@@ -9,6 +9,8 @@ export const BookmarkIdSchema = z.uuid({
   message: SCHEMA_MESSAGE.INVALID_ID_FORMAT,
 })
 
+export type BookmarkId = z.infer<typeof BookmarkIdSchema>
+
 export const BookmarkTitleSchema = z
   .string({ message: SCHEMA_MESSAGE.TITLE_REQUIRED })
   .trim()
@@ -51,3 +53,7 @@ export const UpdateBookmarkSchema = z.object({
   title: BookmarkTitleSchema,
   url: BookmarkUrlSchema,
 })
+
+export type UpdateBookmarkPayload = z.infer<typeof UpdateBookmarkSchema> & {
+  id: BookmarkId
+}

--- a/src/hooks/useUpdateBookmark.test.tsx
+++ b/src/hooks/useUpdateBookmark.test.tsx
@@ -4,6 +4,8 @@ import { uuidv7 } from 'uuidv7'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TestBookmarks } from '../../functions/test/fixtures'
 import { useUpdateBookmark } from './useUpdateBookmark'
+import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
+import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
 
 const { mockPatch } = vi.hoisted(() => ({
   mockPatch: vi.fn(),
@@ -81,10 +83,91 @@ describe('useUpdateBookmark', () => {
       })
     })
   })
+
   describe('異常系', () => {
-    it('APIが400でバリデーションエラーを返したときにエラー処理が行われること', () => {})
-    it('APIが404でブックマークが存在しないエラーを返したときにエラー処理が行われること', () => {})
-    it('APIが409で登録済みのurlを登録しようとしたエラーを返したときにエラー処理が行われること', () => {})
-    it('APIが500などの一般的なエラーを返したときにエラー処理が行われること', () => {})
+    it.each([
+      {
+        status: 400,
+        errorName: 'バリデーション',
+        errorText: SCHEMA_MESSAGE.INVALID_ID_FORMAT,
+      },
+      {
+        status: 404,
+        errorName: 'ブックマークが存在しない',
+        errorText: UI_MESSAGES.API.NOT_FOUND_BOOKMARK,
+      },
+      {
+        status: 409,
+        errorName: '登録済みのurlを登録しようとした',
+        errorText: UI_MESSAGES.API.DUPLICATE_URL,
+      },
+      {
+        status: 500,
+        errorName: '一般的な',
+        errorText: ERROR_MESSAGE.SERVER_ERROR,
+      },
+    ])(
+      `APIが$statusで$errorNameエラーを返したときにエラー処理が行われること`,
+      async ({ status, errorText }) => {
+        mockPatch.mockResolvedValueOnce({
+          status,
+          ok: false,
+          json: async () => ({
+            success: false,
+            error: errorText,
+          }),
+        })
+        const updatedPayload = {
+          id: validId,
+          title: TestBookmarks[0].title,
+          url: TestBookmarks[0].url,
+        }
+        const { queryClient, wrapper } = createTestQueryClient()
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+        const { result } = renderHook(() => useUpdateBookmark(), { wrapper })
+
+        result.current.mutate(updatedPayload)
+
+        await waitFor(() => {
+          expect(result.current.isSuccess).toBe(false)
+          expect(result.current.error).toBeInstanceOf(Error)
+          expect(result.current.error?.message).toBe(errorText)
+
+          expect(invalidateSpy).not.toHaveBeenCalled()
+        })
+      },
+    )
+
+    it(`APIが不明なエラーを返したときにエラー処理が行われること`, async () => {
+      mockPatch.mockResolvedValueOnce({
+        status: 500,
+        ok: false,
+        json: async () => ({
+          success: false,
+        }),
+      })
+      const updatedPayload = {
+        id: validId,
+        title: TestBookmarks[0].title,
+        url: TestBookmarks[0].url,
+      }
+      const { queryClient, wrapper } = createTestQueryClient()
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      const { result } = renderHook(() => useUpdateBookmark(), { wrapper })
+
+      result.current.mutate(updatedPayload)
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(false)
+        expect(result.current.error).toBeInstanceOf(Error)
+        expect(result.current.error?.message).toBe(
+          ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK,
+        )
+
+        expect(invalidateSpy).not.toHaveBeenCalled()
+      })
+    })
   })
 })

--- a/src/hooks/useUpdateBookmark.test.tsx
+++ b/src/hooks/useUpdateBookmark.test.tsx
@@ -1,0 +1,90 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { uuidv7 } from 'uuidv7'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TestBookmarks } from '../../functions/test/fixtures'
+import { useUpdateBookmark } from './useUpdateBookmark'
+
+const { mockPatch } = vi.hoisted(() => ({
+  mockPatch: vi.fn(),
+}))
+
+// Honoクライアントのモック化
+vi.mock('hono/client', () => ({
+  hc: () => ({
+    api: {
+      bookmarks: {
+        ':id': {
+          $patch: mockPatch,
+        },
+      },
+    },
+  }),
+}))
+
+const createTestQueryClient = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  return { queryClient, wrapper }
+}
+
+describe('useUpdateBookmark', () => {
+  const validId = uuidv7()
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('更新APIが200を返したときにキャッシュが更新されること', async () => {
+    const updatedPayload = {
+      id: validId,
+      title: TestBookmarks[0].title,
+      url: TestBookmarks[0].url,
+    }
+    mockPatch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: updatedPayload,
+      }),
+    })
+
+    const { queryClient, wrapper } = createTestQueryClient()
+    // 💡 本物の queryClient の invalidateQueries を spyOn する
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+    const { result } = renderHook(() => useUpdateBookmark(), { wrapper })
+
+    result.current.mutate(updatedPayload)
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+
+      expect(mockPatch).toHaveBeenCalledWith({
+        param: { id: validId },
+        json: {
+          title: updatedPayload.title,
+          url: updatedPayload.url,
+        },
+      })
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['bookmarks'],
+      })
+    })
+  })
+  describe('異常系', () => {
+    it('APIが400でバリデーションエラーを返したときにエラー処理が行われること', () => {})
+    it('APIが404でブックマークが存在しないエラーを返したときにエラー処理が行われること', () => {})
+    it('APIが409で登録済みのurlを登録しようとしたエラーを返したときにエラー処理が行われること', () => {})
+    it('APIが500などの一般的なエラーを返したときにエラー処理が行われること', () => {})
+  })
+})

--- a/src/hooks/useUpdateBookmark.ts
+++ b/src/hooks/useUpdateBookmark.ts
@@ -1,0 +1,31 @@
+import { hc } from 'hono/client'
+import { AppType } from '../../functions/api/[[route]]'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
+import { UpdateBookmarkPayload } from '../../functions/schemas/bookmark'
+
+const client = hc<AppType>('/')
+
+export const useUpdateBookmark = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({ id, title, url }: UpdateBookmarkPayload) => {
+      const res = await client.api.bookmarks[':id'].$patch({
+        param: { id },
+        json: { title, url },
+      })
+
+      const json = await res.json()
+      if (!json.success) {
+        throw new Error(json.error || ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK)
+      }
+
+      return json
+    },
+    onSuccess: () => {
+      // 1. ブックマーク一覧のキャッシュを古いものとして扱い、再取得を走らせる
+      queryClient.invalidateQueries({ queryKey: ['bookmarks'] })
+    },
+  })
+}


### PR DESCRIPTION
## 概要
ブックマーク詳細画面等から `PATCH /api/bookmarks/:id` を呼び出してデータ（タイトル・URL）を更新するためのカスタムフック `useUpdateBookmark` を実装し、その単体テストを作成しました。

## 関連 Issue
Fixes #37 

## 変更内容

### 1. スキーマ・型定義の追加
- `functions/schemas/bookmark.ts`
  - 更新リクエスト用の型 `UpdateBookmarkPayload` (`UpdateBookmarkSchema` + `id`) を定義

### 2. カスタムフックの実装
- `src/hooks/useUpdateBookmark.ts`
  - TanStack Query の `useMutation` を使用した更新用フックを実装
  - Hono Client (`$patch`) を用いて API リクエストを送信
  - 更新成功時に `queryClient.invalidateQueries` で `'bookmarks'` のキャッシュを無効化し、画面表示を最新化
  - API から返されたエラーメッセージ（409 Duplicate など）をキャッチして throw するエラーハンドリングを追加

### 3. 単体テストの追加
- `src/hooks/useUpdateBookmark.test.tsx`
  - **正常系**: API から `200` が返った際、正しいパラメータ（`param` / `json`）で呼び出され、キャッシュ無効化が実行されること
  - **異常系 (`it.each`)**: API が 400, 404, 409, 500 を返した際、適切なエラーメッセージがセットされ、キャッシュが無効化されないこと
  - **フォールバック**: エラーメッセージが含まれない未知のレスポンス時にデフォルトエラーメッセージが採用されること

## 動作確認手順
1. `npm test src/hooks/useUpdateBookmark.test.tsx` を実行し、すべてのテスト（正常系・異常系）が PASS することを確認