### PR TITLE
feat: ブックマーク更新の画面とテストの実装

### DIFF
--- a/functions/schemas/bookmark.ts
+++ b/functions/schemas/bookmark.ts
@@ -24,7 +24,7 @@ export const BookmarkUrlSchema = z
   .min(1, SCHEMA_MESSAGE.URL_REQUIRED) // 空文字を弾くための明示的なガード
   .max(LENGTH_LIMITATION.URL.MAX, SCHEMA_MESSAGE.MAX_LENGTH_URL)
   .refine((val) => val.startsWith('http://') || val.startsWith('https://'), {
-    message: SCHEMA_MESSAGE.START_PROTOCOL,
+    message: SCHEMA_MESSAGE.PROTOCOL_CONSTRAINT,
   })
   // 🎯 ステップ2: 合格した文字列を、Zod v4 推奨の z.url() スキーマに流し込む（バリデーションの結合）
   .pipe(z.url({ message: SCHEMA_MESSAGE.INVALID_URL }))

--- a/functions/schemas/bookmark.ts
+++ b/functions/schemas/bookmark.ts
@@ -23,6 +23,9 @@ export const BookmarkUrlSchema = z
   .trim()
   .min(1, SCHEMA_MESSAGE.URL_REQUIRED) // 空文字を弾くための明示的なガード
   .max(LENGTH_LIMITATION.URL.MAX, SCHEMA_MESSAGE.MAX_LENGTH_URL)
+  .refine((val) => val.startsWith('http://') || val.startsWith('https://'), {
+    message: SCHEMA_MESSAGE.START_PROTOCOL,
+  })
   // 🎯 ステップ2: 合格した文字列を、Zod v4 推奨の z.url() スキーマに流し込む（バリデーションの結合）
   .pipe(z.url({ message: SCHEMA_MESSAGE.INVALID_URL }))
 

--- a/functions/test/fixtures.ts
+++ b/functions/test/fixtures.ts
@@ -28,6 +28,7 @@ export const BookmarksTableData = {
 
 export const INVALID_STRING = {
   URL: 'not-a-valid-url',
+  FTP: 'ftp://ftp.com',
   ID: 'not-found-id',
 } as const
 

--- a/shared/constants/validation.ts
+++ b/shared/constants/validation.ts
@@ -11,4 +11,5 @@ export const SCHEMA_MESSAGE = {
   MAX_LENGTH_URL: `URLは${LENGTH_LIMITATION.URL.MAX}文字以内で入力してください`,
   INVALID_URL: '不正なURL形式です',
   INVALID_ID_FORMAT: '無効なID形式です',
+  START_PROTOCOL: 'http または https で始まるURLを入力してください',
 } as const

--- a/shared/constants/validation.ts
+++ b/shared/constants/validation.ts
@@ -11,5 +11,5 @@ export const SCHEMA_MESSAGE = {
   MAX_LENGTH_URL: `URLは${LENGTH_LIMITATION.URL.MAX}文字以内で入力してください`,
   INVALID_URL: '不正なURL形式です',
   INVALID_ID_FORMAT: '無効なID形式です',
-  START_PROTOCOL: 'http または https で始まるURLを入力してください',
+  PROTOCOL_CONSTRAINT: 'http または https で始まるURLを入力してください',
 } as const

--- a/src/components/BookmarkForm.test.tsx
+++ b/src/components/BookmarkForm.test.tsx
@@ -27,6 +27,16 @@ vi.mock('../hooks/useDeleteBookmark', () => ({
   }),
 }))
 
+const mockUpdate = vi.fn()
+const mockIsUpdatePending = false
+
+vi.mock('../hooks/useUpdateBookmark', () => ({
+  useUpdateBookmark: () => ({
+    mutate: mockUpdate,
+    isPending: mockIsUpdatePending,
+  }),
+}))
+
 describe('BookmarkForm', () => {
   it('該当するブックマークのurlとタイトルが正しく表示されること', async () => {
     const targetBookmark = TestBookmarks[0]
@@ -230,6 +240,90 @@ describe('BookmarkForm', () => {
 
       // 検証: ボタンが disabled（非活性）になっていること
       expect(deleteButton).toBeDisabled()
+    })
+  })
+
+  describe('更新ボタンの動作', () => {
+    const testBookmark = TestBookmarks[0]
+
+    const testData: { name: string; title?: string; url?: string }[] = [
+      { name: 'タイトルもurlも変更しなければ' },
+      { name: 'タイトルが不正ならば', title: '' },
+      { name: 'urlが不正ならば', url: INVALID_STRING.URL },
+      { name: 'urlがftpならば', url: INVALID_STRING.FTP },
+    ]
+
+    it.each(testData)(
+      `$name更新ボタンが無効であること`,
+      async ({ title, url }) => {
+        const user = userEvent.setup()
+
+        render(<BookmarkForm bookmark={testBookmark} />)
+
+        if (title !== undefined) {
+          const titleInput = await screen.findByRole('textbox', {
+            name: UI_LABELS.FIELDS.TITLE,
+          })
+          await user.clear(titleInput)
+          if (title !== '') {
+            await user.type(titleInput, title)
+          }
+        }
+        if (url !== undefined) {
+          const urlInput = await screen.findByRole('textbox', {
+            name: UI_LABELS.FIELDS.URL,
+          })
+          await user.clear(urlInput)
+          if (url !== '') {
+            await user.type(urlInput, url)
+          }
+        }
+
+        const updateButton = await screen.findByRole('button', {
+          name: UI_LABELS.ACTIONS.UPDATE,
+        })
+        expect(updateButton).toBeDisabled()
+      },
+    )
+
+    it('タイトルを正しく変更したら更新ボタンが有効になること', async () => {
+      const user = userEvent.setup()
+
+      render(<BookmarkForm bookmark={testBookmark} />)
+
+      const titleInput = await screen.findByRole('textbox', {
+        name: UI_LABELS.FIELDS.TITLE,
+      })
+      await user.clear(titleInput)
+      await user.type(titleInput, TestBookmarks[1].title)
+
+      const updateButton = await screen.findByRole('button', {
+        name: UI_LABELS.ACTIONS.UPDATE,
+      })
+      expect(updateButton).toBeEnabled()
+    })
+
+    it('更新ボタンをクリックしたらupdateBookmark()が呼び出されること', async () => {
+      const user = userEvent.setup()
+      render(<BookmarkForm bookmark={testBookmark} />)
+
+      const titleInput = await screen.findByRole('textbox', {
+        name: UI_LABELS.FIELDS.TITLE,
+      })
+      await user.clear(titleInput)
+      await user.type(titleInput, TestBookmarks[1].title)
+
+      const updateButton = await screen.findByRole('button', {
+        name: UI_LABELS.ACTIONS.UPDATE,
+      })
+      await user.click(updateButton)
+
+      // 検証: フックの削除関数が、正しいIDを引数にして呼ばれたか
+      expect(mockUpdate).toHaveBeenCalledWith({
+        id: testBookmark.id,
+        title: TestBookmarks[1].title,
+        url: testBookmark.url,
+      })
     })
   })
 })

--- a/src/components/BookmarkForm.tsx
+++ b/src/components/BookmarkForm.tsx
@@ -2,7 +2,12 @@ import { useState } from 'react'
 import { UI_LABELS, UI_MESSAGES } from '../../shared/constants/uiMessages'
 import { useRouter } from '@tanstack/react-router'
 import { useDeleteBookmark } from '../hooks/useDeleteBookmark'
-import { Bookmark } from '../../functions/schemas/bookmark'
+import {
+  Bookmark,
+  BookmarkUrlSchema,
+  UpdateBookmarkSchema,
+} from '../../functions/schemas/bookmark'
+import { useUpdateBookmark } from '../hooks/useUpdateBookmark'
 
 interface BookmarkFormProps {
   bookmark: Bookmark
@@ -13,19 +18,14 @@ export const BookmarkForm = ({ bookmark }: BookmarkFormProps) => {
   const [url, setUrl] = useState(bookmark.url)
   const router = useRouter()
   const { mutate: deleteBookmark, isPending } = useDeleteBookmark()
+  const { mutate: updateBookmark, isPending: isUpdatePending } =
+    useUpdateBookmark()
 
-  const isValidateUrl = () => {
-    try {
-      const newUrl = new URL(url)
-      // protocolには末尾に「:」が含まれるため、'http:' または 'https:' で判定します
-      return newUrl.protocol === 'http:' || newUrl.protocol === 'https:'
-    } catch {
-      // URLとして解析できない場合はfalse
-      return false
-    }
-  }
-
-  const isSubmitDisable = !isValidateUrl()
+  const isSubmitDisable = !BookmarkUrlSchema.safeParse(url).success
+  const isDirty = bookmark.title !== title.trim() || bookmark.url !== url.trim()
+  const canUpdate =
+    isDirty && UpdateBookmarkSchema.safeParse({ title, url }).success
+  const isUpdateDisable = !canUpdate || isUpdatePending
 
   const handleSubmit = (e: React.SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -50,6 +50,14 @@ export const BookmarkForm = ({ bookmark }: BookmarkFormProps) => {
       // バリデーション済みのIDを渡してAPI実行をトリガー
       deleteBookmark(bookmark.id)
     }
+  }
+
+  const handleUpdate = () => {
+    updateBookmark({
+      id: bookmark.id,
+      title,
+      url,
+    })
   }
 
   return (
@@ -90,7 +98,11 @@ export const BookmarkForm = ({ bookmark }: BookmarkFormProps) => {
           </button>
           <button
             type="button"
-            className="border border-slate-300 text-slate-700 bg-indigo-200 rounded px-2 py-1 cursor-pointer hover:text-slate-200 hover:bg-indigo-700 hover:font-semibold"
+            onClick={handleUpdate}
+            disabled={isUpdateDisable}
+            className={`border border-slate-300 text-slate-700 bg-indigo-200 rounded px-2 py-1 cursor-pointer
+            hover:text-slate-200 hover:bg-indigo-700 hover:font-semibold
+            disabled:bg-slate-200 disabled:text-slate-500`}
           >
             {UI_LABELS.ACTIONS.UPDATE}
           </button>

--- a/src/hooks/useUpdateBookmark.test.tsx
+++ b/src/hooks/useUpdateBookmark.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { uuidv7 } from 'uuidv7'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest'
 import { TestBookmarks } from '../../functions/test/fixtures'
 import { useUpdateBookmark } from './useUpdateBookmark'
 import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
@@ -42,6 +42,7 @@ describe('useUpdateBookmark', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    vi.spyOn(window, 'alert').mockImplementation(() => {}) // alertのポップアップを抑制
   })
 
   it('更新APIが200を返したときにキャッシュが更新されること', async () => {
@@ -85,6 +86,11 @@ describe('useUpdateBookmark', () => {
   })
 
   describe('異常系', () => {
+    let alertSpy: Mock<(message?: unknown) => void>
+
+    beforeEach(() => {
+      alertSpy = vi.spyOn(window, 'alert')
+    })
     it.each([
       {
         status: 400,
@@ -135,6 +141,8 @@ describe('useUpdateBookmark', () => {
           expect(result.current.error?.message).toBe(errorText)
 
           expect(invalidateSpy).not.toHaveBeenCalled()
+
+          expect(alertSpy).toHaveBeenCalledWith(errorText)
         })
       },
     )
@@ -163,6 +171,9 @@ describe('useUpdateBookmark', () => {
         expect(result.current.isSuccess).toBe(false)
         expect(result.current.error).toBeInstanceOf(Error)
         expect(result.current.error?.message).toBe(
+          ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK,
+        )
+        expect(alertSpy).toHaveBeenCalledWith(
           ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK,
         )
 

--- a/src/hooks/useUpdateBookmark.ts
+++ b/src/hooks/useUpdateBookmark.ts
@@ -24,8 +24,10 @@ export const useUpdateBookmark = () => {
       return json
     },
     onSuccess: () => {
-      // 1. ブックマーク一覧のキャッシュを古いものとして扱い、再取得を走らせる
       queryClient.invalidateQueries({ queryKey: ['bookmarks'] })
+    },
+    onError: (error) => {
+      alert(error.message)
     },
   })
 }


### PR DESCRIPTION
## 概要
ブックマーク詳細画面の更新ボタンを実装して、その単体テストを作成しました。

## 関連 Issue
Fixes #59 

## 変更内容

### 1. スキーマ型定義の修正
- urlの型定義にhttp://あるいはhttps://で始まるルールを追加した

### 2. 更新ボタンの実装
- 更新ボタンのonClickに設定するhandleUpdateを実装
- タイトルやurlが変更されていない、タイトルやurlが不正な形式など更新ができない場合には更新ボタンを無効にする機能を実装

### 3. 単体テストの追加
- `src/components/BookmarkForm.test.tsx`
  - **正常系**: 正しいパラメータでupdateBookmarkが呼び出されること
  - **更新ボタンの有効と無効**: 更新ボタンが正しく無効と有効になること
- `src/hooks/useUpdateBookmark.test.tsx`
  - **異常系**: ステータスが400, 404, 409, 500の場合、正しいメッセージでダイアログが表示されること

## 動作確認手順
1. `npm test src/components/BookmarkForm.test.tsx` を実行し、すべてのテスト（正常系・異常系）が PASS することを確認
2. `npm test src/hooks/useUpdateBookmark.test.tsx` を実行し、すべてのテスト（正常系・異常系）が PASS することを確認