### PR TITLE
refact: alertを呼び出す関数を作成した

### DIFF
--- a/src/hooks/useDeleteBookmark.test.tsx
+++ b/src/hooks/useDeleteBookmark.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useDeleteBookmark } from './useDeleteBookmark'
@@ -8,10 +8,16 @@ import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
 import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
 
 // 💡 1. Hono RPC クライアントと共通のモック関数の準備
-const { mockDelete, mockNavigate, mockInvalidateQueries } = vi.hoisted(() => ({
+const {
+  mockDelete,
+  mockNavigate,
+  mockInvalidateQueries,
+  mockShowErrorMessage,
+} = vi.hoisted(() => ({
   mockDelete: vi.fn(),
   mockNavigate: vi.fn(),
   mockInvalidateQueries: vi.fn(),
+  mockShowErrorMessage: vi.fn(),
 }))
 
 // Honoクライアントのモック化
@@ -44,6 +50,11 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
   }
 })
 
+// notification モジュールのモック化を追加
+vi.mock('../lib/notification', () => ({
+  showErrorMessage: mockShowErrorMessage,
+}))
+
 // 💡 2. TanStack Query用のラッパーコンポーネントを作成
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -59,11 +70,10 @@ const createWrapper = () => {
 
 describe('useDeleteBookmark', () => {
   const validId = uuidv7()
-  let alertSpy: Mock<(message?: unknown) => void>
 
   beforeEach(() => {
     vi.resetAllMocks()
-    alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {}) // alertのポップアップを抑制
+    vi.spyOn(window, 'alert').mockImplementation(() => {}) // alertのポップアップを抑制
   })
 
   // -------------------------------------------------------------
@@ -95,7 +105,7 @@ describe('useDeleteBookmark', () => {
       // 検証: 画面遷移したか
       expect(mockNavigate).toHaveBeenCalledWith({ to: '/' })
 
-      expect(alertSpy).not.toHaveBeenCalled()
+      expect(mockShowErrorMessage).not.toHaveBeenCalled()
     })
   })
 
@@ -137,7 +147,7 @@ describe('useDeleteBookmark', () => {
         expect(result.current.error).toBeInstanceOf(Error)
         expect(result.current.error?.message).toBe(errorText)
 
-        expect(alertSpy).toHaveBeenCalledWith(errorText)
+        expect(mockShowErrorMessage).toHaveBeenCalledWith(errorText)
         expect(mockNavigate).not.toHaveBeenCalled()
         expect(mockInvalidateQueries).not.toHaveBeenCalled()
       })
@@ -164,7 +174,7 @@ describe('useDeleteBookmark', () => {
       expect(result.current.error?.message).toBe(
         ERROR_MESSAGE.FAILED_DELETE_BOOKMARK,
       )
-      expect(alertSpy).toHaveBeenCalledWith(
+      expect(mockShowErrorMessage).toHaveBeenCalledWith(
         ERROR_MESSAGE.FAILED_DELETE_BOOKMARK,
       )
 

--- a/src/hooks/useDeleteBookmark.ts
+++ b/src/hooks/useDeleteBookmark.ts
@@ -4,6 +4,7 @@ import { hc } from 'hono/client'
 import { useRouter } from '@tanstack/react-router'
 import { AppType } from '../../functions/api/[[route]]'
 import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
+import { showErrorMessage } from '../lib/notification'
 
 // HonoのRPCクライアントを作成（型安全なAPI呼び出し用）
 const client = hc<AppType>('/')
@@ -37,7 +38,7 @@ export const useDeleteBookmark = () => {
       router.navigate({ to: '/' })
     },
     onError: (error) => {
-      alert(error.message)
+      showErrorMessage(error.message)
     },
   })
 }

--- a/src/hooks/useUpdateBookmark.test.tsx
+++ b/src/hooks/useUpdateBookmark.test.tsx
@@ -1,14 +1,15 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { uuidv7 } from 'uuidv7'
-import { beforeEach, describe, expect, it, Mock, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TestBookmarks } from '../../functions/test/fixtures'
 import { useUpdateBookmark } from './useUpdateBookmark'
 import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
 import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
 
-const { mockPatch } = vi.hoisted(() => ({
+const { mockPatch, mockShowErrorMessage } = vi.hoisted(() => ({
   mockPatch: vi.fn(),
+  mockShowErrorMessage: vi.fn(),
 }))
 
 // Honoクライアントのモック化
@@ -22,6 +23,11 @@ vi.mock('hono/client', () => ({
       },
     },
   }),
+}))
+
+// notification モジュールのモック化を追加
+vi.mock('../lib/notification', () => ({
+  showErrorMessage: mockShowErrorMessage,
 }))
 
 const createTestQueryClient = () => {
@@ -86,11 +92,6 @@ describe('useUpdateBookmark', () => {
   })
 
   describe('異常系', () => {
-    let alertSpy: Mock<(message?: unknown) => void>
-
-    beforeEach(() => {
-      alertSpy = vi.spyOn(window, 'alert')
-    })
     it.each([
       {
         status: 400,
@@ -142,7 +143,7 @@ describe('useUpdateBookmark', () => {
 
           expect(invalidateSpy).not.toHaveBeenCalled()
 
-          expect(alertSpy).toHaveBeenCalledWith(errorText)
+          expect(mockShowErrorMessage).toHaveBeenCalledWith(errorText)
         })
       },
     )
@@ -173,7 +174,7 @@ describe('useUpdateBookmark', () => {
         expect(result.current.error?.message).toBe(
           ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK,
         )
-        expect(alertSpy).toHaveBeenCalledWith(
+        expect(mockShowErrorMessage).toHaveBeenCalledWith(
           ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK,
         )
 

--- a/src/hooks/useUpdateBookmark.ts
+++ b/src/hooks/useUpdateBookmark.ts
@@ -3,6 +3,7 @@ import { AppType } from '../../functions/api/[[route]]'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
 import { UpdateBookmarkPayload } from '../../functions/schemas/bookmark'
+import { showErrorMessage } from '../lib/notification'
 
 const client = hc<AppType>('/')
 
@@ -27,7 +28,7 @@ export const useUpdateBookmark = () => {
       queryClient.invalidateQueries({ queryKey: ['bookmarks'] })
     },
     onError: (error) => {
-      alert(error.message)
+      showErrorMessage(error.message)
     },
   })
 }

--- a/src/lib/notification.test.ts
+++ b/src/lib/notification.test.ts
@@ -1,0 +1,17 @@
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest'
+import { showErrorMessage } from './notification'
+import { TEST_ERROR_MESSAGE } from '../../functions/test/fixtures'
+
+describe('メッセージ表示', () => {
+  let alertSpy: Mock<(message?: unknown) => void>
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {}) // alertのポップアップを抑制
+  })
+
+  it('showErrorMessage', () => {
+    showErrorMessage(TEST_ERROR_MESSAGE.API_ERROR)
+    expect(alertSpy).toHaveBeenCalledWith(TEST_ERROR_MESSAGE.API_ERROR)
+  })
+})

--- a/src/lib/notification.ts
+++ b/src/lib/notification.ts
@@ -1,0 +1,11 @@
+/**
+ * ユーザーへエラーメッセージを表示するユーティリティ関数
+ * ※ 将来的にはダイアログ表示からトースト表示・インラインエリア表示へ差し替え予定
+ */
+export const showErrorMessage = (message: string) => {
+  // 現時点：ダイアログ（alertなど）で表示
+  alert(message)
+
+  // 将来の変更例：
+  // notificationStore.addMessage({ type: 'error', text: message })
+}


### PR DESCRIPTION
## 概要

useDeleteBookmarkとuseUpdateBookmarkのそれぞれのカスタムフックで、onErrorの場合にダイアログでメッセージを表示します。
将来的には、ダイアログではなくメッセージのエリアに表示するように切り替えるつもりですが、そのときに切り替えが簡単になるようにダイアログの表示を関数にまとめて、src/lib/notification.tsを作成します。

## 変更内容

- 現段階ではダイアログを呼び出すことでメッセージを表示するshowErrorMessageをsrc/lib/notification.tsを作成しました。
- src/lib/notification.tsをテストするsrc/lib/notification.test.tsを作成しました。
- これまではalertの呼び出しを検証していたテストを、showErrorMessageを呼び出すテストに変更しました。

## 確認方法

- npm run src/lib/notification.tsを実行して、すべてのテストがPASSすること。
- alertの呼び出しの検証をshowErrorMessageの呼び出しの検証に置き換えたテストがPASSすること。

## 関連issue

- closes #67 