### PR TITLE
refact: Mutationカスタムフックのテスト用ヘルパー関数を共通化

### DIFF
--- a/src/hooks/useBookmarks.test.tsx
+++ b/src/hooks/useBookmarks.test.tsx
@@ -1,15 +1,14 @@
 // src/hooks/useBookmarks.test.ts
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useBookmarks, useBookmarkById } from './useBookmarks'
 import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
-import React from 'react'
 import {
   INVALID_STRING,
   mockBookmarksData,
   TestBookmarks,
 } from '../../functions/test/fixtures'
+import { createTestQueryClient } from '../test/test-utils'
 
 // ==========================================
 // 1. Hono クライアントのモック化
@@ -26,44 +25,24 @@ vi.mock('hono/client', () => ({
   }),
 }))
 
-// ==========================================
-// 2. テスト用ラッパーのセットアップ
-// ==========================================
-function createTestQueryClient() {
-  return new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false, // エラー系のテストがリトライで遅くなるのを防ぐ
-        gcTime: 0, // キャッシュがテスト間で残るのを防ぐ
-      },
-    },
-  })
-}
-
-const mockWrapper = () => {
-  const queryClient = createTestQueryClient()
-  const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  )
-  return wrapper
-}
-
 const renderBookmark = () => {
+  const { wrapper } = createTestQueryClient()
   const { result } = renderHook(() => useBookmarks(), {
-    wrapper: mockWrapper(),
+    wrapper,
   })
   return result
 }
 
 const renderBookmarkById = (id: string) => {
+  const { wrapper } = createTestQueryClient()
   const { result } = renderHook(() => useBookmarkById(id), {
-    wrapper: mockWrapper(),
+    wrapper,
   })
   return result
 }
 
 // ==========================================
-// 3. テストケース定義
+// テストケース定義
 // ==========================================
 describe('useBookmarks Hooks', () => {
   beforeEach(() => {

--- a/src/hooks/useDeleteBookmark.test.tsx
+++ b/src/hooks/useDeleteBookmark.test.tsx
@@ -1,22 +1,15 @@
-import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useDeleteBookmark } from './useDeleteBookmark'
 import { uuidv7 } from 'uuidv7'
 import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
 import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
+import { createTestQueryClient, expectMutationError } from '../test/test-utils'
 
 // 💡 1. Hono RPC クライアントと共通のモック関数の準備
-const {
-  mockDelete,
-  mockNavigate,
-  mockInvalidateQueries,
-  mockShowErrorMessage,
-} = vi.hoisted(() => ({
+const { mockDelete, mockNavigate, mockShowErrorMessage } = vi.hoisted(() => ({
   mockDelete: vi.fn(),
   mockNavigate: vi.fn(),
-  mockInvalidateQueries: vi.fn(),
   mockShowErrorMessage: vi.fn(),
 }))
 
@@ -40,32 +33,18 @@ vi.mock('@tanstack/react-router', () => ({
   }),
 }))
 
-vi.mock('@tanstack/react-query', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@tanstack/react-query')>()
-  return {
-    ...actual,
-    useQueryClient: () => ({
-      invalidateQueries: mockInvalidateQueries,
-    }),
-  }
-})
-
 // notification モジュールのモック化を追加
 vi.mock('../lib/notification', () => ({
   showErrorMessage: mockShowErrorMessage,
 }))
 
-// 💡 2. TanStack Query用のラッパーコンポーネントを作成
-const createWrapper = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
+const renderDeleteBookmark = () => {
+  const { wrapper, mockInvalidateQueries } = createTestQueryClient()
+
+  const { result } = renderHook(() => useDeleteBookmark(), {
+    wrapper,
   })
-  return ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  )
+  return { result, mockInvalidateQueries }
 }
 
 describe('useDeleteBookmark', () => {
@@ -86,9 +65,7 @@ describe('useDeleteBookmark', () => {
       ok: true,
     })
 
-    const { result } = renderHook(() => useDeleteBookmark(), {
-      wrapper: createWrapper(),
-    })
+    const { result, mockInvalidateQueries } = renderDeleteBookmark()
 
     // 💡 フックの mutate を実行
     result.current.mutate(validId)
@@ -136,20 +113,18 @@ describe('useDeleteBookmark', () => {
         }),
       })
 
-      const { result } = renderHook(() => useDeleteBookmark(), {
-        wrapper: createWrapper(),
-      })
+      const { result, mockInvalidateQueries } = renderDeleteBookmark()
 
       result.current.mutate(validId)
 
       await waitFor(() => {
-        expect(result.current.isError).toBe(true)
-        expect(result.current.error).toBeInstanceOf(Error)
-        expect(result.current.error?.message).toBe(errorText)
-
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(errorText)
-        expect(mockNavigate).not.toHaveBeenCalled()
-        expect(mockInvalidateQueries).not.toHaveBeenCalled()
+        expectMutationError({
+          result,
+          errorText,
+          mockShowErrorMessage,
+          mockNavigate,
+          mockInvalidateQueries,
+        })
       })
     },
   )
@@ -162,24 +137,19 @@ describe('useDeleteBookmark', () => {
         success: false,
       }),
     })
-    const { result } = renderHook(() => useDeleteBookmark(), {
-      wrapper: createWrapper(),
-    })
+
+    const { result, mockInvalidateQueries } = renderDeleteBookmark()
 
     result.current.mutate(validId)
 
     await waitFor(() => {
-      expect(result.current.isSuccess).toBe(false)
-      expect(result.current.error).toBeInstanceOf(Error)
-      expect(result.current.error?.message).toBe(
-        ERROR_MESSAGE.FAILED_DELETE_BOOKMARK,
-      )
-      expect(mockShowErrorMessage).toHaveBeenCalledWith(
-        ERROR_MESSAGE.FAILED_DELETE_BOOKMARK,
-      )
-
-      expect(mockNavigate).not.toHaveBeenCalled()
-      expect(mockInvalidateQueries).not.toHaveBeenCalled()
+      expectMutationError({
+        result,
+        errorText: ERROR_MESSAGE.FAILED_DELETE_BOOKMARK,
+        mockShowErrorMessage,
+        mockNavigate,
+        mockInvalidateQueries,
+      })
     })
   })
 })

--- a/src/hooks/useDeleteBookmark.test.tsx
+++ b/src/hooks/useDeleteBookmark.test.tsx
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor } from '@testing-library/react'
 import { useDeleteBookmark } from './useDeleteBookmark'
 import { uuidv7 } from 'uuidv7'
 import { ERROR_MESSAGE } from '../../shared/constants/uiMessages'
 import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
-import { createTestQueryClient, expectMutationError } from '../test/test-utils'
+import {
+  createTestQueryClient,
+  expectMutationError,
+  expectMutationSuccess,
+} from '../test/test-utils'
 
 // 💡 1. Hono RPC クライアントと共通のモック関数の準備
 const { mockDelete, mockNavigate, mockShowErrorMessage } = vi.hoisted(() => ({
@@ -72,17 +76,14 @@ describe('useDeleteBookmark', () => {
 
     // 非同期処理（onSuccess）が完了するまで待機して検証
     await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true)
-      // 検証: 正しいIDでAPIが呼ばれたか
-      expect(mockDelete).toHaveBeenCalledWith({ param: { id: validId } })
-      // 検証: キャッシュ更新(invalidate)が走ったか
-      expect(mockInvalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['bookmarks'],
+      expectMutationSuccess({
+        result,
+        mockMutation: mockDelete,
+        payload: { param: { id: validId } },
+        mockInvalidateQueries,
+        navigate: { mockNavigate, path: '/' },
+        mockShowErrorMessage,
       })
-      // 検証: 画面遷移したか
-      expect(mockNavigate).toHaveBeenCalledWith({ to: '/' })
-
-      expect(mockShowErrorMessage).not.toHaveBeenCalled()
     })
   })
 

--- a/src/hooks/useUpdateBookmark.test.tsx
+++ b/src/hooks/useUpdateBookmark.test.tsx
@@ -1,11 +1,15 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { uuidv7 } from 'uuidv7'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, it, vi } from 'vitest'
 import { TestBookmarks } from '../../functions/test/fixtures'
 import { useUpdateBookmark } from './useUpdateBookmark'
 import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
 import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
-import { createTestQueryClient, expectMutationError } from '../test/test-utils'
+import {
+  createTestQueryClient,
+  expectMutationError,
+  expectMutationSuccess,
+} from '../test/test-utils'
 
 const { mockPatch, mockShowErrorMessage } = vi.hoisted(() => ({
   mockPatch: vi.fn(),
@@ -64,21 +68,19 @@ describe('useUpdateBookmark', () => {
     result.current.mutate(updatedPayload)
 
     await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true)
-
-      expect(mockPatch).toHaveBeenCalledWith({
-        param: { id: updatedPayload.id },
-        json: {
-          title: updatedPayload.title,
-          url: updatedPayload.url,
+      expectMutationSuccess({
+        result,
+        mockMutation: mockPatch,
+        payload: {
+          param: { id: updatedPayload.id },
+          json: {
+            title: updatedPayload.title,
+            url: updatedPayload.url,
+          },
         },
+        mockInvalidateQueries,
+        mockShowErrorMessage,
       })
-
-      expect(mockInvalidateQueries).toHaveBeenCalledWith({
-        queryKey: ['bookmarks'],
-      })
-
-      expect(mockShowErrorMessage).not.toHaveBeenCalled()
     })
   })
 

--- a/src/hooks/useUpdateBookmark.test.tsx
+++ b/src/hooks/useUpdateBookmark.test.tsx
@@ -1,4 +1,3 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderHook, waitFor } from '@testing-library/react'
 import { uuidv7 } from 'uuidv7'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -6,6 +5,7 @@ import { TestBookmarks } from '../../functions/test/fixtures'
 import { useUpdateBookmark } from './useUpdateBookmark'
 import { ERROR_MESSAGE, UI_MESSAGES } from '../../shared/constants/uiMessages'
 import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
+import { createTestQueryClient, expectMutationError } from '../test/test-utils'
 
 const { mockPatch, mockShowErrorMessage } = vi.hoisted(() => ({
   mockPatch: vi.fn(),
@@ -30,21 +30,19 @@ vi.mock('../lib/notification', () => ({
   showErrorMessage: mockShowErrorMessage,
 }))
 
-const createTestQueryClient = () => {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: { retry: false },
-      mutations: { retry: false },
-    },
-  })
-  const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-  )
-  return { queryClient, wrapper }
+const renderUpdateBookmark = () => {
+  const { wrapper, mockInvalidateQueries } = createTestQueryClient()
+  const { result } = renderHook(() => useUpdateBookmark(), { wrapper })
+  return { result, mockInvalidateQueries }
 }
 
 describe('useUpdateBookmark', () => {
   const validId = uuidv7()
+  const updatedPayload = {
+    id: validId,
+    title: TestBookmarks[0].title,
+    url: TestBookmarks[0].url,
+  }
 
   beforeEach(() => {
     vi.resetAllMocks()
@@ -52,11 +50,6 @@ describe('useUpdateBookmark', () => {
   })
 
   it('更新APIが200を返したときにキャッシュが更新されること', async () => {
-    const updatedPayload = {
-      id: validId,
-      title: TestBookmarks[0].title,
-      url: TestBookmarks[0].url,
-    }
     mockPatch.mockResolvedValueOnce({
       status: 200,
       ok: true,
@@ -66,11 +59,7 @@ describe('useUpdateBookmark', () => {
       }),
     })
 
-    const { queryClient, wrapper } = createTestQueryClient()
-    // 💡 本物の queryClient の invalidateQueries を spyOn する
-    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
-
-    const { result } = renderHook(() => useUpdateBookmark(), { wrapper })
+    const { result, mockInvalidateQueries } = renderUpdateBookmark()
 
     result.current.mutate(updatedPayload)
 
@@ -78,16 +67,18 @@ describe('useUpdateBookmark', () => {
       expect(result.current.isSuccess).toBe(true)
 
       expect(mockPatch).toHaveBeenCalledWith({
-        param: { id: validId },
+        param: { id: updatedPayload.id },
         json: {
           title: updatedPayload.title,
           url: updatedPayload.url,
         },
       })
 
-      expect(invalidateSpy).toHaveBeenCalledWith({
+      expect(mockInvalidateQueries).toHaveBeenCalledWith({
         queryKey: ['bookmarks'],
       })
+
+      expect(mockShowErrorMessage).not.toHaveBeenCalled()
     })
   })
 
@@ -124,26 +115,18 @@ describe('useUpdateBookmark', () => {
             error: errorText,
           }),
         })
-        const updatedPayload = {
-          id: validId,
-          title: TestBookmarks[0].title,
-          url: TestBookmarks[0].url,
-        }
-        const { queryClient, wrapper } = createTestQueryClient()
-        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
-        const { result } = renderHook(() => useUpdateBookmark(), { wrapper })
+        const { result, mockInvalidateQueries } = renderUpdateBookmark()
 
         result.current.mutate(updatedPayload)
 
         await waitFor(() => {
-          expect(result.current.isSuccess).toBe(false)
-          expect(result.current.error).toBeInstanceOf(Error)
-          expect(result.current.error?.message).toBe(errorText)
-
-          expect(invalidateSpy).not.toHaveBeenCalled()
-
-          expect(mockShowErrorMessage).toHaveBeenCalledWith(errorText)
+          expectMutationError({
+            result,
+            errorText,
+            mockShowErrorMessage,
+            mockInvalidateQueries,
+          })
         })
       },
     )
@@ -156,29 +139,18 @@ describe('useUpdateBookmark', () => {
           success: false,
         }),
       })
-      const updatedPayload = {
-        id: validId,
-        title: TestBookmarks[0].title,
-        url: TestBookmarks[0].url,
-      }
-      const { queryClient, wrapper } = createTestQueryClient()
-      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
 
-      const { result } = renderHook(() => useUpdateBookmark(), { wrapper })
+      const { result, mockInvalidateQueries } = renderUpdateBookmark()
 
       result.current.mutate(updatedPayload)
 
       await waitFor(() => {
-        expect(result.current.isSuccess).toBe(false)
-        expect(result.current.error).toBeInstanceOf(Error)
-        expect(result.current.error?.message).toBe(
-          ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK,
-        )
-        expect(mockShowErrorMessage).toHaveBeenCalledWith(
-          ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK,
-        )
-
-        expect(invalidateSpy).not.toHaveBeenCalled()
+        expectMutationError({
+          result,
+          errorText: ERROR_MESSAGE.FAILED_UPDATE_BOOKMARK,
+          mockShowErrorMessage,
+          mockInvalidateQueries,
+        })
       })
     })
   })

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -1,0 +1,74 @@
+import { expect, Mock, vi } from 'vitest'
+import {
+  QueryClient,
+  QueryClientProvider,
+  UseMutationResult,
+} from '@tanstack/react-query'
+import { UpdateBookmarkPayload } from '../../functions/schemas/bookmark'
+
+type ErrorResultType =
+  | {
+      current: UseMutationResult<
+        | { success: boolean; error: string }
+        | {
+            readonly success: true
+            readonly data: { id: string; title: string; url: string }
+          },
+        Error,
+        UpdateBookmarkPayload,
+        unknown
+      >
+    }
+  | { current: UseMutationResult<void, Error, string, unknown> }
+
+interface ExpectMutationErrorOptions {
+  result: ErrorResultType
+  errorText: string
+  mockShowErrorMessage: Mock
+  mockNavigate?: Mock
+  mockInvalidateQueries?: Mock
+}
+
+/**
+ * Mutationフックでエラーが発生した際の共通アサーションヘルパー
+ */
+export const expectMutationError = ({
+  result,
+  errorText,
+  mockShowErrorMessage,
+  mockNavigate,
+  mockInvalidateQueries,
+}: ExpectMutationErrorOptions) => {
+  // 1. フックのエラー状態の検証
+  expect(result.current.isError).toBe(true)
+  expect(result.current.error).toBeInstanceOf(Error)
+  expect(result.current.error?.message).toBe(errorText)
+
+  // 2. サイドエフェクトの検証
+  expect(mockShowErrorMessage).toHaveBeenCalledWith(errorText)
+
+  if (mockNavigate) {
+    expect(mockNavigate).not.toHaveBeenCalled()
+  }
+  if (mockInvalidateQueries) {
+    expect(mockInvalidateQueries).not.toHaveBeenCalled()
+  }
+}
+
+export const createTestQueryClient = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0, // キャッシュがテスト間で残るのを防ぐ
+      },
+      mutations: { retry: false },
+    },
+  })
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  const mockInvalidateQueries = vi.spyOn(queryClient, 'invalidateQueries')
+
+  return { wrapper, mockInvalidateQueries }
+}

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -6,23 +6,59 @@ import {
 } from '@tanstack/react-query'
 import { UpdateBookmarkPayload } from '../../functions/schemas/bookmark'
 
-type ErrorResultType =
-  | {
-      current: UseMutationResult<
-        | { success: boolean; error: string }
-        | {
-            readonly success: true
-            readonly data: { id: string; title: string; url: string }
-          },
-        Error,
-        UpdateBookmarkPayload,
-        unknown
-      >
-    }
-  | { current: UseMutationResult<void, Error, string, unknown> }
+type ResultDelete = { current: UseMutationResult<void, Error, string, unknown> }
+type ResultUpdate = {
+  current: UseMutationResult<
+    | { success: boolean; error: string }
+    | {
+        readonly success: true
+        readonly data: { id: string; title: string; url: string }
+      },
+    Error,
+    UpdateBookmarkPayload,
+    unknown
+  >
+}
+
+type ResultType = ResultDelete | ResultUpdate
+
+interface ExpectMutationSuccessOptions {
+  result: ResultType
+  mockMutation: Mock
+  payload: { param: { id: string }; json?: { title: string; url: string } }
+  navigate?: { mockNavigate: Mock; path: string }
+  mockInvalidateQueries?: Mock
+  mockShowErrorMessage?: Mock
+}
+
+export const expectMutationSuccess = ({
+  result,
+  mockMutation,
+  payload,
+  navigate,
+  mockInvalidateQueries,
+  mockShowErrorMessage,
+}: ExpectMutationSuccessOptions) => {
+  expect(result.current.isSuccess).toBe(true)
+  // // 検証: 正しいIDでAPIが呼ばれたか
+  expect(mockMutation).toHaveBeenCalledWith(payload)
+  // // 検証: キャッシュ更新(invalidate)が走ったか
+  if (mockInvalidateQueries) {
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['bookmarks'],
+    })
+  }
+  // // 検証: 画面遷移したか
+  if (navigate) {
+    expect(navigate.mockNavigate).toHaveBeenCalledWith({ to: navigate.path })
+  }
+  if (mockShowErrorMessage) {
+    expect(mockShowErrorMessage).not.toHaveBeenCalled()
+  }
+}
 
 interface ExpectMutationErrorOptions {
-  result: ErrorResultType
+  result: ResultType
   errorText: string
   mockShowErrorMessage: Mock
   mockNavigate?: Mock

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -1,26 +1,13 @@
 import { expect, Mock, vi } from 'vitest'
-import {
-  QueryClient,
-  QueryClientProvider,
-  UseMutationResult,
-} from '@tanstack/react-query'
-import { UpdateBookmarkPayload } from '../../functions/schemas/bookmark'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-type ResultDelete = { current: UseMutationResult<void, Error, string, unknown> }
-type ResultUpdate = {
-  current: UseMutationResult<
-    | { success: boolean; error: string }
-    | {
-        readonly success: true
-        readonly data: { id: string; title: string; url: string }
-      },
-    Error,
-    UpdateBookmarkPayload,
-    unknown
-  >
+type ResultType = {
+  current: {
+    isSuccess: boolean
+    isError: boolean
+    error: Error | null
+  }
 }
-
-type ResultType = ResultDelete | ResultUpdate
 
 interface ExpectMutationSuccessOptions {
   result: ResultType

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -60,7 +60,7 @@ export default defineConfig({
       exclude: [
         '**/*.test.{ts,tsx}',
         'src/main.tsx',
-        'src/test/setup.ts',
+        'src/test/**.{ts,tsx}',
         'src/routeTree.gen.ts',
         'functions/schemas/**',
         'functions/constants/**',


### PR DESCRIPTION
## 概要
`useDeleteBookmark` や `useUpdateBookmark` などのカスタムフックのテストコード内で重複していた `QueryClient` / `wrapper` の生成およびMutation の共通アサーション（成功・エラー処理の検証）を`src/test/test-utils.tsx` へ共通化・リファクタリングしました。

## 変更内容
- **`src/test/test-utils.tsx` の作成**:
  - `createTestQueryClient`: テストごとの独立した `QueryClient` と `wrapper` を生成
  - `expectMutationSuccess`: Mutation 成功時の共通アサーション（API呼び出し、キャッシュ無効化、画面遷移等の検証）
  - `expectMutationError`: Mutation 失敗時の共通アサーション（エラー状態、メッセージ通知等の検証）
- **既存のテストコードのリファクタリング**:
  - `useBookmarks.test.tsx`, `useDeleteBookmark.test.tsx`, `useUpdateBookmark.test.tsx` で共通ヘルパーを利用するように変更
- **カバレッジ設定の更新**:
  - `vite.config.ts` の `coverage.exclude` に `src/test/**` を追加し、テストヘルパーがカバレッジ率に影響しないよう修正

## 変更理由・背景
- 各テストファイルで `QueryClient` の作成やエラー時の `expect` が重複して記述されており、保守性や可読性に課題がありました。
- 今後新しいカスタムフックや Mutation のテストを追加する際にも、同じ検証ロジックを再利用できるようにするため。

## 動作確認・テスト結果
- `npm run test` および `npm run test:coverage` を実行し、すべてのユニットテストがパスすることを確認済みです。

## 関連issue

- #69 