### PR TITLE
test: BookmarkForm のテストを機能別ファイルへ分割・リファクタリング

### DIFF
--- a/src/components/BookmarkForm.back-bookmark.test.tsx
+++ b/src/components/BookmarkForm.back-bookmark.test.tsx
@@ -1,0 +1,62 @@
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TestBookmarks } from '../../functions/test/fixtures'
+import { render } from '@testing-library/react'
+import { BookmarkForm } from './BookmarkForm'
+import { clickButton } from '../test/test-utils'
+import { UI_LABELS } from '../../shared/constants/uiMessages'
+
+const mockBack = vi.fn()
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({
+    history: {
+      back: mockBack,
+    },
+    navigate: mockNavigate,
+  }),
+}))
+
+vi.mock('../hooks/useDeleteBookmark', () => ({
+  useDeleteBookmark: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../hooks/useUpdateBookmark', () => ({
+  useUpdateBookmark: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+describe('戻るボタンの動作', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  const testBookmark = TestBookmarks[0]
+
+  it('戻るボタンをクリックしたときに、router.history.back が呼び出されること', async () => {
+    const user = userEvent.setup()
+
+    render(<BookmarkForm bookmark={testBookmark} />)
+
+    await clickButton(user, UI_LABELS.ACTIONS.BACK)
+
+    // 💡 3. モック関数が1回呼び出されたかを検証
+    expect(mockBack).not.toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledTimes(1)
+  })
+
+  it('履歴が存在する場合（window.history.length > 1）、router.history.back が呼び出されること', async () => {
+    const user = userEvent.setup()
+
+    // 💡 1. window.history.length が常に「2」を返すように偽装する
+    vi.spyOn(window.history, 'length', 'get').mockReturnValue(2)
+
+    render(<BookmarkForm bookmark={testBookmark} />)
+
+    await clickButton(user, UI_LABELS.ACTIONS.BACK)
+
+    // 💡 2. router.history.back が呼ばれ、navigate は呼ばれていないことを検証
+    expect(mockBack).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/BookmarkForm.delete-bookmark.test.tsx
+++ b/src/components/BookmarkForm.delete-bookmark.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TestBookmarks } from '../../functions/test/fixtures'
+import userEvent from '@testing-library/user-event'
+import { UI_LABELS, UI_MESSAGES } from '../../shared/constants/uiMessages'
+import { clickButton } from '../test/test-utils'
+import { BookmarkForm } from './BookmarkForm'
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({ history: { back: vi.fn() }, navigate: vi.fn() }),
+}))
+
+const mockDelete = vi.fn()
+let mockIsPending = false
+
+vi.mock('../hooks/useDeleteBookmark', () => ({
+  useDeleteBookmark: () => ({
+    mutate: mockDelete,
+    isPending: mockIsPending,
+  }),
+}))
+
+vi.mock('../hooks/useUpdateBookmark', () => ({
+  useUpdateBookmark: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+describe('削除ボタンの動作', () => {
+  const testBookmark = TestBookmarks[0]
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockIsPending = false // ローディング状態をデフォルトに戻す
+  })
+
+  // -------------------------------------------------------------
+  // ケース1: 確認ダイアログで「OK」を選んだとき
+  // -------------------------------------------------------------
+  it('削除ボタンを押し、ダイアログでOKを押した場合、deleteBookmarkが実行されること', async () => {
+    const user = userEvent.setup()
+
+    // 💡 window.confirm が呼び出されたら「true（OK）」を返すように偽装
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    render(<BookmarkForm bookmark={testBookmark} />)
+
+    await clickButton(user, UI_LABELS.ACTIONS.DELETE)
+
+    // 検証: 確認ダイアログが正しい文言で開かれたか
+    expect(confirmSpy).toHaveBeenCalledWith(
+      UI_MESSAGES.BOOKMARKS.CONFIRM_DELETE(testBookmark.title),
+    )
+    // 検証: フックの削除関数が、正しいIDを引数にして呼ばれたか
+    expect(mockDelete).toHaveBeenCalledWith(testBookmark.id)
+  })
+
+  // -------------------------------------------------------------
+  // ケース2: 確認ダイアログで「キャンセル」を選んだとき
+  // -------------------------------------------------------------
+  it('削除ボタンを押し、ダイアログでキャンセルを押した場合、削除処理が中断されること', async () => {
+    const user = userEvent.setup()
+
+    // 💡 window.confirm が呼び出されたら「false（キャンセル）」を返すように偽装
+    vi.spyOn(window, 'confirm').mockReturnValue(false)
+
+    render(<BookmarkForm bookmark={testBookmark} />)
+
+    await clickButton(user, UI_LABELS.ACTIONS.DELETE)
+
+    // 検証: 削除関数が呼び出されていないこと
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------
+  // ケース3: 削除通信中（isPending = true）のとき
+  // -------------------------------------------------------------
+  it('削除処理中（isPendingがtrue）の場合、ボタンが非活性になること', () => {
+    // 💡 テストケース実行前にローディング状態を再現
+    mockIsPending = true
+
+    render(<BookmarkForm bookmark={testBookmark} />)
+
+    const deleteButton = screen.getByRole('button', {
+      name: UI_LABELS.ACTIONS.DELETE,
+    })
+
+    // 検証: ボタンが disabled（非活性）になっていること
+    expect(deleteButton).toBeDisabled()
+  })
+})

--- a/src/components/BookmarkForm.open-bookmark.test.tsx
+++ b/src/components/BookmarkForm.open-bookmark.test.tsx
@@ -1,0 +1,75 @@
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { INVALID_STRING, TestBookmarks } from '../../functions/test/fixtures'
+import { render } from '@testing-library/react'
+import { BookmarkForm } from './BookmarkForm'
+import { clickButton, inputText } from '../test/test-utils'
+import { UI_LABELS } from '../../shared/constants/uiMessages'
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({ history: { back: vi.fn() }, navigate: vi.fn() }),
+}))
+
+vi.mock('../hooks/useDeleteBookmark', () => ({
+  useDeleteBookmark: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('../hooks/useUpdateBookmark', () => ({
+  useUpdateBookmark: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+describe('開くボタンの動作', () => {
+  it('開くボタンをクリックしたときに、正しいURLと属性で window.open が呼び出されること', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+    const user = userEvent.setup()
+    const targetBookmark = TestBookmarks[0]
+
+    render(<BookmarkForm key={targetBookmark.id} bookmark={targetBookmark} />)
+
+    await clickButton(user, UI_LABELS.ACTIONS.OPEN)
+
+    expect(openSpy).toHaveBeenCalledTimes(1) // 1回だけ呼ばれたか
+    expect(openSpy).toHaveBeenCalledWith(
+      targetBookmark.url,
+      '_blank', // 第2引数：ターゲット
+      'noreferrer', // 第3引数：機能文字列
+    )
+
+    openSpy.mockRestore()
+  })
+
+  it('URLを変更した場合には、変更したURLでwindow.open が呼び出されること', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+    const user = userEvent.setup()
+    const targetBookmark = TestBookmarks[0]
+    const inputUrl = TestBookmarks[1].url
+
+    render(<BookmarkForm key={targetBookmark.id} bookmark={targetBookmark} />)
+
+    await inputText(user, UI_LABELS.FIELDS.URL, inputUrl)
+    await clickButton(user, UI_LABELS.ACTIONS.OPEN)
+
+    expect(openSpy).toHaveBeenCalledTimes(1) // 1回だけ呼ばれたか
+    expect(openSpy).toHaveBeenCalledWith(
+      inputUrl,
+      '_blank', // 第2引数：ターゲット
+      'noreferrer', // 第3引数：機能文字列
+    )
+
+    openSpy.mockRestore()
+  })
+
+  it('URLのテキストボックスに不正な文字列が入力されている場合には開くボタンは無効となること', async () => {
+    const user = userEvent.setup()
+    const targetBookmark = TestBookmarks[0]
+
+    render(<BookmarkForm key={targetBookmark.id} bookmark={targetBookmark} />)
+
+    await inputText(user, UI_LABELS.FIELDS.URL, INVALID_STRING.URL)
+    const openButton = await clickButton(user, UI_LABELS.ACTIONS.OPEN)
+
+    expect(openButton).toBeDisabled()
+  })
+})

--- a/src/components/BookmarkForm.test.tsx
+++ b/src/components/BookmarkForm.test.tsx
@@ -53,41 +53,6 @@ describe('BookmarkForm', () => {
     expect(urlElement).toHaveValue(targetBookmark.url)
   })
 
-  describe('戻るボタンの動作', () => {
-    beforeEach(() => {
-      vi.resetAllMocks()
-    })
-
-    const testBookmark = TestBookmarks[0]
-
-    it('戻るボタンをクリックしたときに、router.history.back が呼び出されること', async () => {
-      const user = userEvent.setup()
-
-      render(<BookmarkForm bookmark={testBookmark} />)
-
-      await clickButton(user, UI_LABELS.ACTIONS.BACK)
-
-      // 💡 3. モック関数が1回呼び出されたかを検証
-      expect(mockBack).not.toHaveBeenCalled()
-      expect(mockNavigate).toHaveBeenCalledTimes(1)
-    })
-
-    it('履歴が存在する場合（window.history.length > 1）、router.history.back が呼び出されること', async () => {
-      const user = userEvent.setup()
-
-      // 💡 1. window.history.length が常に「2」を返すように偽装する
-      vi.spyOn(window.history, 'length', 'get').mockReturnValue(2)
-
-      render(<BookmarkForm bookmark={testBookmark} />)
-
-      await clickButton(user, UI_LABELS.ACTIONS.BACK)
-
-      // 💡 2. router.history.back が呼ばれ、navigate は呼ばれていないことを検証
-      expect(mockBack).toHaveBeenCalledTimes(1)
-      expect(mockNavigate).not.toHaveBeenCalled()
-    })
-  })
-
   describe('BookmarkDetail - handleDelete', () => {
     const testBookmark = TestBookmarks[0]
 

--- a/src/components/BookmarkForm.test.tsx
+++ b/src/components/BookmarkForm.test.tsx
@@ -53,62 +53,6 @@ describe('BookmarkForm', () => {
     expect(urlElement).toHaveValue(targetBookmark.url)
   })
 
-  describe('開くボタンの動作', () => {
-    it('開くボタンをクリックしたときに、正しいURLと属性で window.open が呼び出されること', async () => {
-      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
-
-      const user = userEvent.setup()
-      const targetBookmark = TestBookmarks[0]
-
-      render(<BookmarkForm key={targetBookmark.id} bookmark={targetBookmark} />)
-
-      await clickButton(user, UI_LABELS.ACTIONS.OPEN)
-
-      expect(openSpy).toHaveBeenCalledTimes(1) // 1回だけ呼ばれたか
-      expect(openSpy).toHaveBeenCalledWith(
-        targetBookmark.url,
-        '_blank', // 第2引数：ターゲット
-        'noreferrer', // 第3引数：機能文字列
-      )
-
-      openSpy.mockRestore()
-    })
-
-    it('URLを変更した場合には、変更したURLでwindow.open が呼び出されること', async () => {
-      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
-
-      const user = userEvent.setup()
-      const targetBookmark = TestBookmarks[0]
-      const inputUrl = TestBookmarks[1].url
-
-      render(<BookmarkForm key={targetBookmark.id} bookmark={targetBookmark} />)
-
-      await inputText(user, UI_LABELS.FIELDS.URL, inputUrl)
-      await clickButton(user, UI_LABELS.ACTIONS.OPEN)
-
-      expect(openSpy).toHaveBeenCalledTimes(1) // 1回だけ呼ばれたか
-      expect(openSpy).toHaveBeenCalledWith(
-        inputUrl,
-        '_blank', // 第2引数：ターゲット
-        'noreferrer', // 第3引数：機能文字列
-      )
-
-      openSpy.mockRestore()
-    })
-
-    it('URLのテキストボックスに不正な文字列が入力されている場合には開くボタンは無効となること', async () => {
-      const user = userEvent.setup()
-      const targetBookmark = TestBookmarks[0]
-
-      render(<BookmarkForm key={targetBookmark.id} bookmark={targetBookmark} />)
-
-      await inputText(user, UI_LABELS.FIELDS.URL, INVALID_STRING.URL)
-      const openButton = await clickButton(user, UI_LABELS.ACTIONS.OPEN)
-
-      expect(openButton).toBeDisabled()
-    })
-  })
-
   describe('戻るボタンの動作', () => {
     beforeEach(() => {
       vi.resetAllMocks()

--- a/src/components/BookmarkForm.test.tsx
+++ b/src/components/BookmarkForm.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { BookmarkForm } from './BookmarkForm'
 import { INVALID_STRING, TestBookmarks } from '../../functions/test/fixtures'
-import { UI_LABELS, UI_MESSAGES } from '../../shared/constants/uiMessages'
+import { UI_LABELS } from '../../shared/constants/uiMessages'
 import { userEvent } from '@testing-library/user-event'
-import { clickButton, inputText } from '../test/test-utils'
+import { inputText } from '../test/test-utils'
 
 const mockBack = vi.fn()
 const mockNavigate = vi.fn()
@@ -51,70 +51,6 @@ describe('BookmarkForm', () => {
       name: UI_LABELS.FIELDS.URL,
     })
     expect(urlElement).toHaveValue(targetBookmark.url)
-  })
-
-  describe('BookmarkDetail - handleDelete', () => {
-    const testBookmark = TestBookmarks[0]
-
-    beforeEach(() => {
-      vi.resetAllMocks()
-      mockIsPending = false // ローディング状態をデフォルトに戻す
-    })
-
-    // -------------------------------------------------------------
-    // ケース1: 確認ダイアログで「OK」を選んだとき
-    // -------------------------------------------------------------
-    it('削除ボタンを押し、ダイアログでOKを押した場合、deleteBookmarkが実行されること', async () => {
-      const user = userEvent.setup()
-
-      // 💡 window.confirm が呼び出されたら「true（OK）」を返すように偽装
-      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
-
-      render(<BookmarkForm bookmark={testBookmark} />)
-
-      await clickButton(user, UI_LABELS.ACTIONS.DELETE)
-
-      // 検証: 確認ダイアログが正しい文言で開かれたか
-      expect(confirmSpy).toHaveBeenCalledWith(
-        UI_MESSAGES.BOOKMARKS.CONFIRM_DELETE(testBookmark.title),
-      )
-      // 検証: フックの削除関数が、正しいIDを引数にして呼ばれたか
-      expect(mockMutate).toHaveBeenCalledWith(testBookmark.id)
-    })
-
-    // -------------------------------------------------------------
-    // ケース2: 確認ダイアログで「キャンセル」を選んだとき
-    // -------------------------------------------------------------
-    it('削除ボタンを押し、ダイアログでキャンセルを押した場合、削除処理が中断されること', async () => {
-      const user = userEvent.setup()
-
-      // 💡 window.confirm が呼び出されたら「false（キャンセル）」を返すように偽装
-      vi.spyOn(window, 'confirm').mockReturnValue(false)
-
-      render(<BookmarkForm bookmark={testBookmark} />)
-
-      await clickButton(user, UI_LABELS.ACTIONS.DELETE)
-
-      // 検証: 削除関数が呼び出されていないこと
-      expect(mockMutate).not.toHaveBeenCalled()
-    })
-
-    // -------------------------------------------------------------
-    // ケース3: 削除通信中（isPending = true）のとき
-    // -------------------------------------------------------------
-    it('削除処理中（isPendingがtrue）の場合、ボタンが非活性になること', () => {
-      // 💡 テストケース実行前にローディング状態を再現
-      mockIsPending = true
-
-      render(<BookmarkForm bookmark={testBookmark} />)
-
-      const deleteButton = screen.getByRole('button', {
-        name: UI_LABELS.ACTIONS.DELETE,
-      })
-
-      // 検証: ボタンが disabled（非活性）になっていること
-      expect(deleteButton).toBeDisabled()
-    })
   })
 
   describe('更新ボタンの動作', () => {

--- a/src/components/BookmarkForm.test.tsx
+++ b/src/components/BookmarkForm.test.tsx
@@ -1,41 +1,19 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import { BookmarkForm } from './BookmarkForm'
-import { INVALID_STRING, TestBookmarks } from '../../functions/test/fixtures'
+import { TestBookmarks } from '../../functions/test/fixtures'
 import { UI_LABELS } from '../../shared/constants/uiMessages'
-import { userEvent } from '@testing-library/user-event'
-import { inputText } from '../test/test-utils'
-
-const mockBack = vi.fn()
-const mockNavigate = vi.fn()
 
 vi.mock('@tanstack/react-router', () => ({
-  useRouter: () => ({
-    history: {
-      back: mockBack,
-    },
-    navigate: mockNavigate,
-  }),
+  useRouter: () => ({ history: { back: vi.fn() }, navigate: vi.fn() }),
 }))
-
-const mockMutate = vi.fn()
-let mockIsPending = false
 
 vi.mock('../hooks/useDeleteBookmark', () => ({
-  useDeleteBookmark: () => ({
-    mutate: mockMutate,
-    isPending: mockIsPending,
-  }),
+  useDeleteBookmark: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
-const mockUpdate = vi.fn()
-const mockIsUpdatePending = false
-
 vi.mock('../hooks/useUpdateBookmark', () => ({
-  useUpdateBookmark: () => ({
-    mutate: mockUpdate,
-    isPending: mockIsUpdatePending,
-  }),
+  useUpdateBookmark: () => ({ mutate: vi.fn(), isPending: false }),
 }))
 
 describe('BookmarkForm', () => {
@@ -51,65 +29,5 @@ describe('BookmarkForm', () => {
       name: UI_LABELS.FIELDS.URL,
     })
     expect(urlElement).toHaveValue(targetBookmark.url)
-  })
-
-  describe('更新ボタンの動作', () => {
-    const testBookmark = TestBookmarks[0]
-
-    const testData: { name: string; title?: string; url?: string }[] = [
-      { name: 'タイトルもurlも変更しなければ' },
-      { name: 'タイトルが不正ならば', title: '' },
-      { name: 'urlが不正ならば', url: INVALID_STRING.URL },
-      { name: 'urlがftpならば', url: INVALID_STRING.FTP },
-    ]
-
-    it.each(testData)(
-      `$name更新ボタンが無効であること`,
-      async ({ title, url }) => {
-        const user = userEvent.setup()
-
-        render(<BookmarkForm bookmark={testBookmark} />)
-
-        await inputText(user, UI_LABELS.FIELDS.TITLE, title)
-        await inputText(user, UI_LABELS.FIELDS.URL, url)
-
-        const updateButton = await screen.findByRole('button', {
-          name: UI_LABELS.ACTIONS.UPDATE,
-        })
-        expect(updateButton).toBeDisabled()
-      },
-    )
-
-    it('タイトルを正しく変更したら更新ボタンが有効になること', async () => {
-      const user = userEvent.setup()
-
-      render(<BookmarkForm bookmark={testBookmark} />)
-
-      await inputText(user, UI_LABELS.FIELDS.TITLE, TestBookmarks[1].title)
-
-      const updateButton = await screen.findByRole('button', {
-        name: UI_LABELS.ACTIONS.UPDATE,
-      })
-      expect(updateButton).toBeEnabled()
-    })
-
-    it('更新ボタンをクリックしたらupdateBookmark()が呼び出されること', async () => {
-      const user = userEvent.setup()
-      render(<BookmarkForm bookmark={testBookmark} />)
-
-      await inputText(user, UI_LABELS.FIELDS.TITLE, TestBookmarks[1].title)
-
-      const updateButton = await screen.findByRole('button', {
-        name: UI_LABELS.ACTIONS.UPDATE,
-      })
-      await user.click(updateButton)
-
-      // 検証: フックの削除関数が、正しいIDを引数にして呼ばれたか
-      expect(mockUpdate).toHaveBeenCalledWith({
-        id: testBookmark.id,
-        title: TestBookmarks[1].title,
-        url: testBookmark.url,
-      })
-    })
   })
 })

--- a/src/components/BookmarkForm.update-bookmark.test.tsx
+++ b/src/components/BookmarkForm.update-bookmark.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import { INVALID_STRING, TestBookmarks } from '../../functions/test/fixtures'
+import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/react'
+import { BookmarkForm } from './BookmarkForm'
+import { inputText } from '../test/test-utils'
+import { UI_LABELS } from '../../shared/constants/uiMessages'
+
+vi.mock('@tanstack/react-router', () => ({
+  useRouter: () => ({ history: { back: vi.fn() }, navigate: vi.fn() }),
+}))
+
+vi.mock('../hooks/useDeleteBookmark', () => ({
+  useDeleteBookmark: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+const mockUpdate = vi.fn()
+const mockIsUpdatePending = false
+
+vi.mock('../hooks/useUpdateBookmark', () => ({
+  useUpdateBookmark: () => ({
+    mutate: mockUpdate,
+    isPending: mockIsUpdatePending,
+  }),
+}))
+
+describe('更新ボタンの動作', () => {
+  const testBookmark = TestBookmarks[0]
+
+  const testData: { name: string; title?: string; url?: string }[] = [
+    { name: 'タイトルもurlも変更しなければ' },
+    { name: 'タイトルが不正ならば', title: '' },
+    { name: 'urlが不正ならば', url: INVALID_STRING.URL },
+    { name: 'urlがftpならば', url: INVALID_STRING.FTP },
+  ]
+
+  it.each(testData)(
+    `$name更新ボタンが無効であること`,
+    async ({ title, url }) => {
+      const user = userEvent.setup()
+
+      render(<BookmarkForm bookmark={testBookmark} />)
+
+      await inputText(user, UI_LABELS.FIELDS.TITLE, title)
+      await inputText(user, UI_LABELS.FIELDS.URL, url)
+
+      const updateButton = await screen.findByRole('button', {
+        name: UI_LABELS.ACTIONS.UPDATE,
+      })
+      expect(updateButton).toBeDisabled()
+    },
+  )
+
+  it('タイトルを正しく変更したら更新ボタンが有効になること', async () => {
+    const user = userEvent.setup()
+
+    render(<BookmarkForm bookmark={testBookmark} />)
+
+    await inputText(user, UI_LABELS.FIELDS.TITLE, TestBookmarks[1].title)
+
+    const updateButton = await screen.findByRole('button', {
+      name: UI_LABELS.ACTIONS.UPDATE,
+    })
+    expect(updateButton).toBeEnabled()
+  })
+
+  it('更新ボタンをクリックしたらupdateBookmark()が呼び出されること', async () => {
+    const user = userEvent.setup()
+    render(<BookmarkForm bookmark={testBookmark} />)
+
+    await inputText(user, UI_LABELS.FIELDS.TITLE, TestBookmarks[1].title)
+
+    const updateButton = await screen.findByRole('button', {
+      name: UI_LABELS.ACTIONS.UPDATE,
+    })
+    await user.click(updateButton)
+
+    // 検証: フックの削除関数が、正しいIDを引数にして呼ばれたか
+    expect(mockUpdate).toHaveBeenCalledWith({
+      id: testBookmark.id,
+      title: TestBookmarks[1].title,
+      url: testBookmark.url,
+    })
+  })
+})


### PR DESCRIPTION
## 概要

 `BookmarkForm.test.tsx` のファイルサイズ増大に伴う可読性低下を防ぐため、ボタンの機能単位（開く /  戻る / 削除 / 更新 / 基本表示）にテストファイルを分割しました。

## 変更内容

単一の `BookmarkForm.test.tsx` を以下の5つの機能別ファイルへ分割しました：

- **`BookmarkForm.test.tsx`**: コンポーネントの初期表示・レンダリングテスト
- **`BookmarkForm.open-bookmark.test.tsx`**: 「開く」ボタンの動作テスト
- **`BookmarkForm.back-bookmark.test.tsx`**: 「戻る」ボタンの動作テスト
- **`BookmarkForm.delete-bookmark.test.tsx`**: 「削除」ボタンの動作テスト
- **`BookmarkForm.update-bookmark.test.tsx`**: 「更新」ボタンの動作テスト
                                                                                                        各ファイルに必要な `vi.mock` 設定を独立して記述し、テスト間の相互干渉を防ぐ設計にしています。

## 変更理由・背景

- 今後さらにテストケースが追加される見込みがあり、単一ファイルでの管理が困難になることが予想されたため。
- 機能単位でファイル分割を行うことで、コードの可読性・メンテナンス性を高め、Vitestのファイル並列実行のメリットを活かすため。

## 動作確認結果

- `npx vitest run src/components/BookmarkForm*.test.tsx` を実行し、分割した 5 ファイル（全 15 テスト）すべてが正常に合格することを確認済みです。

## 関連issue

closes #82 