### PR TITLE
test: APIのCORSミドルウェアに対するテストケースを追加

### DIFF
--- a/functions/api/[[route]].cors.test.ts
+++ b/functions/api/[[route]].cors.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { app } from './[[route]]'
+
+describe('CORS Middleware', () => {
+  it('Chrome拡張機能からのオリジン (chrome-extension://) を許可すること', async () => {
+    const res = await app.request('/api/bookmarks', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'chrome-extension://abcdefghijklmnopqrstuvwxyz',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'chrome-extension://abcdefghijklmnopqrstuvwxyz',
+    )
+  })
+
+  it('ローカル開発環境のオリジン (http://localhost:5173) を許可すること', async () => {
+    const res = await app.request('/api/bookmarks', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'http://localhost:5173',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'http://localhost:5173',
+    )
+  })
+
+  it('Pagesデプロイ環境のオリジン (*.pages.dev) を許可すること', async () => {
+    const res = await app.request('/api/bookmarks', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://bookmark-page.pages.dev',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(
+      'https://bookmark-page.pages.dev',
+    )
+  })
+
+  it('許可されていない外部オリジンからのアクセスを拒否すること', async () => {
+    const res = await app.request('/api/bookmarks', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://malicious-site.com',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+
+  it('不正な形式のOriginヘッダーでもエラーにならず拒否されること', async () => {
+    const res = await app.request('/api/bookmarks', {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'invalid-url-string',
+        'Access-Control-Request-Method': 'GET',
+      },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+})


### PR DESCRIPTION
## 概要                                                                                                                                                                                                     
`functions/api/[[route]].ts` の CORS ミドルウェアにおけるオリジン判定処理に対するユニットテストを追加しました。                                                                                             
                                                                                                                                                                                                                
## 変更内容                                                                                                                                                                                                 
`functions/api/[[route]].cors.test.ts` を新規作成し、以下の 5 パターンの検証ケースを追加しました：                                                                                                          
                                                                                                                                                                                                                
1. **Chrome 拡張機能からのアクセス許可**:                                                                                                                                                                   
  - `chrome-extension://` からの `Origin` ヘッダーに対し、正しくアクセスが許可されること                                                                                                                   
2. **ローカル開発環境からのアクセス許可**:                                                                                                                                                                  
  - `http://localhost:5173` からの `Origin` ヘッダーに対し、正しくアクセスが許可されること                                                                                                                 
3. **Cloudflare Pages 環境からのアクセス許可**:                                                                                                                                                             
  - `https://*.pages.dev` からの `Origin` ヘッダーに対し、正しくアクセスが許可されること                                                                                                                   
4. **未許可オリジンの拒否**:                                                                                                                                                                                
  - 許可されていない外部ドメインからのアクセスに対して `Access-Control-Allow-Origin` が付与されないこと                                                                                                    
5. **不正な形式の Origin 文字列の安全な処理**:                                                                                                                                                              
  - 不正な URL 文字列が指定されても例外にならず、静かにアクセスが拒否されること

## 変更理由・背景
- `functions/api/[[route]].ts` のテストカバレッジにおいて、CORS 制御ブロック（60〜73行目）が未テスト状態となっていたため。
- 拡張機能やフロントエンド環境との接続性およびセキュリティ設定の回帰バグを防ぐため。

## 動作確認結果
- `npx vitest run functions/api/[[route]].cors.test.ts` を実行し、全 5 ケースが正常に合格することを確認済みです。
- `npm run test:coverage` を実行し、CORS 判定ブロックのカバレッジが向上したことを確認しました。

## 関連issue

closes #84 