### PR TITLE
clsxとtailwind-mergeを組み合わせたユーティリティ関数(cn)を共通ライブラリに作成しました

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
         "@hono/zod-validator": "^0.8.0",
         "@tanstack/react-query": "^5.101.1",
         "@tanstack/react-router": "^1.170.17",
+        "clsx": "^2.1.1",
         "hono": "4.12.26",
         "react": "19.2.7",
         "react-dom": "19.2.7",
+        "tailwind-merge": "^3.6.0",
         "uuidv7": "^1.2.1",
         "zod": "4.4.3"
       },
@@ -3732,6 +3734,15 @@
         "node": ">=20"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/concurrently": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
@@ -5954,6 +5965,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "@hono/zod-validator": "^0.8.0",
     "@tanstack/react-query": "^5.101.1",
     "@tanstack/react-router": "^1.170.17",
+    "clsx": "^2.1.1",
     "hono": "4.12.26",
     "react": "19.2.7",
     "react-dom": "19.2.7",
+    "tailwind-merge": "^3.6.0",
     "uuidv7": "^1.2.1",
     "zod": "4.4.3"
   },

--- a/shared/lib/utils.test.ts
+++ b/shared/lib/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+describe('cn utility', () => {
+  it('クラス名を正しく結合し、Tailwindの衝突を解決すること', () => {
+    // 条件付き結合の検証
+    expect(cn('px-2', true && 'py-2', false && 'bg-blue-500')).toBe('px-2 py-2')
+
+    // Tailwindクラス衝突の解消（後の記述が優先されるか）の検証
+    expect(cn('p-4 bg-red-500', 'p-6 bg-blue-500')).toBe('p-6 bg-blue-500')
+  })
+})

--- a/shared/lib/utils.ts
+++ b/shared/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         'src/**/*.{ts,tsx}',
         'functions/**/*.{ts,tsx}',
         'extension/**/*.{ts,tsx}',
+        'shared/lib/**/*.{ts,tsx}',
       ],
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
@@ -63,6 +64,7 @@ export default defineConfig({
       'src/**/*.test.{ts,tsx}',
       'functions/**/*.test.{ts,tsx}',
       'extension/**/*.test.{ts,tsx}',
+      'shared/lib/**/*.test.{ts,tsx}',
     ],
 
     root: resolve(__dirname, '.'),


### PR DESCRIPTION
## 変更内容

- clsxとtailwind-mergeをインストールした
- テストの対象範囲に共通ライブラリ(shared/lib)を追加した。
- clsxとtailwind-mergeを組み合わせたユーティリティ関数(cn)を共通ライブラリに作成した。

## 変更ファイル

- vite.config.ts
- shared/lib/utils.ts
- shared/lib/utils.test.ts