### PR TITLE
feat:ラベルとテキストボックスを組み合わせたコンポーネントを作成しました

### DIFF
--- a/src/components/BookmarkForm.tsx
+++ b/src/components/BookmarkForm.tsx
@@ -10,6 +10,7 @@ import { UI_LABELS, UI_MESSAGES } from '../../shared/constants/uiMessages'
 import { useDeleteBookmark } from '../hooks/useDeleteBookmark'
 import { useUpdateBookmark } from '../hooks/useUpdateBookmark'
 import { Button } from './Button'
+import { FormInput } from './FormInput'
 
 interface BookmarkFormProps {
   bookmark: Bookmark
@@ -63,25 +64,15 @@ export const BookmarkForm = ({ bookmark }: BookmarkFormProps) => {
     <form onSubmit={handleSubmit}>
       <div className="w-1/2 m-auto">
         <div className="grid grid-cols-[max-content_1fr] items-center gap-1">
-          <label className="text-sm font-medium text-slate-600">
-            {UI_LABELS.FIELDS.TITLE}
-          </label>
-          <input
-            aria-label={UI_LABELS.FIELDS.TITLE}
-            className="border border-slate-300 text-slate-700 bg-slate-200 rounded px-2 py-1"
+          <FormInput
+            label={UI_LABELS.FIELDS.TITLE}
             onChange={(e) => setTitle(e.target.value)}
-            type="text"
             value={title}
           />
 
-          <label className="text-sm font-medium text-slate-600">
-            {UI_LABELS.FIELDS.URL}
-          </label>
-          <input
-            aria-label={UI_LABELS.FIELDS.URL}
-            className="border border-slate-300 text-slate-700 bg-slate-200 rounded px-2 py-1"
+          <FormInput
+            label={UI_LABELS.FIELDS.URL}
             onChange={(e) => setUrl(e.target.value)}
-            type="text"
             value={url}
           />
         </div>

--- a/src/components/FormInput.tsx
+++ b/src/components/FormInput.tsx
@@ -1,0 +1,31 @@
+import React, { useId } from 'react'
+
+interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string
+}
+
+export const FormInput = ({
+  className = '',
+  id,
+  label,
+  type = 'text',
+  ...props
+}: FormInputProps) => {
+  // idが指定されていなければユニークなIDを自動生成して label と input を紐付ける
+  const inputId = id || useId()
+
+  return (
+    <>
+      <label className="text-sm font-medium text-slate-600" htmlFor={inputId}>
+        {label}
+      </label>
+      <input
+        aria-label={label}
+        className={`border border-slate-300 text-slate-700 bg-slate-200 rounded px-2 py-1 ${className}`}
+        id={inputId}
+        type={type}
+        {...props}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## 変更内容

- ラベルとテキストボックスを組み合わせたコンポーネントを作成しました。
- BookmarkFormのラベルとテキストボックスを、作成したコンポーネントに置き換えました。

## 変更ファイル

- src/components/FormInput.tsx
- src/components/BookmarkForm.tsx

## テスト結果

- lintと型チェック、テストはすべて成功しました。
- 追加したsrc/components/FormInput.tsxのテストのカバレッジは100%です。

## 関連issue

closes #102 