### PR TITLE
fix: タイトルのリンクをaタグからLinkに変更しました

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { createRootRoute, Outlet } from '@tanstack/react-router'
+import { createRootRoute, Link, Outlet } from '@tanstack/react-router'
 
 import { UI_LABELS } from '../../shared/constants/uiMessages'
 
@@ -7,9 +7,7 @@ export const Route = createRootRoute({
     <div className="min-h-screen bg-slate-50 text-slate-900">
       {/* 必要であればここにヘッダーなどを共通配置 */}
       <div className="text-slate-200 bg-slate-700 font-bold w-1/2 m-auto text-center text-xl p-2 mb-2 mt-2">
-        <a href="/" rel="noreferrer">
-          {UI_LABELS.HEADER.PAGE_HEADER}
-        </a>
+        <Link to="/">{UI_LABELS.HEADER.PAGE_HEADER}</Link>
       </div>
 
       <main className="container mx-auto">


### PR DESCRIPTION
## 変更内容

タイトルのリンクをaタグからLinkに変更しました。

## 変更ファイル

src/routes/__root.tsx

## テスト結果

以下のすべてに成功しました。

- npm run lint
- npm run typecheck
- npm run test
- npm run test:coverage

## 関連issue

closes #104 