### PR TITLE
refact: 拡張機能の見た目をwebアプリと統一しました

### DIFF
--- a/extension/extension.css
+++ b/extension/extension.css
@@ -1,1 +1,2 @@
 @import 'tailwindcss';
+@source "../src/components/";

--- a/extension/index.html
+++ b/extension/index.html
@@ -12,7 +12,7 @@
           system-ui,
           -apple-system,
           sans-serif;
-        background-color: #e2e8f0;
+        background-color: #f9fafb;
       }
     </style>
   </head>

--- a/extension/index.html
+++ b/extension/index.html
@@ -5,15 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bookmark Page</title>
     <style>
-      /* 💡 ポップアップの初期サイズを固定しておくのが、拡張機能開発のコツです */
       body {
-        width: 320px;
+        width: 480px;
         margin: 0;
         font-family:
           system-ui,
           -apple-system,
           sans-serif;
-        background-color: #f9fafb;
+        background-color: #e2e8f0;
       }
     </style>
   </head>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bookmark Page Extension",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "閲覧中のページをブックマークに追加します",
   "permissions": ["activeTab", "storage"],
   "host_permissions": ["http://localhost:8788/*", "https://*.pages.dev/*"],

--- a/extension/src/Popup.test.tsx
+++ b/extension/src/Popup.test.tsx
@@ -63,7 +63,9 @@ describe('Popup Component', () => {
     const urlInput = screen.getByLabelText(
       UI_LABELS.FIELDS.URL,
     ) as HTMLInputElement
-    const submitButton = screen.getByRole('button', { name: '保存する' })
+    const submitButton = screen.getByRole('button', {
+      name: UI_LABELS.ACTIONS.ADD_BOOKMARK,
+    })
     const apiUrlInput = screen.getByLabelText(
       UI_LABELS.FIELDS.API_URL,
     ) as HTMLInputElement
@@ -99,7 +101,7 @@ describe('Popup Component', () => {
     // 保存中の状態を経て、成功メッセージが出ることを検証
     await waitFor(() => {
       expect(
-        screen.getByText('ブックマークを保存しました！'),
+        screen.getByText(UI_MESSAGES.BOOKMARKS.ADDED_BOOKMARK),
       ).toBeInTheDocument()
     })
 

--- a/extension/src/Popup.tsx
+++ b/extension/src/Popup.tsx
@@ -11,6 +11,7 @@ import {
   UI_MESSAGES,
 } from '../../shared/constants/uiMessages'
 import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
+import { Button } from '../../src/components/Button'
 import { FormInput } from '../../src/components/FormInput'
 import { STORAGE_KEY } from '../constants/storage'
 import '../extension.css'
@@ -198,20 +199,9 @@ export function Popup() {
           />
         </div>
 
-        <button
-          disabled={loading}
-          style={{
-            backgroundColor: loading ? '#9ca3af' : '#2563eb',
-            border: 'none',
-            borderRadius: '4px',
-            color: '#fff',
-            cursor: loading ? 'not-allowed' : 'pointer',
-            padding: '8px',
-          }}
-          type="submit"
-        >
+        <Button disabled={loading} type="submit">
           {loading ? UI_LABELS.ACTIONS.SAVING : UI_LABELS.ACTIONS.SAVE}
-        </button>
+        </Button>
 
         <div className="grid grid-cols-[max-content_1fr] items-center gap-1">
           <FormInput
@@ -222,36 +212,12 @@ export function Popup() {
           />
         </div>
 
-        <button
-          disabled={loading}
-          onClick={handleSaveApiUrl}
-          style={{
-            backgroundColor: loading ? '#9ca3af' : '#2563eb',
-            border: 'none',
-            borderRadius: '4px',
-            color: '#fff',
-            cursor: loading ? 'not-allowed' : 'pointer',
-            padding: '8px',
-          }}
-          type="button"
-        >
+        <Button disabled={loading} onClick={handleSaveApiUrl} type="button">
           {UI_LABELS.ACTIONS.SAVE_API_URL}
-        </button>
-        <button
-          disabled={loading}
-          onClick={handleTestConnection}
-          style={{
-            backgroundColor: loading ? '#9ca3af' : '#2563eb',
-            border: 'none',
-            borderRadius: '4px',
-            color: '#fff',
-            cursor: loading ? 'not-allowed' : 'pointer',
-            padding: '8px',
-          }}
-          type="button"
-        >
+        </Button>
+        <Button disabled={loading} onClick={handleTestConnection} type="button">
           {UI_LABELS.ACTIONS.VERIFY_API_URL}
-        </button>
+        </Button>
       </form>
 
       {message && (

--- a/extension/src/Popup.tsx
+++ b/extension/src/Popup.tsx
@@ -70,7 +70,7 @@ export function Popup() {
 
       if (data.success) {
         setMessage({
-          text: UI_MESSAGES.BOOKMARKS.SAVED_BOOKMARK,
+          text: UI_MESSAGES.BOOKMARKS.ADDED_BOOKMARK,
           type: 'success',
         })
       } else {
@@ -200,7 +200,9 @@ export function Popup() {
         </div>
 
         <Button disabled={loading} type="submit">
-          {loading ? UI_LABELS.ACTIONS.SAVING : UI_LABELS.ACTIONS.SAVE}
+          {loading
+            ? UI_LABELS.ACTIONS.ADDING_BOOKMARK
+            : UI_LABELS.ACTIONS.ADD_BOOKMARK}
         </Button>
 
         <div className="grid grid-cols-[max-content_1fr] items-center gap-1">
@@ -212,12 +214,18 @@ export function Popup() {
           />
         </div>
 
-        <Button disabled={loading} onClick={handleSaveApiUrl} type="button">
-          {UI_LABELS.ACTIONS.SAVE_API_URL}
-        </Button>
-        <Button disabled={loading} onClick={handleTestConnection} type="button">
-          {UI_LABELS.ACTIONS.VERIFY_API_URL}
-        </Button>
+        <div className="grid grid-cols-2 gap-2">
+          <Button disabled={loading} onClick={handleSaveApiUrl} type="button">
+            {UI_LABELS.ACTIONS.SAVE_API_URL}
+          </Button>
+          <Button
+            disabled={loading}
+            onClick={handleTestConnection}
+            type="button"
+          >
+            {UI_LABELS.ACTIONS.VERIFY_API_URL}
+          </Button>
+        </div>
       </form>
 
       {message && (

--- a/extension/src/Popup.tsx
+++ b/extension/src/Popup.tsx
@@ -176,8 +176,8 @@ export function Popup() {
   }
 
   return (
-    <div style={{ padding: '16px' }}>
-      <h1 className="text-gray-900 text-base mb-3">
+    <div className="p-4">
+      <h1 className="text-slate-200 bg-slate-700 font-bold m-auto text-lg text-center p-2 mb-2">
         {UI_LABELS.HEADER.ADD_BOOKMARK}
       </h1>
 

--- a/extension/src/Popup.tsx
+++ b/extension/src/Popup.tsx
@@ -11,9 +11,10 @@ import {
   UI_MESSAGES,
 } from '../../shared/constants/uiMessages'
 import { SCHEMA_MESSAGE } from '../../shared/constants/validation'
+import { FormInput } from '../../src/components/FormInput'
 import { STORAGE_KEY } from '../constants/storage'
-import { client } from './lib/hono'
 import '../extension.css'
+import { client } from './lib/hono'
 
 export function Popup() {
   const [title, setTitle] = useState('')
@@ -181,52 +182,18 @@ export function Popup() {
         {UI_LABELS.HEADER.ADD_BOOKMARK}
       </h1>
 
-      <form
-        onSubmit={handleSubmit}
-        style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}
-      >
-        <div>
-          <label
-            htmlFor="title-input"
-            style={{
-              color: '#4b5563',
-              display: 'block',
-              fontSize: '12px',
-              marginBottom: '4px',
-            }}
-          >
-            {UI_LABELS.FIELDS.TITLE}
-          </label>
-          <input
-            className="border"
+      <form className="flex flex-col gap-2.5" onSubmit={handleSubmit}>
+        <div className="grid grid-cols-[max-content_1fr] items-center gap-1">
+          <FormInput
             id="title-input"
+            label={UI_LABELS.FIELDS.TITLE}
             onChange={(e) => setTitle(e.target.value)}
-            required
-            style={{ boxSizing: 'border-box', padding: '6px', width: '100%' }}
-            type="text"
             value={title}
           />
-        </div>
-
-        <div>
-          <label
-            htmlFor="url-input"
-            style={{
-              color: '#4b5563',
-              display: 'block',
-              fontSize: '12px',
-              marginBottom: '4px',
-            }}
-          >
-            {UI_LABELS.FIELDS.URL}
-          </label>
-          <input
-            className="border"
+          <FormInput
             id="url-input"
+            label={UI_LABELS.FIELDS.URL}
             onChange={(e) => setUrl(e.target.value)}
-            required
-            style={{ boxSizing: 'border-box', padding: '6px', width: '100%' }}
-            type="url"
             value={url}
           />
         </div>
@@ -246,24 +213,11 @@ export function Popup() {
           {loading ? UI_LABELS.ACTIONS.SAVING : UI_LABELS.ACTIONS.SAVE}
         </button>
 
-        <div>
-          <label
-            htmlFor="api-url-input"
-            style={{
-              color: '#4b5563',
-              display: 'block',
-              fontSize: '12px',
-              marginBottom: '4px',
-            }}
-          >
-            {UI_LABELS.FIELDS.API_URL}
-          </label>
-          <input
-            className="border"
+        <div className="grid grid-cols-[max-content_1fr] items-center gap-1">
+          <FormInput
             id="api-url-input"
+            label={UI_LABELS.FIELDS.API_URL}
             onChange={(e) => setApiUrl(e.target.value)}
-            style={{ boxSizing: 'border-box', padding: '6px', width: '100%' }}
-            type="url"
             value={apiUrl}
           />
         </div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bookmark-page",
   "type": "module",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "license": "MIT",
   "scripts": {
     "dev:frontend": "vite",

--- a/shared/constants/uiMessages.ts
+++ b/shared/constants/uiMessages.ts
@@ -12,8 +12,8 @@ export const ERROR_MESSAGE = {
 export const UI_LABELS = {
   ACTIONS: {
     LOADING: '読み込み中...',
-    SAVING: '保存中...',
-    SAVE: '保存する',
+    ADDING_BOOKMARK: 'ブックマークを追加中...',
+    ADD_BOOKMARK: 'ブックマークを追加',
     OPEN: '開く',
     UPDATE: '更新',
     DELETE: '削除',
@@ -41,7 +41,7 @@ export const UI_MESSAGES = {
       'Zero Trust のログインセッションが見つかりません。先にブラウザでWEB画面を開いてログインしてください。',
   },
   BOOKMARKS: {
-    SAVED_BOOKMARK: 'ブックマークを保存しました！',
+    ADDED_BOOKMARK: 'ブックマークを追加しました！',
     REGISTERED_BOOKMARKS: (count: number) =>
       `${count}件のブックマークが登録されています。`,
     CONFIRM_DELETE: (title: string) =>


### PR DESCRIPTION
## 関連issue

closes #106 

## 修正内容

- 拡張機能にもTailwindCSSが適用できるように修正しました。(231024cf64caa54a7718940e5f9b9c62b99c6673)
- 拡張機能のポップアップ画面のサイズを480pxに変更する。(0b92ede7ce5104e1d27d0e3e5774bd9313333c5e)
- 拡張機能のポップアップのテキストボックスをwebアプリと同じコンポーネントに置き換えた (bd26314ea0d0f7d49e0f1b8369176667c79af25a)
- 拡張機能のポップアップのボタンをwebアプリと同じコンポーネントに置き換えた (0c7abe6260a5c792b2f40084a50fcfcafdc9a1b0)
- 拡張機能のポップアップの保存ボタンがAPIの保存と紛らわしいためブックマークの追加に変更した (b8f176af2dec42a9f000094e6a1a613628e37310)

### インストールしたコンポーネント

なし

## 完了条件

- 拡張機能のテキストボックスとボタンがwebアプリと同じコンポーネントに置き換えられている。
- 拡張機能のタイトルがwebアプリと同じ見た目に変わっている。

### 追加するテスト

なし

### 必要なテスト

- npm run lint
- npm run typecheck
- npm run test
- npm run test:coverage

### 期待する画面や処理

- 拡張機能の画面

## 変更しないもの

変更するのは見た目だけで機能は変更しない。

## 未着手事項

以下の場合に各ボタンを無効にする処理は別のissueで対応する。
- タイトルやURLが未入力の場合
- ブックマークがURLとして不正な場合
- APIのURLが不正な場合