### PR TITLE
拡張機能のAPIへアクセスするclientをシングルトンからファクトリー方式に変更した

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bookmark Page Extension",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "閲覧中のページをブックマークに追加します",
   "permissions": ["activeTab", "storage"],
   "host_permissions": ["http://localhost:8788/*", "https://*.pages.dev/*"],

--- a/extension/src/hooks/useAddBookmark.test.tsx
+++ b/extension/src/hooks/useAddBookmark.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { hc } from 'hono/client'
-import { beforeEach, describe, expect, it, Mock, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest'
 
 import {
   INVALID_STRING,
@@ -137,6 +137,9 @@ describe('useAddBookmark', () => {
     beforeEach(() => {
       consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     })
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
 
     it('非同期関数がreject(Error)の場合', async () => {
       mockPost.mockRejectedValue(new Error(TEST_ERROR_MESSAGE.API_ERROR))
@@ -175,6 +178,71 @@ describe('useAddBookmark', () => {
         expect(resultMessage?.type).toBe('error')
         expect(resultMessage?.text).toBe(UI_MESSAGES.API.FAILED_CONNECT_SERVER)
         expect(consoleSpy).not.toHaveBeenCalled()
+      })
+    })
+
+    type TestDataType = {
+      description: string
+      tabs:
+        | undefined
+        | {
+            query: ReturnType<typeof vi.fn>
+          }
+    }
+
+    const testData: TestDataType[] = [
+      { description: 'タブにアクセスできない場合', tabs: undefined },
+      {
+        description: 'アクティブなタブにアクセスできない場合',
+        tabs: {
+          query: vi.fn((_queryInfo, callback) => {
+            callback([])
+          }),
+        },
+      },
+      {
+        description: 'アクティブなタブのタイトルとurlにアクセスできない場合',
+        tabs: {
+          query: vi.fn((_queryInfo, callback) => {
+            callback([{}])
+          }),
+        },
+      },
+    ]
+
+    it.each(testData)(`$description`, async ({ tabs }) => {
+      vi.stubGlobal('chrome', {
+        tabs,
+      })
+      const { result } = renderHook(() => useAddBookmark())
+
+      let resultMessage: MessageBarType
+      await act(async () => {
+        resultMessage = await result.current.addBookmark(TEST_API_URL.LOCAL)
+      })
+      await waitFor(() => {
+        expect(resultMessage?.type).toBe('error')
+        expect(resultMessage?.text).toBe(UI_MESSAGES.API.FAILED_CONNECT_SERVER)
+      })
+    })
+
+    it('アクティブなタブにアクセスできない場合', async () => {
+      vi.stubGlobal('chrome', {
+        tabs: {
+          query: vi.fn((_queryInfo, callback) => {
+            callback([{}])
+          }),
+        },
+      })
+      const { result } = renderHook(() => useAddBookmark())
+
+      let resultMessage: MessageBarType
+      await act(async () => {
+        resultMessage = await result.current.addBookmark(TEST_API_URL.LOCAL)
+      })
+      await waitFor(() => {
+        expect(resultMessage?.type).toBe('error')
+        expect(resultMessage?.text).toBe(UI_MESSAGES.API.FAILED_CONNECT_SERVER)
       })
     })
   })

--- a/extension/src/hooks/useAddBookmark.tsx
+++ b/extension/src/hooks/useAddBookmark.tsx
@@ -1,9 +1,9 @@
-import { hc } from 'hono/client'
 import { useEffect, useState } from 'react'
+import { ZodError } from 'zod'
 
-import { AppType } from '../../../functions/api/[[route]]'
 import { UI_MESSAGES } from '../../../shared/constants/uiMessages'
-import { createErrorMessage, validateUrl } from '../../../shared/lib/utils'
+import { createErrorMessage } from '../../../shared/lib/utils'
+import { createClient } from '../lib/hono'
 
 export const useAddBookmark = () => {
   const [title, setTitle] = useState('')
@@ -27,18 +27,16 @@ export const useAddBookmark = () => {
 
   const addBookmark = async (apiUrl: string) => {
     try {
-      const validApiUrl = validateUrl(apiUrl)
-      if (!validApiUrl.success) {
-        return createErrorMessage(validApiUrl.error.issues[0].message)
+      let client
+      try {
+        client = createClient({ apiUrl })
+      } catch (error) {
+        if (error instanceof ZodError) {
+          return createErrorMessage(error.issues[0].message)
+        }
+        throw error
       }
 
-      const client = hc<AppType>(validApiUrl.data, {
-        fetch: (input: RequestInfo | URL, init: RequestInit | undefined) =>
-          fetch(input, {
-            ...init,
-            credentials: 'include',
-          }),
-      })
       const res = await client.api.bookmarks.$post({
         json: { title, url },
       })

--- a/extension/src/hooks/useAddBookmark.tsx
+++ b/extension/src/hooks/useAddBookmark.tsx
@@ -27,15 +27,7 @@ export const useAddBookmark = () => {
 
   const addBookmark = async (apiUrl: string) => {
     try {
-      let client
-      try {
-        client = createClient({ apiUrl })
-      } catch (error) {
-        if (error instanceof ZodError) {
-          return createErrorMessage(error.issues[0].message)
-        }
-        throw error
-      }
+      const client = createClient({ apiUrl })
 
       const res = await client.api.bookmarks.$post({
         json: { title, url },
@@ -55,7 +47,9 @@ export const useAddBookmark = () => {
         )
       }
     } catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof ZodError) {
+        return createErrorMessage(error.issues[0].message)
+      } else if (error instanceof Error) {
         console.error(error.message)
       }
       return createErrorMessage(UI_MESSAGES.API.FAILED_CONNECT_SERVER)

--- a/extension/src/hooks/useApiUrl.test.tsx
+++ b/extension/src/hooks/useApiUrl.test.tsx
@@ -36,12 +36,15 @@ vi.mock('hono/client', () => {
 
 const setupHook = async (url: string) => {
   const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-  vi.spyOn(chrome.storage.local, 'get').mockImplementation(async () => ({
-    [STORAGE_KEY.API_URL]: '',
-  }))
-  const spySet = vi
-    .spyOn(chrome.storage.local, 'set')
-    .mockImplementation(async () => ({}))
+  let spySet
+  if (globalThis.chrome.storage.local) {
+    vi.spyOn(chrome.storage.local, 'get').mockImplementation(async () => ({
+      [STORAGE_KEY.API_URL]: '',
+    }))
+    spySet = vi
+      .spyOn(chrome.storage.local, 'set')
+      .mockImplementation(async () => ({}))
+  }
 
   const { result } = renderHook(() => useApiUrl())
   await waitFor(() => {
@@ -262,12 +265,12 @@ describe('useApiUrl', () => {
     })
 
     it('ストレージにアクセスできない場合', async () => {
-      const { result } = await setupHook(TEST_API_URL.LOCAL)
       vi.stubGlobal('chrome', {
         storage: {
           local: undefined,
         },
       })
+      const { result } = await setupHook(TEST_API_URL.LOCAL)
 
       let resultMessage: MessageBarType
       await act(async () => {

--- a/extension/src/hooks/useApiUrl.tsx
+++ b/extension/src/hooks/useApiUrl.tsx
@@ -50,15 +50,7 @@ export const useApiUrl = () => {
 
   const testConnection = async (): Promise<MessageBarType> => {
     try {
-      let client
-      try {
-        client = createClient({ apiUrl, timeoutMs: TIMEOUT_MILLISECOND })
-      } catch (error) {
-        if (error instanceof ZodError) {
-          return createErrorMessage(error.issues[0].message)
-        }
-        throw error
-      }
+      const client = createClient({ apiUrl, timeoutMs: TIMEOUT_MILLISECOND })
 
       const response = await client.api.bookmarks.$get()
 
@@ -82,7 +74,9 @@ export const useApiUrl = () => {
     } catch (error) {
       let errorMessage: string = UI_MESSAGES.API.FAILED_CONNECT_SERVER
 
-      if (error instanceof Error) {
+      if (error instanceof ZodError) {
+        errorMessage = error.issues[0].message
+      } else if (error instanceof Error) {
         if (error.name === 'AbortError') {
           errorMessage = UI_MESSAGES.API.TIMEOUT_CONNECT_SERVER
         } else {

--- a/extension/src/hooks/useApiUrl.tsx
+++ b/extension/src/hooks/useApiUrl.tsx
@@ -1,7 +1,6 @@
-import { hc } from 'hono/client'
 import { useEffect, useState } from 'react'
+import { ZodError } from 'zod'
 
-import { AppType } from '../../../functions/api/[[route]]'
 import { type MessageBarType } from '../../../shared/components/MessageBar'
 import {
   DEFAULT_API_URL,
@@ -13,6 +12,7 @@ import {
 } from '../../../shared/constants/uiMessages'
 import { createErrorMessage, validateUrl } from '../../../shared/lib/utils'
 import { STORAGE_KEY } from '../../constants/storage'
+import { createClient } from '../lib/hono'
 
 export const useApiUrl = () => {
   const [apiUrl, setApiUrl] = useState(DEFAULT_API_URL)
@@ -49,25 +49,18 @@ export const useApiUrl = () => {
   }
 
   const testConnection = async (): Promise<MessageBarType> => {
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MILLISECOND)
-
     try {
-      const validApiUrl = validateUrl(apiUrl)
-      if (!validApiUrl.success) {
-        return createErrorMessage(validApiUrl.error.issues[0].message)
+      let client
+      try {
+        client = createClient({ apiUrl, timeoutMs: TIMEOUT_MILLISECOND })
+      } catch (error) {
+        if (error instanceof ZodError) {
+          return createErrorMessage(error.issues[0].message)
+        }
+        throw error
       }
 
-      const testClient = hc<AppType>(validApiUrl.data, {
-        fetch: (input: RequestInfo | URL, init: RequestInit | undefined) =>
-          fetch(input, {
-            ...init,
-            credentials: 'include',
-            signal: controller.signal,
-          }),
-      })
-
-      const response = await testClient.api.bookmarks.$get()
+      const response = await client.api.bookmarks.$get()
 
       if (!response.ok) {
         if (response.status === 401 || response.status === 403) {
@@ -97,8 +90,6 @@ export const useApiUrl = () => {
         }
       }
       return createErrorMessage(errorMessage)
-    } finally {
-      clearTimeout(timeoutId)
     }
   }
 

--- a/extension/src/lib/hono.test.ts
+++ b/extension/src/lib/hono.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ZodError } from 'zod'
 
-import { TEST_API_URL } from '../../../functions/test/fixtures'
+import { INVALID_STRING } from '../../../functions/test/fixtures'
 import { DEFAULT_API_URL } from '../../../shared/constants/api'
-import { STORAGE_KEY } from '../../constants/storage'
-import { client } from './hono'
+import { SCHEMA_MESSAGE } from '../../../shared/constants/validation'
+import { createClient } from './hono'
 
 describe('Hono RPC Client', () => {
   beforeEach(() => {
@@ -11,61 +12,43 @@ describe('Hono RPC Client', () => {
   })
 
   it('client が正常に初期化されていること', () => {
+    const client = createClient({ apiUrl: DEFAULT_API_URL })
+
     expect(client).toBeDefined()
     expect(client.api.bookmarks).toBeDefined()
     expect(typeof client.api.bookmarks.$post).toBe('function')
   })
 
-  it.each([
-    {
-      apiUrl: undefined,
-      expectedApiUrl: DEFAULT_API_URL,
-      name: 'ストレージに API URL が保存されていない場合',
-    },
-    {
-      apiUrl: TEST_API_URL.LOCAL,
-      expectedApiUrl: TEST_API_URL.LOCAL,
-      name: 'ストレージに API URL が保存されている場合',
-    },
-  ])(`$name`, async ({ apiUrl, expectedApiUrl }) => {
-    // 1. ストレージのモック（保存されたURLを返すように設定）
-    vi.spyOn(chrome.storage.local, 'get').mockImplementation(async () => ({
-      [STORAGE_KEY.API_URL]: apiUrl,
-    }))
-
-    // 2. グローバル fetch のスパイ化（実際のネットワーク通信を防ぎ、ダミーレスポンスを返す）
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response(JSON.stringify({ success: true })))
-
-    // 3. クライアント経由で通信を実行
-    await client.api.bookmarks.$get()
-
-    // 4. 呼び出された URL がカスタム URL に差し替わっているかを検証
-    expect(fetchSpy).toHaveBeenCalledWith(
-      `${expectedApiUrl}/api/bookmarks`,
-      expect.any(Object),
-    )
+  it('urlが不正な場合にはclientが作成されない、例外を返すこと', () => {
+    let client
+    try {
+      client = createClient({ apiUrl: INVALID_STRING.URL })
+    } catch (error) {
+      if (error instanceof ZodError) {
+        expect(error.issues[0].message).toBe(SCHEMA_MESSAGE.PROTOCOL_CONSTRAINT)
+        expect(client).not.toBeDefined()
+      } else {
+        expect(error).toBeInstanceOf(ZodError)
+      }
+    }
   })
 
-  it('chrome.storage.local が存在しない環境 (undefined) でもエラーにならずデフォルトURLで通信すること', async () => {
-    const originalStorage = globalThis.chrome.storage
-
-    // @ts-expect-error テスト用に一時的に storage を undefined に設定
-    delete globalThis.chrome.storage
-
+  it('fetch に credentials: include と signal が設定されること', async () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockResolvedValue(new Response(JSON.stringify({ success: true })))
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: [], success: true })),
+      )
 
+    const client = createClient({ apiUrl: DEFAULT_API_URL })
     await client.api.bookmarks.$get()
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      `${DEFAULT_API_URL}/api/bookmarks`,
-      expect.any(Object),
+      expect.any(String),
+      expect.objectContaining({
+        credentials: 'include',
+        signal: expect.any(AbortSignal),
+      }),
     )
-
-    // テスト後に元の状態へ復元
-    globalThis.chrome.storage = originalStorage
   })
 })

--- a/extension/src/lib/hono.ts
+++ b/extension/src/lib/hono.ts
@@ -3,31 +3,33 @@ import { hc } from 'hono/client'
 // バックエンド（functions）のエントリーポイントから型定義（AppType）のみをインポート
 import type { AppType } from '../../../functions/api/[[route]]'
 
-import { DEFAULT_API_URL } from '../../../shared/constants/api'
-import { STORAGE_KEY } from '../../constants/storage'
+import { BookmarkUrlSchema } from '../../../functions/schemas/bookmark'
+import { TIMEOUT_MILLISECOND } from '../../../shared/constants/api'
 
-// 型安全な RPC クライアントを生成してエクスポート
-export const client = hc<AppType>(DEFAULT_API_URL, {
-  fetch: async (input: RequestInfo | URL, init: RequestInit | undefined) => {
-    const chrome = globalThis.chrome
-    const apiUrl = chrome?.storage?.local
-      ? (await chrome.storage.local.get([STORAGE_KEY.API_URL]))[
-          STORAGE_KEY.API_URL
-        ]
-      : undefined
+interface ClientOptions {
+  apiUrl: string
+  /** タイムアウト時間（ミリ秒）。デフォルト: 5000ms */
+  timeoutMs?: number
+}
 
-    if (apiUrl) {
-      const urlStr = typeof input === 'string' ? input : input.toString()
-      const newUrl = urlStr.replace(DEFAULT_API_URL, apiUrl)
-      return fetch(newUrl, {
+export const createClient = (clientOptions: ClientOptions) => {
+  const validUrl = BookmarkUrlSchema.parse(clientOptions.apiUrl)
+  const timeoutMs = clientOptions.timeoutMs ?? TIMEOUT_MILLISECOND
+
+  return hc<AppType>(validUrl, {
+    fetch: (input: RequestInfo | URL, init?: RequestInit) => {
+      const timeoutSignal = AbortSignal.timeout(timeoutMs)
+
+      // 呼び出し元の signal と タイムアウト signal を合成
+      const combinedSignal = init?.signal
+        ? AbortSignal.any([init.signal, timeoutSignal])
+        : timeoutSignal
+
+      return fetch(input, {
         ...init,
         credentials: 'include',
+        signal: combinedSignal,
       })
-    }
-
-    return fetch(input, {
-      ...init,
-      credentials: 'include',
-    })
-  },
-})
+    },
+  })
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bookmark-page",
   "type": "module",
   "private": true,
-  "version": "0.4.6",
+  "version": "0.4.7",
   "license": "MIT",
   "scripts": {
     "dev:frontend": "vite",


### PR DESCRIPTION
## 変更内容

- extension/src/lib/hono.tsで管理している、拡張機能でAPIへのurlアクセスするclientを、シングルトン方式からファクトリー方式に変更した
-
-

## 対象外

<!-- このPull Requestでは対応しない内容を記載してください -->

## 確認方法

1. 作成されたclient, client.api.bookmarksが定義されていること、client.api.bookmarks.$postが関数であること
2.
3.

## テスト

- [ ] 単体テストを追加・更新した
- [ ] 手動確認を実施した
- [ ] 既存テストが成功することを確認した

## 影響範囲

- [ ] API
- [ ] データベース
- [ ] フロントエンド
- [ ] 拡張機能
- [ ] 外部サービス
- [ ] 影響なし

## セキュリティ

- [ ] 外部入力を検証している
- [ ] 機密情報をログへ出力していない
- [ ] 新しいシークレットを追加していない

## データベース変更

- [ ] マイグレーションなし
- [ ] マイグレーションあり
- [ ] ロールバック方法を確認した

## 関連Issue

Closes #120 
