### PR TITLE
拡張機能のポップアップ画面にMarkdownフォーマットのリンク形式のテキストボックスを追加しました

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Bookmark Page Extension",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "description": "閲覧中のページをブックマークに追加します",
   "permissions": ["activeTab", "storage"],
   "host_permissions": ["http://localhost:8788/*", "https://*.pages.dev/*"],

--- a/extension/src/Popup.linkText.test.tsx
+++ b/extension/src/Popup.linkText.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { TestBookmarks } from '../../functions/test/fixtures'
+import { UI_LABELS } from '../../shared/constants/uiMessages'
+import { inputText } from '../../src/test/test-utils'
+import { Popup } from './Popup'
+
+type TestDataType = {
+  description: string
+  expectedValue: string
+  inputLabel: string
+  inputValue: string
+}
+
+describe('Popupのリンクテキストのテスト', () => {
+  const testData: TestDataType[] = [
+    {
+      description: 'タイトル',
+      expectedValue: `[${TestBookmarks[1].title}](${TestBookmarks[0].url})`,
+      inputLabel: UI_LABELS.FIELDS.TITLE,
+      inputValue: TestBookmarks[1].title,
+    },
+    {
+      description: 'url',
+      expectedValue: `[${TestBookmarks[0].title}](${TestBookmarks[1].url})`,
+      inputLabel: UI_LABELS.FIELDS.URL,
+      inputValue: TestBookmarks[1].url,
+    },
+  ]
+
+  it.each(testData)(
+    `$description が変更されるとリンクテキストが変更されること`,
+    async ({ expectedValue, inputLabel, inputValue }) => {
+      render(<Popup />)
+
+      expect(
+        screen.getByRole('textbox', {
+          name: UI_LABELS.FIELDS.LINK_TEXT,
+        }),
+      ).toHaveValue(`[${TestBookmarks[0].title}](${TestBookmarks[0].url})`)
+
+      const user = userEvent.setup()
+      await inputText(user, inputLabel, inputValue)
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('textbox', {
+            name: UI_LABELS.FIELDS.LINK_TEXT,
+          }),
+        ).toHaveValue(expectedValue)
+      })
+    },
+  )
+})

--- a/extension/src/Popup.test.tsx
+++ b/extension/src/Popup.test.tsx
@@ -141,7 +141,7 @@ describe('Popup Component', () => {
       mockFn.mockResolvedValue(message)
       render(<Popup />)
       const user = userEvent.setup()
-      clickButton(user, buttonLabel)
+      await clickButton(user, buttonLabel)
 
       // 保存中の状態を経て、成功メッセージが出ることを検証
       await waitFor(() => {

--- a/extension/src/Popup.tsx
+++ b/extension/src/Popup.tsx
@@ -51,7 +51,6 @@ export function Popup() {
 
       <form className="flex flex-col gap-2.5" onSubmit={handleSubmit}>
         <FormInput
-          key={linkText}
           label={UI_LABELS.FIELDS.LINK_TEXT}
           readOnly
           value={linkText}

--- a/extension/src/Popup.tsx
+++ b/extension/src/Popup.tsx
@@ -41,6 +41,8 @@ export function Popup() {
     setMessage(resultMessage)
   }
 
+  const linkText = `\[${title}\]\(${url}\)`
+
   return (
     <div className="p-4">
       <h1 className="text-slate-200 bg-slate-700 font-bold m-auto text-lg text-center p-2 mb-2">
@@ -48,6 +50,13 @@ export function Popup() {
       </h1>
 
       <form className="flex flex-col gap-2.5" onSubmit={handleSubmit}>
+        <FormInput
+          key={linkText}
+          label={UI_LABELS.FIELDS.LINK_TEXT}
+          readOnly
+          value={linkText}
+        />
+
         <BookmarkInput
           setTitle={setTitle}
           setUrl={setUrl}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bookmark-page",
   "type": "module",
   "private": true,
-  "version": "0.4.8",
+  "version": "0.5.0",
   "license": "MIT",
   "scripts": {
     "dev:frontend": "vite",

--- a/shared/constants/uiMessages.ts
+++ b/shared/constants/uiMessages.ts
@@ -26,6 +26,7 @@ export const UI_LABELS = {
     TITLE: 'タイトル',
     URL: 'URL',
     API_URL: 'APIのURL',
+    LINK_TEXT: 'リンク',
   },
   HEADER: {
     PAGE_HEADER: 'Bookmark Page',


### PR DESCRIPTION
## 概要

<!-- このPRで変更した内容を記載してください -->

## 変更理由

アクティブなタブへのリンクを、Markdownのファイルに書き込むときに、タイトルとurlを組み合わせてリンクを作る必要があります。これを自動的に作成するようになります。

## 動作確認

- [x] ローカル環境で確認した
- [x] 関連するテストを実行した
- [x] 既存機能への影響を確認した

## 影響範囲

<!-- 影響する画面、API、バッチなどを記載してください -->

## 関連Issue

Closes #124 